### PR TITLE
fixes the par_domain of the newly introduced Identity Expectation

### DIFF
--- a/pennylane/expval/__init__.py
+++ b/pennylane/expval/__init__.py
@@ -107,7 +107,7 @@ class Identity(PlaceholderExpectation): #pylint: disable=too-few-public-methods,
     """
     num_wires = 0
     num_params = 0
-    par_domain = 'A'
+    par_domain = None
 
 
 __all__ = _cv__all__ + _qubit__all__ + [Identity.__name__]

--- a/pennylane/expval/cv.py
+++ b/pennylane/expval/cv.py
@@ -294,7 +294,7 @@ class Identity(CVExpectation):
     """
     num_wires = 0
     num_params = 0
-    par_domain = 'A'
+    par_domain = None
 
     grad_method = None
     ev_order = None

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -161,7 +161,7 @@ class Identity(Expectation):
     """
     num_wires = 0
     num_params = 0
-    par_domain = 'A'
+    par_domain = None
     grad_method = None
 
 


### PR DESCRIPTION
Somehow we overlooked this when merging the identity branch. Sorry, this was my mistake... 