### PR TITLE
Feature/queue peak

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -196,18 +196,18 @@ class Device(abc.ABC):
         """
         self.check_validity(queue, expectation)
         with self.execution_context():
-            self.pre_apply()
+            self.pre_apply(queued=queue)
             for operation in queue:
                 self.apply(operation.name, operation.wires, operation.parameters)
             self.post_apply()
 
-            self.pre_expval()
+            self.pre_expval(queued=expectation)
             expectations = [self.expval(e.name, e.wires, e.parameters) for e in expectation]
             self.post_expval()
 
             return np.array(expectations)
 
-    def pre_apply(self):
+    def pre_apply(self, **kwargs):
         """Called during :meth:`execute` before the individual operations are executed."""
         pass
 
@@ -215,7 +215,7 @@ class Device(abc.ABC):
         """Called during :meth:`execute` after the individual operations have been executed."""
         pass
 
-    def pre_expval(self):
+    def pre_expval(self, **kwargs):
         """Called during :meth:`execute` before the individual expectations are executed."""
         pass
 

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -35,6 +35,7 @@ quantum operations supported by PennyLane, as well as their conventions.
     PauliX
     PauliY
     PauliZ
+    Hadamard
     Hermitian
     Identity
 

--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -116,6 +116,30 @@ class PauliZ(Expectation):
     par_domain = None
 
 
+class Hadamard(Expectation):
+    r"""pennylane.expval.Hadamard(wires)
+    Expectation value of the Hadamard observable.
+
+    This expectation command returns the value
+
+    .. math::
+        \braket{H} = \braketT{\psi}{\cdots \otimes I\otimes H\otimes I\cdots}{\psi}
+
+    where :math:`H` acts on the requested wire.
+
+    **Details:**
+
+    * Number of wires: 1
+    * Number of parameters: 0
+
+    Args:
+        wires (Sequence[int] or int): the wire the operation acts on
+    """
+    num_wires = 1
+    num_params = 0
+    par_domain = None
+
+
 class Hermitian(Expectation):
     r"""pennylane.expval.Hermitian(A, wires)
     Expectation value of an arbitrary Hermitian observable.
@@ -165,6 +189,6 @@ class Identity(Expectation):
     grad_method = None
 
 
-all_ops = [PauliX, PauliY, PauliZ, Hermitian]
+all_ops = [PauliX, PauliY, PauliZ, Hadamard, Hermitian]
 
 __all__ = [cls.__name__ for cls in all_ops]

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -737,7 +737,7 @@ class DefaultGaussian(Device):
         self.hbar = hbar
         self.reset()
 
-    def pre_apply(self):
+    def pre_apply(self, **kwargs):
         self.reset()
 
     def apply(self, operation, wires, par):

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -737,7 +737,7 @@ class DefaultGaussian(Device):
         self.hbar = hbar
         self.reset()
 
-    def pre_apply(self, **kwargs):
+    def pre_apply(self):
         self.reset()
 
     def apply(self, operation, wires, par):

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -290,7 +290,7 @@ class DefaultQubit(Device):
         self.eng = None
         self._state = None
 
-    def pre_apply(self, **kwargs):
+    def pre_apply(self):
         self.reset()
 
     def apply(self, operation, wires, par):

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -280,6 +280,7 @@ class DefaultQubit(Device):
         'PauliX': X,
         'PauliY': Y,
         'PauliZ': Z,
+        'Hadamard': H,
         'Hermitian': hermitian,
         'Identity': identity
     }

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -289,7 +289,7 @@ class DefaultQubit(Device):
         self.eng = None
         self._state = None
 
-    def pre_apply(self):
+    def pre_apply(self, **kwargs):
         self.reset()
 
     def apply(self, operation, wires, par):


### PR DESCRIPTION
This PR makes the following changes:

* Within `Device.execute`, the attributes `self.op_queue` and `self.ev_queue` are set with the to-be-applied queues, and then reset to `[]` after execution. This allows plugins to 'peek' at the operation/expval queues before application of gates/expectation values.

* Added the `qml.expval.qubit.Hadamard` expectation value for completeness.

**Note:** as implemented, this is should not be a breaking change to the API - all plugins will should continue working.