### PR TITLE
Makes DisplacedSqueezedState() and CatState() take real (abs and phase) parameters instead of complex ones.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install wheel pytest pytest-cov codecov
+- pip install wheel pytest pytest-cov codecov --upgrade
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -185,14 +185,14 @@ class Squeezing(CVOperation):
 
 
 class Displacement(CVOperation):
-    r"""pennylane.Displacement(r, phi, wires)
+    r"""pennylane.Displacement(a, phi, wires)
     Phase space displacement.
 
     .. math::
-       D(r,\phi) = D(\alpha) = \exp(\alpha a^\dagger -\alpha^* a)
+       D(a,\phi) = D(\alpha) = \exp(\alpha a^\dagger -\alpha^* a)
        = \exp\left(-i\sqrt{\frac{2}{\hbar}}(\re(\alpha) \hat{p} -\im(\alpha) \hat{x})/\right).
 
-    where :math:`\alpha = r e^{i\phi}` has magnitude :math:`r\geq 0` and phase :math:`\phi`.
+    where :math:`\alpha = ae^{i\phi}` has magnitude :math:`a\geq 0` and phase :math:`\phi`.
     The result of applying a displacement to the vacuum is a coherent state
     :math:`D(\alpha)\ket{0} = \ket{\alpha}`.
 
@@ -200,14 +200,14 @@ class Displacement(CVOperation):
 
     * Number of wires: 1
     * Number of parameters: 2
-    * Gradient recipe: :math:`\frac{d}{dr}D(r,\phi) = \frac{1}{2s} \left[D(r+s, \phi) - D(r-s, \phi)\right]`,
+    * Gradient recipe: :math:`\frac{d}{dr}D(a,\phi) = \frac{1}{2s} \left[D(a+s, \phi) - D(a-s, \phi)\right]`,
       where :math:`s` is an arbitrary real number (:math:`0.1` by default)
     * Heisenberg representation:
 
-      .. math:: M = \begin{bmatrix} 1 & 0 & 0 \\ 2r\cos\phi & 1 & 0 \\ 2r\sin\phi & 0 & 1\end{bmatrix}
+      .. math:: M = \begin{bmatrix} 1 & 0 & 0 \\ 2a\cos\phi & 1 & 0 \\ 2a\sin\phi & 0 & 1\end{bmatrix}
 
     Args:
-        r (float): displacement magnitude :math:`r=|\alpha|`
+        a (float): displacement magnitude :math:`a=|\alpha|`
         phi (float): phase angle :math:`\phi`
         wires (Sequence[int] or int): the wire the operation acts on
     """

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -721,7 +721,7 @@ class CatState(CVOperation):
     .. math::
        \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{ip\pi} \ket{-\alpha}),
 
-    where :math:`\ket{\pm\alpha} = D(\pm\alpha)\ket{0}` are a coherent states with displacement
+    where :math:`\ket{\pm\alpha} = D(\pm\alpha)\ket{0}` are coherent states with displacement
     parameters :math:`\pm\alpha=\pm ae^{i\phi}` and
     :math:`N = \sqrt{2 (1+\cos(p\pi)e^{-2|\alpha|^2})}` is the normalization factor.
 
@@ -739,7 +739,7 @@ class CatState(CVOperation):
         wires (Sequence[int] or int): the wire the operation acts on
     """
     num_wires = 1
-    num_params = 2
+    num_params = 3
     par_domain = 'R'
     grad_method = 'F'
 

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -147,7 +147,7 @@ class Squeezing(CVOperation):
     Phase space squeezing.
 
     .. math::
-        S(z) = \exp\left(\frac{1}{2}(z^* a^2 -z {a^\dagger}^2)\right).
+        S(z) = \exp\left(\frac{1}{2}(z^* \a^2 -z {\a^\dagger}^2)\right).
 
     where :math:`z = r e^{i\phi}`.
 
@@ -189,8 +189,8 @@ class Displacement(CVOperation):
     Phase space displacement.
 
     .. math::
-       D(a,\phi) = D(\alpha) = \exp(\alpha a^\dagger -\alpha^* a)
-       = \exp\left(-i\sqrt{\frac{2}{\hbar}}(\re(\alpha) \hat{p} -\im(\alpha) \hat{x})/\right).
+       D(a,\phi) = D(\alpha) = \exp(\alpha \ad -\alpha^* \a)
+       = \exp\left(-i\sqrt{\frac{2}{\hbar}}(\re(\alpha) \hat{p} -\im(\alpha) \hat{x})\right).
 
     where :math:`\alpha = ae^{i\phi}` has magnitude :math:`a\geq 0` and phase :math:`\phi`.
     The result of applying a displacement to the vacuum is a coherent state
@@ -232,7 +232,7 @@ class Beamsplitter(CVOperation):
     Beamsplitter interaction.
 
     .. math::
-        B(\theta,\phi) = \exp\left(\theta (e^{i \phi} a b^\dagger -e^{-i \phi}a^\dagger b) \right).
+        B(\theta,\phi) = \exp\left(\theta (e^{i \phi} \a \hat{b}^\dagger -e^{-i \phi}\ad \hat{b}) \right).
 
     **Details:**
 
@@ -281,8 +281,8 @@ class TwoModeSqueezing(CVOperation):
     Phase space two-mode squeezing.
 
     .. math::
-        S_2(z) = \exp\left(z^* ab -z a^\dagger b^\dagger \right)
-        = \exp\left(r (e^{-i\phi} ab -e^{i\phi} a^\dagger b^\dagger \right).
+        S_2(z) = \exp\left(z^* \a \hat{b} -z \ad \hat{b}^\dagger \right)
+        = \exp\left(r (e^{-i\phi} \a\hat{b} -e^{i\phi} \ad \hat{b}^\dagger \right).
 
     where :math:`z = r e^{i\phi}`.
 

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -189,10 +189,12 @@ class Displacement(CVOperation):
     Phase space displacement.
 
     .. math::
-       D(\alpha) = \exp(\alpha a^\dagger -\alpha^* a)
+       D(r,\phi) = D(\alpha) = \exp(\alpha a^\dagger -\alpha^* a)
        = \exp\left(-i\sqrt{\frac{2}{\hbar}}(\re(\alpha) \hat{p} -\im(\alpha) \hat{x})/\right).
 
     where :math:`\alpha = r e^{i\phi}` has magnitude :math:`r\geq 0` and phase :math:`\phi`.
+    The result of applying a displacement to the vacuum is a coherent state
+    :math:`D(\alpha)\ket{0} = \ket{\alpha}`.
 
     **Details:**
 
@@ -579,7 +581,7 @@ class SqueezedState(CVOperation):
 
 
 class DisplacedSqueezedState(CVOperation):
-    r"""pennylane.DisplacedSqueezedState(a, r, phi, wires)
+    r"""pennylane.DisplacedSqueezedState(a, phi_a, r, phi_r, wires)
     Prepares a displaced squeezed vacuum state.
 
     A displaced squeezed state is prepared by squeezing a vacuum state, and
@@ -588,7 +590,7 @@ class DisplacedSqueezedState(CVOperation):
     .. math::
        \ket{\alpha,z} = D(\alpha)\ket{0,z} = D(\alpha)S(z)\ket{0},
 
-    where the squeezing parameter :math:`z=re^{i\phi}`.
+    with the displacement parameter :math:`\alpha=ae^{i\phi_a}` and the squeezing parameter :math:`z=re^{i\phi_r}`.
 
     **Details:**
 
@@ -597,13 +599,14 @@ class DisplacedSqueezedState(CVOperation):
     * Gradient recipe: None (uses finite difference)
 
     Args:
-        alpha (complex): displacement parameter
-        r (float): squeezing magnitude
-        phi (float): squeezing angle :math:`\phi`
+        a (float): displacement magnitude :math:`a=|\alpha|`
+        phi_a (float): displacement angle :math:`\phi_a`
+        r (float): squeezing magnitude :math:`r=|z|`
+        phi_r (float): squeezing angle :math:`\phi_r`
         wires (Sequence[int] or int): the wire the operation acts on
     """
     num_wires = 1
-    num_params = 3
+    num_params = 4
     par_domain = 'R'
     grad_method = 'F'
 
@@ -710,26 +713,29 @@ class FockDensityMatrix(CVOperation):
 
 
 class CatState(CVOperation):
-    r"""pennylane.CatState(alpha, p, wires)
+    r"""pennylane.CatState(a, phi, p, wires)
     Prepares a cat state.
 
     A cat state is the coherent superposition of two coherent states,
 
     .. math::
-       \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{i\phi} \ket{-\alpha}),
+       \ket{\text{cat}(\alpha)} = \frac{1}{N} (\ket{\alpha} +e^{ip\pi} \ket{-\alpha}),
 
-    where :math:`N = \sqrt{2 (1+\cos(\phi)e^{-2|\alpha|^2})}` is the normalization factor.
+    where :math:`\ket{\pm\alpha} = D(\pm\alpha)\ket{0}` are a coherent states with displacement
+    parameters :math:`\pm\alpha=\pm ae^{i\phi}` and
+    :math:`N = \sqrt{2 (1+\cos(p\pi)e^{-2|\alpha|^2})}` is the normalization factor.
 
     **Details:**
 
     * Number of wires: 1
-    * Number of parameters: 2
+    * Number of parameters: 3
     * Gradient recipe: None (uses finite difference)
 
     Args:
-        alpha (complex): displacement parameter
-        p (float): parity, where :math:`\phi=p\pi`. ``p=0`` corresponds to an even
-            cat state, and ``p=1`` an odd cat state.
+        a (float): displacement magnitude :math:`a=|\alpha|`
+        phi (float): displacement angle :math:`\phi`
+        p (float): parity, where :math:`p=0` corresponds to an even
+            cat state, and :math:`p=1` an odd cat state.
         wires (Sequence[int] or int): the wire the operation acts on
     """
     num_wires = 1

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -233,10 +233,10 @@ def rotation(phi):
     """Rotation in the phase space.
 
     Args:
-        phi (float): rotation parameter.
+        phi (float): rotation parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     return np.array([[np.cos(phi), -np.sin(phi)],
                      [np.sin(phi), np.cos(phi)]])
@@ -246,12 +246,12 @@ def displacement(state, wire, alpha, hbar=2):
     """Displacement in the phase space.
 
     Args:
-        state (tuple): contains means vector and covariance matrix.
-        wire (int): wire that the displacement acts on.
-        alpha (float): complex displacement.
+        state (tuple): contains means vector and covariance matrix
+        wire (int): wire that the displacement acts on
+        alpha (float): complex displacement
 
     Returns:
-        tuple: contains the vector of means and covariance matrix.
+        tuple: contains the vector of means and covariance matrix
     """
     mu = state[0]
     mu[wire] += alpha.real*np.sqrt(2*hbar)
@@ -263,11 +263,11 @@ def squeezing(r, phi):
     """Squeezing in the phase space.
 
     Args:
-        r (float): squeezing magnitude.
-        phi (float): rotation parameter.
+        r (float): squeezing magnitude
+        phi (float): rotation parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     cp = np.cos(phi)
     sp = np.sin(phi)
@@ -281,10 +281,10 @@ def quadratic_phase(s):
     """Quadratic phase shift.
 
     Args:
-        s (float): parameter.
+        s (float): gate parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     return np.array([[1, 0],
                      [s, 1]])
@@ -294,11 +294,11 @@ def beamsplitter(theta, phi):
     r"""Beamsplitter.
 
     Args:
-        theta (float): transmittivity angle (:math:`t=\cos\theta`).
-        phi (float): phase angle (:math:`r=e^{i\phi}\sin\theta`).
+        theta (float): transmittivity angle (:math:`t=\cos\theta`)
+        phi (float): phase angle (:math:`r=e^{i\phi}\sin\theta`)
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     cp = np.cos(phi)
     sp = np.sin(phi)
@@ -318,11 +318,11 @@ def two_mode_squeezing(r, phi):
     """Two-mode squeezing.
 
     Args:
-        r (float): squeezing magnitude.
-        phi (float): rotation parameter.
+        r (float): squeezing magnitude
+        phi (float): rotation parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     cp = np.cos(phi)
     sp = np.sin(phi)
@@ -341,10 +341,10 @@ def controlled_addition(s):
     """CX gate.
 
     Args:
-        s (float): parameter.
+        s (float): gate parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     S = np.array([[1, 0, 0, 0],
                   [s, 1, 0, 0],
@@ -358,10 +358,10 @@ def controlled_phase(s):
     """CZ gate.
 
     Args:
-        s (float): parameter.
+        s (float): gate parameter
 
     Returns:
-        array: symplectic transformation matrix.
+        array: symplectic transformation matrix
     """
     S = np.array([[1, 0, 0, 0],
                   [0, 1, 0, 0],
@@ -382,7 +382,7 @@ def squeezed_cov(r, phi, hbar=2):
         r (float): the squeezing magnitude
         p (float): the squeezing phase :math:`\phi`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
     Returns:
         array: the squeezed state
     """
@@ -398,9 +398,9 @@ def vacuum_state(wires, hbar=2.):
     r"""Returns the vacuum state.
 
     Args:
-        basis (str): Returns the vector of means and the covariance matrix.
+        basis (str): Returns the vector of means and the covariance matrix
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
     Returns:
         array: the vacuum state
     """
@@ -417,7 +417,7 @@ def coherent_state(a, phi=0, hbar=2.):
         a (complex) : the displacement
         phi (float): the phase
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
     Returns:
         array: the coherent state
     """
@@ -435,7 +435,7 @@ def squeezed_state(r, phi, hbar=2.):
         r (float): the squeezing magnitude
         phi (float): the squeezing phase :math:`\phi`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         array: the squeezed state
@@ -449,12 +449,12 @@ def displaced_squeezed_state(a, phi_a, r, phi_r, hbar=2.):
     r"""Returns a squeezed coherent state
 
     Args:
-        a (real): the displacement magnitude.
-        phi_a (real): the displacement phase.
+        a (real): the displacement magnitude
+        phi_a (real): the displacement phase
         r (float): the squeezing magnitude
         phi_r (float): the squeezing phase :math:`\phi_r`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         array: the squeezed coherent state
@@ -469,9 +469,9 @@ def thermal_state(nbar, hbar=2.):
     r"""Returns a thermal state.
 
     Args:
-        nbar (float): the mean photon number.
+        nbar (float): the mean photon number
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         array: the thermal state
@@ -494,11 +494,11 @@ def gaussian_state(mu, cov, hbar=2.):
 
     Args:
         mu (array): vector means. Must be length-:math:`2N`,
-            where N is the number of modes.
+            where N is the number of modes
         cov (array): covariance matrix. Must be dimension :math:`2N\times 2N`,
-            where N is the number of modes.
+            where N is the number of modes
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         array: the thermal state
@@ -513,10 +513,10 @@ def set_state(state, wire, mu, cov):
 
     Args:
         state (tuple): contains means vector
-            and covariance matrix of existing state.
-        wire (int): wire corresponding to the new Gaussian state.
-        mu (array): vector of means to insert.
-        cov (array): covariance matrix to insert.
+            and covariance matrix of existing state
+        wire (int): wire corresponding to the new Gaussian state
+        mu (array): vector of means to insert
+        cov (array): covariance matrix to insert
 
     Returns:
         tuple: contains the vector of means and covariance matrix.
@@ -546,15 +546,15 @@ def photon_number(mu, cov, wires, params, hbar=2.):
     r"""Calculates the mean photon number for a given one-mode state.
 
     Args:
-        mu (array): length-2 vector of means.
-        cov (array): :math:`2\times 2` covariance matrix.
-        wires (Sequence[int]): wires to calculate the expectation for.
-        params (None): no parameters are used for this expectation value.
+        mu (array): length-2 vector of means
+        cov (array): :math:`2\times 2` covariance matrix
+        wires (Sequence[int]): wires to calculate the expectation for
+        params (None): no parameters are used for this expectation value
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
-        tuple: contains the photon number expectation and variance.
+        tuple: contains the photon number expectation and variance
     """
     # pylint: disable=unused-argument
     ex = (np.trace(cov) + mu.T @ mu)/(2*hbar) - 1/2
@@ -566,7 +566,7 @@ def homodyne(phi=None):
     """Function factory that returns the Homodyne expectation of a one mode state.
 
     Args:
-        phi (float): the default phase space axis to perform the Homodyne measurement.
+        phi (float): the default phase space axis to perform the Homodyne measurement
 
     Returns:
         function: A function that accepts a single mode means vector, covariance matrix,
@@ -598,14 +598,14 @@ def poly_quad_expectations(mu, cov, wires, params, hbar=2.):
     polynomial of quadrature operators.
 
     Args:
-        mu (array): length-2 vector of means.
-        cov (array): :math:`2\times 2` covariance matrix.
-        wires (Sequence[int]): wires to calculate the expectation for.
+        mu (array): length-2 vector of means
+        cov (array): :math:`2\times 2` covariance matrix
+        wires (Sequence[int]): wires to calculate the expectation for
         params (array): a :math:`(2N+1)\times (2N+1)` array containing the linear
             and quadratic coefficients of the quadrature operators
-            :math:`(\I, \x_0, \p_0, \x_1, \p_1,\dots)`.
+            :math:`(\I, \x_0, \p_0, \x_1, \p_1,\dots)`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         tuple: the mean and variance of the quadrature-polynomial observable
@@ -697,7 +697,7 @@ class DefaultGaussian(Device):
         shots (int): How many times should the circuit be evaluated (or sampled) to estimate
             the expectation values. 0 yields the exact result.
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`.
+            relation :math:`[\x,\p]=i\hbar`
     """
     name = 'Default Gaussian PennyLane plugin'
     short_name = 'default.gaussian'
@@ -781,11 +781,11 @@ class DefaultGaussian(Device):
         r"""Expands a one-mode Symplectic matrix S to act on the entire subsystem.
 
         Args:
-            S (array): :math:`2\times 2` Symplectic matrix.
-            wire (int): the wire S acts on.
+            S (array): :math:`2\times 2` Symplectic matrix
+            wire (int): the wire S acts on
 
         Returns:
-            array: the resulting :math:`2N\times 2N` Symplectic matrix.
+            array: the resulting :math:`2N\times 2N` Symplectic matrix
         """
         S2 = np.identity(2*self.num_wires)
 
@@ -800,11 +800,11 @@ class DefaultGaussian(Device):
         r"""Expands a two-mode Symplectic matrix S to act on the entire subsystem.
 
         Args:
-            S (array): :math:`4\times 4` Symplectic matrix.
-            wires (Sequence[int]): the list of two wires S acts on.
+            S (array): :math:`4\times 4` Symplectic matrix
+            wires (Sequence[int]): the list of two wires S acts on
 
         Returns:
-            array: the resulting :math:`2N\times 2N` Symplectic matrix.
+            array: the resulting :math:`2N\times 2N` Symplectic matrix
         """
         S2 = np.identity(2*self.num_wires)
         w = np.array(wires)
@@ -841,8 +841,8 @@ class DefaultGaussian(Device):
             wires (int of Sequence[int]): indices of the requested wires
 
         Returns:
-            tuple (means, cov): where means is an array containing the vector of means,
-            and cov is a square array containing the covariance matrix.
+            tuple (means, cov): means is an array containing the vector of means,
+            and cov is a square array containing the covariance matrix
         """
         if wires == list(range(self.num_wires)):
             # reduced state is full state

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -445,21 +445,23 @@ def squeezed_state(r, phi, hbar=2.):
     return state
 
 
-def displaced_squeezed_state(a, r, phi, hbar=2.):
+def displaced_squeezed_state(a, phi_a, r, phi_r, hbar=2.):
     r"""Returns a squeezed coherent state
 
     Args:
-        a (complex): the displacement.
+        a (real): the displacement magnitude.
+        phi_a (real): the displacement phase.
         r (float): the squeezing magnitude
-        phi (float): the squeezing phase :math:`\phi`
+        phi_r (float): the squeezing phase :math:`\phi_r`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`.
 
     Returns:
         array: the squeezed coherent state
     """
-    means = np.array([a.real, a.imag]) * np.sqrt(2*hbar)
-    state = [means, squeezed_cov(r, phi, hbar)]
+    alpha = a * np.exp(1j*phi_a)
+    means = np.array([alpha.real, alpha.imag]) * np.sqrt(2*hbar)
+    state = [means, squeezed_cov(r, phi_r, hbar)]
     return state
 
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -131,7 +131,7 @@ QNode internal methods
 Code details
 ~~~~~~~~~~~~
 """
-import collections
+from collections.abc import Sequence
 import inspect
 import copy
 
@@ -298,7 +298,7 @@ class QNode:
             self.output_type = float
             self.output_dim = 1
             res = (res,)
-        elif isinstance(res, collections.Sequence) and res and all(isinstance(x, pennylane.operation.Expectation) for x in res):
+        elif isinstance(res, Sequence) and res and all(isinstance(x, pennylane.operation.Expectation) for x in res):
             # for multiple expectation values, any valid Python sequence of expectation values (i.e., lists, tuples, etc) are supported in the QNode return statement.
             self.output_dim = len(res)
             self.output_type = np.asarray

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -35,7 +35,7 @@ across the PennyLane submodules.
 
     <h3>Code details</h3>
 """
-import collections
+from collections.abc import Iterable
 import numbers
 
 import autograd.numpy as np
@@ -56,7 +56,7 @@ def _flatten(x):
     """
     if isinstance(x, np.ndarray):
         yield from _flatten(x.flat)  # should we allow object arrays? or just "yield from x.flat"?
-    elif isinstance(x, collections.Iterable) and not isinstance(x, (str, bytes)):
+    elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         for item in x:
             yield from _flatten(item)
     else:
@@ -80,7 +80,7 @@ def _unflatten(flat, model):
         idx = model.size
         res = np.array(flat)[:idx].reshape(model.shape)
         return res, flat[idx:]
-    elif isinstance(model, collections.Iterable):
+    elif isinstance(model, Iterable):
         res = []
         for x in model:
             val, flat = _unflatten(flat, x)

--- a/tests/test_classical_gradients.py
+++ b/tests/test_classical_gradients.py
@@ -39,21 +39,21 @@ class BasicTest(BaseTest):
                              lambda x: 2 * x]
         self.multivariate_funcs = [lambda x: np.sin(x[0]) + np.cos(x[1]),
                                    lambda x: np.exp(x[0] / 3) * np.tanh(x[1]),
-                                   lambda x: np.sum(x_ ** 2 for x_ in x)]
+                                   lambda x: np.sum([x_ ** 2 for x_ in x])]
         self.grad_multi_funcs = [lambda x: np.array([np.cos(x[0]), -np.sin(x[1])]),
                                  lambda x: np.array([np.exp(x[0] / 3) / 3 * np.tanh(x[1]),
                                                      np.exp(x[0] / 3) * (1 - np.tanh(x[1]) ** 2)]),
                                  lambda x: np.array([2 * x_ for x_ in x])]
         self.mvar_mdim_funcs = [lambda x: np.sin(x[0, 0]) + np.cos(x[1, 0]),
                                 lambda x: np.exp(x[0, 0] / 3) * np.tanh(x[1, 0]),
-                                lambda x: np.sum(x_[0] ** 2 for x_ in x)]
+                                lambda x: np.sum([x_[0] ** 2 for x_ in x])]
         self.grad_mvar_mdim_funcs = [lambda x: np.array([[np.cos(x[0, 0])], [-np.sin(x[[1]])]]),
                                      lambda x: np.array([[np.exp(x[0, 0] / 3) / 3 * np.tanh(x[1, 0])],
                                                          [np.exp(x[0, 0] / 3) * (1 - np.tanh(x[1, 0]) ** 2)]]),
                                      lambda x: np.array([[2 * x_[0]] for x_ in x])]
         self.margs_fns = [lambda x,y: np.sin(x) + np.cos(y),
                           lambda x,y: np.exp(x / 3) * np.tanh(y),
-                          lambda x,y: np.sum(x_ ** 2 for x_ in [x,y])]
+                          lambda x,y: np.sum([x_ ** 2 for x_ in [x,y]])]
         self.grad_margs_funcs = [lambda x,y: (np.cos(x), -np.sin(y)),
                                  lambda x,y: (np.exp(x / 3) / 3 * np.tanh(y),
                                               np.exp(x / 3) * (1 - np.tanh(y) ** 2)),

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -259,15 +259,17 @@ class TestStates(BaseTest):
     def test_displaced_squeezed_state(self):
         """Test the displaced squeezed state is correct."""
         self.logTestName()
-        a = 0.541+0.109j
+        alpha = 0.541+0.109j
+        a = abs(alpha)
+        phi_a = np.angle(alpha)
         r = 0.432
-        phi = 0.123
-        means, cov = displaced_squeezed_state(a, r, phi, hbar=hbar)
+        phi_r = 0.123
+        means, cov = displaced_squeezed_state(a, phi_a, r, phi_r, hbar=hbar)
 
         # test vector of means is correct
-        self.assertAllAlmostEqual(means, np.array([a.real, a.imag])*np.sqrt(2*hbar), delta=self.tol)
+        self.assertAllAlmostEqual(means, np.array([alpha.real, alpha.imag])*np.sqrt(2*hbar), delta=self.tol)
 
-        R = rotation(phi/2)
+        R = rotation(phi_r/2)
         expected = R @ np.array([[np.exp(-2*r), 0],
                                  [0, np.exp(2*r)]]) * hbar/2 @ R.T
         # test covariance matrix is correct
@@ -320,12 +322,14 @@ class TestDefaultGaussianDevice(BaseTest):
             self.dev.reset()
 
             # start in the displaced squeezed state
-            a = 0.542+0.123j
+            alpha = 0.542+0.123j
+            a = abs(alpha)
+            phi_a = np.angle(alpha)
             r = 0.652
-            phi = -0.124
+            phi_r = -0.124
 
-            self.dev.apply('DisplacedSqueezedState', wires=[0], par=[a, r, phi])
-            self.dev.apply('DisplacedSqueezedState', wires=[1], par=[a, r, phi])
+            self.dev.apply('DisplacedSqueezedState', wires=[0], par=[a, phi_a, r, phi_r])
+            self.dev.apply('DisplacedSqueezedState', wires=[1], par=[a, phi_a, r, phi_r])
 
             # get the equivalent pennylane operation class
             op = qml.ops.__getattribute__(gate_name)
@@ -340,7 +344,7 @@ class TestDefaultGaussianDevice(BaseTest):
                     expected_out = p
             else:
                 # the parameter is a float
-                p = [0.432423, -0.12312, 0.324][:op.num_params]
+                p = [0.432423, -0.12312, 0.324, 0.751][:op.num_params]
 
                 if gate_name == 'Displacement':
                     alpha = p[0]*np.exp(1j*p[1])
@@ -627,7 +631,7 @@ class TestDefaultGaussianIntegration(BaseTest):
             if g == 'GaussianState':
                 p = [np.array([0.432, 0.123, 0.342, 0.123]), np.diag([0.5234]*4)]
             else:
-                p = [0.432423, -0.12312, 0.324][:op.num_params]
+                p = [0.432423, -0.12312, 0.324, 0.763][:op.num_params]
 
             self.assertAllEqual(circuit(*p), reference(*p))
 

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -19,20 +19,21 @@ import unittest
 import inspect
 import logging as log
 
-from pennylane import numpy as np
 from scipy.special import factorial as fac
 from scipy.linalg import block_diag
 
 from defaults import pennylane as qml, BaseTest
 
+from pennylane import numpy as np
+
 from pennylane.plugins.default_gaussian import fock_prob
 
 from pennylane.plugins.default_gaussian import (rotation, squeezing, quadratic_phase,
-                                              beamsplitter, two_mode_squeezing,
-                                              controlled_addition, controlled_phase)
+                                                beamsplitter, two_mode_squeezing,
+                                                controlled_addition, controlled_phase)
 from pennylane.plugins.default_gaussian import (vacuum_state, coherent_state,
-                                              squeezed_state, displaced_squeezed_state,
-                                              thermal_state)
+                                                squeezed_state, displaced_squeezed_state,
+                                                thermal_state)
 
 from pennylane.plugins.default_gaussian import DefaultGaussian
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -124,14 +124,14 @@ class BasicTest(BaseTest):
                              lambda x: 2 * x]
         self.multivariate_funcs = [lambda x: np.sin(x[0]) + np.cos(x[1]),
                                    lambda x: np.exp(x[0] / 3) * np.tanh(x[1]),
-                                   lambda x: np.sum(x_ ** 2 for x_ in x)]
+                                   lambda x: np.sum([x_ ** 2 for x_ in x])]
         self.grad_multi_funcs = [lambda x: np.array([np.cos(x[0]), -np.sin(x[1])]),
                                  lambda x: np.array([np.exp(x[0] / 3) / 3 * np.tanh(x[1]),
                                                      np.exp(x[0] / 3) * (1 - np.tanh(x[1]) ** 2)]),
                                  lambda x: np.array([2 * x_ for x_ in x])]
         self.mvar_mdim_funcs = [lambda x: np.sin(x[0, 0]) + np.cos(x[1, 0]) - np.sin(x[0, 1]) + x[1, 1],
                                 lambda x: np.exp(x[0, 0] / 3) * np.tanh(x[0, 1]),
-                                lambda x: np.sum(x_[0] ** 2 for x_ in x)]
+                                lambda x: np.sum([x_[0] ** 2 for x_ in x])]
         self.grad_mvar_mdim_funcs = [lambda x: np.array([[np.cos(x[0, 0]), -np.cos(x[0, 1])],
                                                          [-np.sin(x[1, 0]), 1.              ]]),
                                      lambda x: np.array([[np.exp(x[0, 0] / 3) / 3 * np.tanh(x[0, 1]),


### PR DESCRIPTION
Makes `DisplacedSqueezedState()` and `CatState()` take real (abs and phase) parameters instead of complex ones. This fixes #146 .