### PR TITLE
Adds a Python 3.7 build to the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache: pip
 python:
   - 3.5
   - 3.6
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
 env:
   global:
     - COVERALLS_PARALLEL=true

--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -120,11 +120,11 @@ numpy.__doc__ = "NumPy with automatic differentiation support, provided by Autog
 
 
 # set up logging
+numeric_level = 100 # info
 if "LOGGING" in os.environ:
     logLevel = os.environ["LOGGING"]
     numeric_level = getattr(log, logLevel.upper(), 10)
-else:
-    numeric_level = 100 # info
+
 
 log.basicConfig(
     level=numeric_level,


### PR DESCRIPTION
**Description of the Change:**

Now that Ubuntu Xenial (16.04) is supported natively on Travis (see https://github.com/travis-ci/travis-ci/issues/9815), we can now run the test suite on Python 3.7 as well.