### PR TITLE
Add Identity expectation

### DIFF
--- a/doc/code/expval.rst
+++ b/doc/code/expval.rst
@@ -4,6 +4,3 @@ Core expectations
 **Module name:** :mod:`pennylane.expval`
 
 .. automodule:: pennylane.expval
-   :members:
-   :private-members:
-   :inherited-members:

--- a/doc/code/expval/cv.rst
+++ b/doc/code/expval/cv.rst
@@ -1,3 +1,4 @@
 .. automodule:: pennylane.expval.cv
    :members:
    :private-members:
+   :ignore-module-all:

--- a/doc/code/expval/qubit.rst
+++ b/doc/code/expval/qubit.rst
@@ -1,3 +1,4 @@
 .. automodule:: pennylane.expval.qubit
    :members:
    :private-members:
+   :ignore-module-all:

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -58,7 +58,7 @@ from .cv import * #pylint: disable=unused-wildcard-import,wildcard-import
 from .cv import __all__ as _cv__all__
 from .qubit import __all__ as _qubit__all__
 
-class Identity(object): #pylint: disable=too-few-public-methods,function-redefined
+class Identity: #pylint: disable=too-few-public-methods,function-redefined
     r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.
 

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -50,11 +50,13 @@ as the conventions chosen for their implementation.
     expval/cv
 """
 
-#from pennylane.operation import Expectation
 from pennylane.qnode import QNode, QuantumFunctionError
 
 from .qubit import * #pylint: disable=unused-import
 from .cv import * #pylint: disable=unused-import
+
+from .cv import __all__ as __cv_all__
+from .qubit import __all__ as __qubit_all__
 
 #class Identity(Expectation):
 class Identity(object):
@@ -87,3 +89,5 @@ class Identity(object):
     num_params = 0
     par_domain = 'A'
     grad_method = None
+
+__all__ = __cv_all__ + __qubit_all__ + ['Identity']

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -58,7 +58,14 @@ from .cv import * #pylint: disable=unused-wildcard-import,wildcard-import
 from .cv import __all__ as _cv__all__
 from .qubit import __all__ as _qubit__all__
 
-class PlaceholderOperation:
+class PlaceholderExpectation():
+    r"""pennylane.expval.PlaceholderExpectation()
+    A generic base class for constructing placeholders for operations that
+    exist under the same name in CV and qubit based devices.
+
+    When instantiated inside a QNode context, returns an instance
+    of the respective class in expval.cv or expval.qubit.
+    """
     def __new__(cls, *args, **kwargs):
         if QNode._current_context is None:
             raise QuantumFunctionError("Quantum operations can only be used inside a qfunc.")
@@ -69,14 +76,14 @@ class PlaceholderOperation:
         elif supported_expectations.intersection([cls for cls in _qubit__all__]):
             return getattr(qubit, cls.__name__)(*args, **kwargs)
         else:
-            raise QuantumFunctionError("Unable to determine whether this device supports CV or qubit operations when constructing this "+cls.__name__+" expectation.")
+            raise QuantumFunctionError("Unable to determine whether this device supports CV or qubit Operations when constructing this "+cls.__name__+" Expectation.")
 
     num_wires = 0
     num_params = 0
     par_domain = 'A'
     grad_method = None
 
-class Identity(PlaceholderOperation): #pylint: disable=too-few-public-methods,function-redefined
+class Identity(PlaceholderExpectation): #pylint: disable=too-few-public-methods,function-redefined
     r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.
 

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -50,5 +50,40 @@ as the conventions chosen for their implementation.
     expval/cv
 """
 
-from .qubit import *
-from .cv import *
+#from pennylane.operation import Expectation
+from pennylane.qnode import QNode, QuantumFunctionError
+
+from .qubit import * #pylint: disable=unused-import
+from .cv import * #pylint: disable=unused-import
+
+#class Identity(Expectation):
+class Identity(object):
+    r"""pennylane.expval.Identity(wires)
+    Expectation value of the identity observable :math:`\I`.
+
+    The expectation of this observable
+
+    .. math::
+        E[\I] = \text{Tr}(\I \rho)
+
+    corresponds to the trace of the quantum state, which in exact
+    simulators should always be equal to 1.
+
+    This is a placeholder for the Identity classes in expval.qubit and expval.cv and instantiates the Identity appropriate for the respective device.
+    """
+    def __new__(cls, *args, **kwargs):
+        if QNode._current_context is None:
+            raise QuantumFunctionError("Quantum operations can only be used inside a qfunc.")
+
+        supported_expectations = QNode._current_context.device.expectations
+        if supported_expectations.intersection([cls for cls in cv.__all__]):
+            return cv.Identity(*args, **kwargs)
+        elif supported_expectations.intersection([cls for cls in qubit.__all__]):
+            return qubit.Identity(*args, **kwargs)
+        else:
+            raise QuantumFunctionError("Unable to guess whether this device supports CV or qubit operations when constructing an Identity expectation.")
+
+    num_wires = 0
+    num_params = 0
+    par_domain = 'A'
+    grad_method = None

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -52,14 +52,13 @@ as the conventions chosen for their implementation.
 
 from pennylane.qnode import QNode, QuantumFunctionError
 
-from .qubit import * #pylint: disable=unused-import
-from .cv import * #pylint: disable=unused-import
+from .qubit import * #pylint: disable=unused-wildcard-import,wildcard-import
+from .cv import * #pylint: disable=unused-wildcard-import,wildcard-import
 
-from .cv import __all__ as __cv_all__
-from .qubit import __all__ as __qubit_all__
+from .cv import __all__ as _cv__all__
+from .qubit import __all__ as _qubit__all__
 
-#class Identity(Expectation):
-class Identity(object):
+class Identity(object): #pylint: disable=too-few-public-methods,function-redefined
     r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.
 
@@ -71,16 +70,17 @@ class Identity(object):
     corresponds to the trace of the quantum state, which in exact
     simulators should always be equal to 1.
 
-    This is a placeholder for the Identity classes in expval.qubit and expval.cv and instantiates the Identity appropriate for the respective device.
+    This is a placeholder for the Identity classes in expval.qubit and expval.cv
+    and instantiates the Identity appropriate for the respective device.
     """
     def __new__(cls, *args, **kwargs):
         if QNode._current_context is None:
             raise QuantumFunctionError("Quantum operations can only be used inside a qfunc.")
 
         supported_expectations = QNode._current_context.device.expectations
-        if supported_expectations.intersection([cls for cls in cv.__all__]):
+        if supported_expectations.intersection([cls for cls in _cv__all__]):
             return cv.Identity(*args, **kwargs)
-        elif supported_expectations.intersection([cls for cls in qubit.__all__]):
+        elif supported_expectations.intersection([cls for cls in _qubit__all__]):
             return qubit.Identity(*args, **kwargs)
         else:
             raise QuantumFunctionError("Unable to guess whether this device supports CV or qubit operations when constructing an Identity expectation.")
@@ -90,4 +90,4 @@ class Identity(object):
     par_domain = 'A'
     grad_method = None
 
-__all__ = __cv_all__ + __qubit_all__ + ['Identity']
+__all__ = _cv__all__ + _qubit__all__ + [Identity.__name__]

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -58,10 +58,11 @@ from .cv import * #pylint: disable=unused-wildcard-import,wildcard-import
 from .cv import __all__ as _cv__all__
 from .qubit import __all__ as _qubit__all__
 
+
 class PlaceholderExpectation():
     r"""pennylane.expval.PlaceholderExpectation()
     A generic base class for constructing placeholders for operations that
-    exist under the same name in CV and qubit based devices.
+    exist under the same name in CV and qubit-based devices.
 
     When instantiated inside a QNode context, returns an instance
     of the respective class in expval.cv or expval.qubit.
@@ -76,12 +77,9 @@ class PlaceholderExpectation():
         elif supported_expectations.intersection([cls for cls in _qubit__all__]):
             return getattr(qubit, cls.__name__)(*args, **kwargs)
         else:
-            raise QuantumFunctionError("Unable to determine whether this device supports CV or qubit Operations when constructing this "+cls.__name__+" Expectation.")
+            raise QuantumFunctionError("Unable to determine whether this device supports CV or qubit "
+                                       "Operations when constructing this "+cls.__name__+" Expectation.")
 
-    num_wires = 0
-    num_params = 0
-    par_domain = 'A'
-    grad_method = None
 
 class Identity(PlaceholderExpectation): #pylint: disable=too-few-public-methods,function-redefined
     r"""pennylane.expval.Identity(wires)
@@ -98,6 +96,9 @@ class Identity(PlaceholderExpectation): #pylint: disable=too-few-public-methods,
     This is a placeholder for the Identity classes in expval.qubit and expval.cv
     and instantiates the Identity appropriate for the respective device.
     """
-    pass
+    num_wires = 0
+    num_params = 0
+    par_domain = 'A'
+
 
 __all__ = _cv__all__ + _qubit__all__ + [Identity.__name__]

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -83,7 +83,7 @@ class Identity: #pylint: disable=too-few-public-methods,function-redefined
         elif supported_expectations.intersection([cls for cls in _qubit__all__]):
             return qubit.Identity(*args, **kwargs)
         else:
-            raise QuantumFunctionError("Unable to guess whether this device supports CV or qubit operations when constructing an Identity expectation.")
+            raise QuantumFunctionError("Unable to determine whether this device supports CV or qubit operations when constructing an Identity expectation.")
 
     num_wires = 0
     num_params = 0

--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -52,6 +52,9 @@ as the conventions chosen for their implementation.
 
 from pennylane.qnode import QNode, QuantumFunctionError
 
+from . import cv
+from . import qubit
+
 from .qubit import * #pylint: disable=unused-wildcard-import,wildcard-import
 from .cv import * #pylint: disable=unused-wildcard-import,wildcard-import
 
@@ -67,11 +70,17 @@ class PlaceholderExpectation():
     When instantiated inside a QNode context, returns an instance
     of the respective class in expval.cv or expval.qubit.
     """
+    # pylint: disable=too-few-public-methods
     def __new__(cls, *args, **kwargs):
+        # pylint: disable=protected-access
         if QNode._current_context is None:
             raise QuantumFunctionError("Quantum operations can only be used inside a qfunc.")
 
         supported_expectations = QNode._current_context.device.expectations
+
+        # TODO: in the next breaking release, make it mandatory for plugins to declare
+        # whether they target qubit or CV operations, to avoid needing to
+        # inspect supported_expectation directly.
         if supported_expectations.intersection([cls for cls in _cv__all__]):
             return getattr(cv, cls.__name__)(*args, **kwargs)
         elif supported_expectations.intersection([cls for cls in _qubit__all__]):

--- a/pennylane/expval/cv.py
+++ b/pennylane/expval/cv.py
@@ -263,6 +263,12 @@ class NumberState(CVExpectation):
     grad_method = None
     ev_order = None
 
+# As both the qubit and the CV case need an Identity Expectation,
+# and these need to reside in the same name space but have to have
+# different types, this Identity class is not imported into expval
+# directly (it is not put in __all__ below) and instead expval
+# contains a placeholder class Identity that returns appropriate
+# Identity instances via __new__() suitable for the respective device.
 class Identity(CVExpectation):
     r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.

--- a/pennylane/expval/cv.py
+++ b/pennylane/expval/cv.py
@@ -38,7 +38,7 @@ quantum operations supported by PennyLane, as well as their conventions.
     Homodyne
     PolyXP
     NumberState
-    Trace
+    Identity
 
 :html:`<h3>Code details</h3>`
 """
@@ -263,20 +263,22 @@ class NumberState(CVExpectation):
     grad_method = None
     ev_order = None
 
-class Trace(CVExpectation):
-    r"""pennylane.expval.Trace(wires)
+class Identity(CVExpectation):
+    r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.
 
     The expectation of this observable
 
     .. math::
-        E[\I] = \text{Tr}(\I \rho) = 1
+        E[\I] = \text{Tr}(\I \rho)
 
-    corresponds to the trace of the quantum state.
+    corresponds to the trace of the quantum state, which in exact
+    simulators should always be equal to 1.
 
     .. note::
 
-        Can be used to check normalization in fock basis based simulators.
+        Can be used to check normalization in approximate simulators such as
+        fock basis based ones.
 
     **Details:**
 
@@ -292,6 +294,6 @@ class Trace(CVExpectation):
     ev_order = None
 
 
-all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState, Trace]
+all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/expval/cv.py
+++ b/pennylane/expval/cv.py
@@ -38,6 +38,7 @@ quantum operations supported by PennyLane, as well as their conventions.
     Homodyne
     PolyXP
     NumberState
+    Identity
 
 :html:`<h3>Code details</h3>`
 """
@@ -262,7 +263,35 @@ class NumberState(CVExpectation):
     grad_method = None
     ev_order = None
 
+class Identity(CVExpectation):
+    r"""pennylane.expval.Identity(wires)
+    Expectation value of the identity observable :math:`\I`.
 
-all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState]
+    The expectation of this observable
+
+    .. math::
+        E[\I] = \text{Tr}(\I \rho) = 1
+
+    corresponds to the trace of the quantum state.
+
+    .. note::
+
+        Can be used to check normalization in fock basis based simulators.
+
+    **Details:**
+
+    * Number of wires: None (applied to any subset of wires).
+    * Number of parameters: 0
+    * Expectation order: None (non-Gaussian)
+    """
+    num_wires = 0
+    num_params = 0
+    par_domain = 'A'
+
+    grad_method = None
+    ev_order = None
+
+
+all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState, Identity]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/expval/cv.py
+++ b/pennylane/expval/cv.py
@@ -38,7 +38,7 @@ quantum operations supported by PennyLane, as well as their conventions.
     Homodyne
     PolyXP
     NumberState
-    Identity
+    Trace
 
 :html:`<h3>Code details</h3>`
 """
@@ -263,8 +263,8 @@ class NumberState(CVExpectation):
     grad_method = None
     ev_order = None
 
-class Identity(CVExpectation):
-    r"""pennylane.expval.Identity(wires)
+class Trace(CVExpectation):
+    r"""pennylane.expval.Trace(wires)
     Expectation value of the identity observable :math:`\I`.
 
     The expectation of this observable
@@ -292,6 +292,6 @@ class Identity(CVExpectation):
     ev_order = None
 
 
-all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState, Identity]
+all_ops = [Homodyne, MeanPhoton, P, X, PolyXP, NumberState, Trace]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -136,6 +136,12 @@ class Hermitian(Expectation):
     par_domain = 'A'
     grad_method = 'F'
 
+# As both the qubit and the CV case need an Identity Expectation,
+# and these need to reside in the same name space but have to have
+# different types, this Identity class is not imported into expval
+# directly (it is not put in __all__ below) and instead expval
+# contains a placeholder class Identity that returns appropriate
+# Identity instances via __new__() suitable for the respective device.
 class Identity(Expectation):
     r"""pennylane.expval.Identity(wires)
     Expectation value of the identity observable :math:`\I`.

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -143,9 +143,10 @@ class Identity(Expectation):
     The expectation of this observable
 
     .. math::
-        E[\I] = \text{Tr}(\I \rho) = 1
+        E[\I] = \text{Tr}(\I \rho)
 
-    corresponds to the trace of the quantum state.
+    corresponds to the trace of the quantum state, which in exact
+    simulators should always be equal to 1.
 
     .. note::
 
@@ -155,9 +156,9 @@ class Identity(Expectation):
     num_wires = 0
     num_params = 0
     par_domain = 'A'
-    grad_method = 'F'
+    grad_method = None
 
 
-all_ops = [PauliX, PauliY, PauliZ, Hermitian, Identity]
+all_ops = [PauliX, PauliY, PauliZ, Hermitian]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -36,7 +36,7 @@ quantum operations supported by PennyLane, as well as their conventions.
     PauliY
     PauliZ
     Hermitian
-
+    Identity
 
 :html:`<h3>Code details</h3>`
 """
@@ -46,7 +46,7 @@ from pennylane.operation import Expectation
 
 class PauliX(Expectation):
     r"""pennylane.expval.PauliX(wires)
-    Returns the Pauli-X expectation value.
+    Expectation value of Pauli-X.
 
     This expectation command returns the value
 
@@ -70,7 +70,7 @@ class PauliX(Expectation):
 
 class PauliY(Expectation):
     r"""pennylane.expval.PauliY(wires)
-    Returns the Pauli-Y expectation value.
+    Expectation value of Pauli-Y.
 
     This expectation command returns the value
 
@@ -94,7 +94,7 @@ class PauliY(Expectation):
 
 class PauliZ(Expectation):
     r"""pennylane.expval.PauliZ(wires)
-    Returns the Pauli-Z expectation value.
+    Expectation value of Pauli-Z.
 
     This expectation command returns the value
 
@@ -118,7 +118,7 @@ class PauliZ(Expectation):
 
 class Hermitian(Expectation):
     r"""pennylane.expval.Hermitian(A, wires)
-    Returns the expectation value of an arbitrary Hermitian observable.
+    Expectation value of an arbitrary Hermitian observable.
 
     For a Hermitian matrix :math:`A`, this expectation command returns the value
 
@@ -136,7 +136,28 @@ class Hermitian(Expectation):
     par_domain = 'A'
     grad_method = 'F'
 
+class Identity(Expectation):
+    r"""pennylane.expval.Identity(wires)
+    Expectation value of the identity observable :math:`\I`.
 
-all_ops = [PauliX, PauliY, PauliZ, Hermitian]
+    The expectation of this observable
+
+    .. math::
+        E[\I] = \text{Tr}(\I \rho) = 1
+
+    corresponds to the trace of the quantum state.
+
+    .. note::
+
+        Can be used to check normalization in approximate simulators.
+
+    """
+    num_wires = 0
+    num_params = 0
+    par_domain = 'A'
+    grad_method = 'F'
+
+
+all_ops = [PauliX, PauliY, PauliZ, Hermitian, Identity]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -714,7 +714,7 @@ class DefaultGaussian(Device):
         'Homodyne': homodyne(None),
         'PolyXP': poly_quad_expectations,
         'NumberState': fock_expectation,
-        'Identity': identity
+        'Trace': identity
     }
 
     _circuits = {}

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -663,6 +663,12 @@ def fock_expectation(mu, cov, wires, params, hbar=2.):
     var = ex - ex**2
     return ex, var
 
+def identity():
+    """Returns 1
+    """
+    return 1, 0
+
+
 
 #========================================================
 #  device
@@ -707,7 +713,8 @@ class DefaultGaussian(Device):
         'P': homodyne(np.pi/2),
         'Homodyne': homodyne(None),
         'PolyXP': poly_quad_expectations,
-        'NumberState': fock_expectation
+        'NumberState': fock_expectation,
+        'Identity': identity
     }
 
     _circuits = {}
@@ -796,6 +803,9 @@ class DefaultGaussian(Device):
         return S2
 
     def expval(self, expectation, wires, par):
+        if expectation == 'Identity':
+            return 1
+
         mu, cov = self.reduced_state(wires)
 
         if expectation == 'PolyXP':

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -714,7 +714,7 @@ class DefaultGaussian(Device):
         'Homodyne': homodyne(None),
         'PolyXP': poly_quad_expectations,
         'NumberState': fock_expectation,
-        'Trace': identity
+        'Identity': identity
     }
 
     _circuits = {}

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -664,8 +664,20 @@ def fock_expectation(mu, cov, wires, params, hbar=2.):
     return ex, var
 
 def identity(mu, cov, wires, params, hbar=2.):
-    """Returns 1
+    r"""Returns 1.
+
+    Args:
+        mu (array): vector of means
+        cov (array): covariance matrix
+        wires (Sequence[int]): wires to calculate the expectation for
+        params (Sequence[int]): None.
+        hbar (float): (default 2) the value of :math:`\hbar` in the commutation
+            relation :math:`[\x,\p]=i\hbar`
+
+    Returns:
+        tuple: the Fock state expectation and variance
     """
+    # pylint: disable=unused-argument
     return 1, 0
 
 
@@ -804,10 +816,6 @@ class DefaultGaussian(Device):
 
     def expval(self, expectation, wires, par):
         mu, cov = self.reduced_state(wires)
-
-        # if expectation == 'PolyXP':
-        #     mu, cov = self._state
-
         ev, var = self._expectation_map[expectation](mu, cov, wires, par, hbar=self.hbar)
 
         if self.shots != 0:

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -663,7 +663,7 @@ def fock_expectation(mu, cov, wires, params, hbar=2.):
     var = ex - ex**2
     return ex, var
 
-def identity():
+def identity(mu, cov, wires, params, hbar=2.):
     """Returns 1
     """
     return 1, 0
@@ -803,9 +803,6 @@ class DefaultGaussian(Device):
         return S2
 
     def expval(self, expectation, wires, par):
-        if expectation == 'Identity':
-            return 1
-
         mu, cov = self.reduced_state(wires)
 
         if expectation == 'PolyXP':

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -805,8 +805,8 @@ class DefaultGaussian(Device):
     def expval(self, expectation, wires, par):
         mu, cov = self.reduced_state(wires)
 
-        if expectation == 'PolyXP':
-            mu, cov = self._state
+        # if expectation == 'PolyXP':
+        #     mu, cov = self._state
 
         ev, var = self._expectation_map[expectation](mu, cov, wires, par, hbar=self.hbar)
 

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -118,6 +118,7 @@ I = np.eye(2)
 X = np.array([[0, 1], [1, 0]]) #: Pauli-X matrix
 Y = np.array([[0, -1j], [1j, 0]]) #: Pauli-Y matrix
 Z = np.array([[1, 0], [0, -1]]) #: Pauli-Z matrix
+I = np.identity(2)
 
 H = np.array([[1, 1], [1, -1]])/np.sqrt(2) #: Hadamard gate
 # Two qubit gates
@@ -272,7 +273,8 @@ class DefaultQubit(Device):
         'PauliX': X,
         'PauliY': Y,
         'PauliZ': Z,
-        'Hermitian': hermitian
+        'Hermitian': hermitian,
+        'Identity': I
     }
 
     def __init__(self, wires, *, shots=0):

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -228,16 +228,12 @@ def hermitian(*args):
 
     return A
 
-def identity(*args):
+def identity(*par):
     """Identity matrix for expectations.
 
-    Args:
-        args (array): ???
-
     Returns:
-        array: square hermitian matrix
+        array: 2x2 identity matrix
     """
-    print("args"+str(args))
     return np.identity(2)
 
 #========================================================

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -118,7 +118,6 @@ I = np.eye(2)
 X = np.array([[0, 1], [1, 0]]) #: Pauli-X matrix
 Y = np.array([[0, -1j], [1j, 0]]) #: Pauli-Y matrix
 Z = np.array([[1, 0], [0, -1]]) #: Pauli-Z matrix
-I = np.identity(2)
 
 H = np.array([[1, 1], [1, -1]])/np.sqrt(2) #: Hadamard gate
 # Two qubit gates
@@ -229,6 +228,18 @@ def hermitian(*args):
 
     return A
 
+def identity(*args):
+    """Identity matrix for expectations.
+
+    Args:
+        args (array): ???
+
+    Returns:
+        array: square hermitian matrix
+    """
+    print("args"+str(args))
+    return np.identity(2)
+
 #========================================================
 #  device
 #========================================================
@@ -274,7 +285,7 @@ class DefaultQubit(Device):
         'PauliY': Y,
         'PauliZ': Z,
         'Hermitian': hermitian,
-        'Identity': I
+        'Identity': identity
     }
 
     def __init__(self, wires, *, shots=0):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -335,7 +335,7 @@ class QNode:
         if all(temp):
             self.type = 'CV'
         elif not True in temp:
-            self.type = 'discrete'
+            self.type = 'qubit'
         else:
             raise QuantumFunctionError("Continuous and discrete operations are not "
                                        "allowed in the same quantum circuit.")

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -307,7 +307,7 @@ class TestDefaultGaussianDevice(BaseTest):
     def test_expectation_map(self):
         """Test that default Gaussian device supports all PennyLane Gaussian continuous expectations."""
         self.logTestName()
-        self.assertEqual(set(qml.expval.cv.__all__)-{'Heterodyne'},
+        self.assertEqual(set(qml.expval.cv.__all__)|{'Identity'}-{'Heterodyne'},
                          set(self.dev._expectation_map))
 
     def test_apply(self):
@@ -506,7 +506,7 @@ class TestDefaultGaussianIntegration(BaseTest):
         dev = qml.device('default.gaussian', wires=2)
 
         obs = set(dev._expectation_map.keys())
-        all_obs = {m[0] for m in inspect.getmembers(qml.expval, inspect.isclass)}
+        all_obs = set(qml.expval.__all__)
 
         for g in all_obs - obs:
             op = getattr(qml.expval, g)
@@ -540,6 +540,21 @@ class TestDefaultGaussianIntegration(BaseTest):
             return qml.expval.X(0)
 
         self.assertAlmostEqual(circuit(p), p*np.sqrt(2*hbar), delta=self.tol)
+
+    def test_gaussian_identity(self):
+        """Test that the default gaussian plugin provides correct result for the identity expectation"""
+        self.logTestName()
+        dev = qml.device('default.gaussian', wires=1)
+
+        p = 0.543
+
+        @qml.qnode(dev)
+        def circuit(x):
+            """Test quantum function"""
+            qml.Displacement(x, 0, wires=0)
+            return qml.expval.Identity(0)
+
+        self.assertAlmostEqual(circuit(p), 1, delta=self.tol)
 
     def test_nonzero_shots(self):
         """Test that the default gaussian plugin provides correct result for high shot number"""

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -201,7 +201,7 @@ class TestDefaultQubitDevice(BaseTest):
         """Test that default qubit device supports all PennyLane discrete expectations."""
         self.logTestName()
 
-        self.assertEqual(set(qml.expval.qubit.__all__), set(self.dev._expectation_map))
+        self.assertEqual(set(qml.expval.qubit.__all__)|{'Identity'}, set(self.dev._expectation_map))
 
     def test_expand_one(self):
         """Test that a 1 qubit gate correctly expands to 3 qubits."""
@@ -486,7 +486,7 @@ class TestDefaultQubitIntegration(BaseTest):
         dev = qml.device('default.qubit', wires=2)
 
         obs = set(dev._expectation_map.keys())
-        all_obs = {m[0] for m in inspect.getmembers(qml.expval, inspect.isclass)}
+        all_obs = set(qml.expval.__all__)
 
         for g in all_obs - obs:
             op = getattr(qml.expval, g)
@@ -522,6 +522,21 @@ class TestDefaultQubitIntegration(BaseTest):
         # <0|RX(p)^\dagger.PauliY.RX(p)|0> = -sin(p)
         expected = -np.sin(p)
         self.assertAlmostEqual(circuit(p), expected, delta=self.tol)
+
+    def test_qubit_identity(self):
+        """Test that the default qubit plugin provides correct result for the Identiy expectation"""
+        self.logTestName()
+        dev = qml.device('default.qubit', wires=1)
+
+        p = 0.543
+
+        @qml.qnode(dev)
+        def circuit(x):
+            """Test quantum function"""
+            qml.RX(x, wires=0)
+            return qml.expval.Identity(0)
+
+        self.assertAlmostEqual(circuit(p), 1, delta=self.tol)
 
     def test_nonzero_shots(self):
         """Test that the default qubit plugin provides correct result for high shot number"""

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -402,11 +402,15 @@ class TestDefaultQubitDevice(BaseTest):
                 # otherwise, the operation is simply an array.
                 O = fn
 
+            print("op.num_wires="+str(op.num_wires))
+
             # calculate the expected output
-            if op.num_wires == 1:
+            if op.num_wires == 1 or op.num_wires == 0:
                 expected_out = self.dev._state.conj() @ np.kron(O, I) @ self.dev._state
             elif op.num_wires == 2:
                 expected_out = self.dev._state.conj() @ O @ self.dev._state
+            else:
+                raise NotImplementedError("Test for operations with num_wires="+op.num_wires+" not implemented.")
 
             res = self.dev.ev(O, wires=[0])
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -137,7 +137,7 @@ class DeviceTest(BaseTest):
                         expval = dev.execute(queue, [qml.expval.PauliX(0, do_queue=False)])
 
             exps = dev.expectations
-            all_exps = {m[0] for m in inspect.getmembers(qml.expval, inspect.isclass)}
+            all_exps = set(qml.expval.__all__)
 
             for g in all_exps-exps:
                 op = qml.expval.__getattribute__(g)

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -1,0 +1,67 @@
+# Copyright 2018 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
+"""
+# pylint: disable=protected-access,cell-var-from-loop
+import unittest
+import inspect
+import logging as log
+
+import pennylane as qml
+
+from pennylane import numpy as np
+from scipy.linalg import block_diag
+
+from defaults import pennylane as qml, BaseTest
+from pennylane.expval import Identity
+from pennylane.qnode import QuantumFunctionError
+
+log.getLogger('defaults')
+
+class TestExpval(BaseTest):
+    """Tests that the Expectations in expval work propperly."""
+
+    def test_identiy_raises_exception_if_outside_qnode(self):
+        """Tests that proper exceptions are raised if we try to call Idenity
+        outside a QNode."""
+        self.logTestName()
+
+        with self.assertRaisesRegex(QuantumFunctionError, 'can only be used inside a qfunc'):
+            Identity(wires=0)
+
+    def test_identiy_raises_exception_if_cannot_guess_device_type(self):
+        """Tests that proper exceptions are raised if Identity fails to guess
+        whether on a device is CV or qubit."""
+        self.logTestName()
+
+        dev = qml.device('default.qubit', wires=1)
+        dev._expectation_map = {}
+
+        @qml.qnode(dev)
+        def circuit():
+            return qml.expval.Identity(wires=0)
+
+        with self.assertRaisesRegex(QuantumFunctionError, 'Unable to guess whether this device supports CV or qubit operations'):
+            circuit()
+
+
+if __name__ == '__main__':
+    print('Testing PennyLane version ' + qml.version() + ', expval.')
+    # run the tests in this file
+    suite = unittest.TestSuite()
+    for t in (TestExpval):
+        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
+        suite.addTests(ttt)
+    unittest.TextTestRunner().run(suite)

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -53,7 +53,7 @@ class TestExpval(BaseTest):
         def circuit():
             return qml.expval.Identity(wires=0)
 
-        with self.assertRaisesRegex(QuantumFunctionError, 'Unable to guess whether this device supports CV or qubit operations'):
+        with self.assertRaisesRegex(QuantumFunctionError, 'Unable to determine whether this device supports CV or qubit operations'):
             circuit()
 
 

--- a/tests/test_expval.py
+++ b/tests/test_expval.py
@@ -53,7 +53,7 @@ class TestExpval(BaseTest):
         def circuit():
             return qml.expval.Identity(wires=0)
 
-        with self.assertRaisesRegex(QuantumFunctionError, 'Unable to determine whether this device supports CV or qubit operations'):
+        with self.assertRaisesRegex(QuantumFunctionError, 'Unable to determine whether this device supports CV or qubit'):
             circuit()
 
 


### PR DESCRIPTION
**Description of the Change:**

Adds an Identity Expectation for both the CV and qubit case. The implementation was complicated by the fact that it is not possible to have a CV and and a qubit Expectation under the same name. I have basically followed the rout recommended in https://discuss.pennylane.ai/t/pennylane-version-0-2-discussion/27/9. 

In the end I actually managed not having to touch `QNode` at all and no braking changes in the plugins are required.

This is achieved by implementing a "placeholder" class in `expval.__init__` that has an overloaded `__new__()` method, which inspects the list of Expectations a device supports to determine whether it is a CV or qubit device and then returns an instance of the appropriate Identity classes for the CV or qubit device.

The PR comes complete with unit tests, implementation of Identity in the default plugins, and documentation changes. Please, nevertheless, review this carefully. 

I have also made the documentation of the CV and qubit operations more similar.

**Benefits:**

This is important to check normalization in approximate simulators.

**Possible Drawbacks:**

The implementation is non-trivial and relies on a "placeholder" class in `expval.__init__` that loads the respective appropriate class from `expval.qubit` and `expval.cv`.

**Related GitHub Issues:**
https://discuss.pennylane.ai/t/pennylane-version-0-2-discussion/27/9