### PR TITLE
Support wires as variable objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install wheel pytest pytest-cov codecov
+- pip install wheel pytest pytest-cov codecov --upgrade
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -287,8 +287,32 @@ class Operation(abc.ABC):
 
         # apply the operation on the given wires
         if not isinstance(wires, Sequence):
-            wires = [wires]
+            self._wires = [wires]
+        else:
+            self._wires = wires
 
+        if all([isinstance(w, int) for w in self._wires]):
+            # If all wires are integers (i.e., not Variable), check
+            # that they are valid for the given operation
+            self.check_wires(self._wires)
+
+        if do_queue:
+            self.queue()
+
+    def __str__(self):
+        """Print the operation name and some information."""
+        return self.name +': {} params, wires {}'.format(len(self.params), self.wires)
+
+    def check_wires(self, wires):
+        """Check the validity of the operation wires.
+
+        Args:
+            wires (Sequence[int, Variable]): wires to check
+        Raises:
+            TypeError: list of wires is invalid
+        Returns:
+            Number, array, Variable: p
+        """
         if self.num_wires != 0 and len(wires) != self.num_wires:
             raise ValueError("{}: wrong number of wires. "
                              "{} wires given, {} expected.".format(self.name, len(wires), self.num_wires))
@@ -296,13 +320,7 @@ class Operation(abc.ABC):
         if len(set(wires)) != len(wires):
             raise ValueError('{}: wires must be unique, got {}.'.format(self.name, wires))
 
-        self.wires = [i.val if isinstance(i, Variable) else i for i in wires]  #: Sequence[int]: subsystems the operation acts on
-        if do_queue:
-            self.queue()
-
-    def __str__(self):
-        """Print the operation name and some information."""
-        return self.name +': {} params, wires {}'.format(len(self.params), self.wires)
+        return wires
 
     def check_domain(self, p, flattened=False):
         """Check the validity of a parameter.
@@ -341,6 +359,21 @@ class Operation(abc.ABC):
         else:
             raise ValueError('{}: Unknown parameter domain \'{}\'.'.format(self.name, self.par_domain))
         return p
+
+    @property
+    def wires(self):
+        """Current wire values.
+
+        Fixed wires are returned as is, free wires represented by
+        :class:`~.variable.Variable` instances are replaced by their
+        current numerical value.
+
+        Returns:
+            list[int]: wire values
+        """
+        w = [i.val if isinstance(i, Variable) else i for i in self._wires]
+        self.check_wires(w)
+        return w
 
     @property
     def parameters(self):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -109,6 +109,7 @@ Code details
 """
 import abc
 import numbers
+from collections.abc import Sequence
 import logging as log
 
 import autograd.numpy as np
@@ -285,7 +286,7 @@ class Operation(abc.ABC):
             assert self.grad_recipe is None, 'Gradient recipe is only used by the A method!'
 
         # apply the operation on the given wires
-        if isinstance(wires, int):
+        if not isinstance(wires, Sequence):
             wires = [wires]
 
         if self.num_wires != 0 and len(wires) != self.num_wires:
@@ -295,7 +296,7 @@ class Operation(abc.ABC):
         if len(set(wires)) != len(wires):
             raise ValueError('{}: wires must be unique, got {}.'.format(self.name, wires))
 
-        self.wires = wires  #: Sequence[int]: subsystems the operation acts on
+        self.wires = [i.val if isinstance(i, Variable) else i for i in wires]  #: Sequence[int]: subsystems the operation acts on
         if do_queue:
             self.queue()
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -492,8 +492,8 @@ class QNode:
             """Make sure only existing wires are referenced."""
             for w in op.wires:
                 if w < 0 or w >= self.num_wires:
-                    raise QuantumFunctionError("Operation {} applied to wire {}, "
-                                               "device only has {}.".format(op.name, w, self.num_wires))
+                    raise QuantumFunctionError("Operation {} applied to invalid wire {} "
+                                               "on device with {} wires.".format(op.name, w, self.num_wires))
 
         # check every gate/preparation and ev measurement
         for op in self.ops:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -285,6 +285,7 @@ class QNode:
             raise QuantumFunctionError('QNode._current_context must not be modified outside this method.')
         # generate the program queue by executing the quantum circuit function
         try:
+            Variable.kwarg_values = keyword_values
             res = self.func(*variables, **kwarg_variables)
         finally:
             # remove the context
@@ -320,6 +321,7 @@ class QNode:
             raise QuantumFunctionError('Each wire in the quantum circuit can only be measured once.')
 
         self.ops = self.queue + list(self.ev)  #: list[Operation]: combined list of circuit operations
+
 
         def check_op(op):
             """Make sure only existing wires are referenced."""

--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -70,7 +70,10 @@ keyword arguments, its ``name``, to return the correct value to the operation.
     <h3>Code details</h3>
 """
 import logging
+from collections.abc import Sequence
 import copy
+
+import numpy as np
 
 logging.getLogger()
 
@@ -131,9 +134,10 @@ class Variable:
         # pylint: disable=unsubscriptable-object
         if self.name is None:
             # The variable is a placeholder for a positional argument
-            value = self.free_param_values[self.idx] * self.mult
-            return value
+            return self.free_param_values[self.idx] * self.mult
 
         # The variable is a placeholder for a keyword argument
-        value = self.kwarg_values[self.name][self.idx] * self.mult
-        return value
+        if isinstance(self.kwarg_values[self.name], (Sequence, np.ndarray)):
+            return self.kwarg_values[self.name][self.idx] * self.mult
+
+        return self.kwarg_values[self.name] * self.mult

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -200,7 +200,7 @@ class BasicTest(BaseTest):
             qml.RX(x, [0])
             qml.CNOT([0, 2])
             return qml.expval.PauliZ(0)
-        with self.assertRaisesRegex(QuantumFunctionError, 'device only has'):
+        with self.assertRaisesRegex(QuantumFunctionError, 'applied to invalid wire'):
             qf(par)
 
         # CV and discrete ops must not be mixed

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -465,13 +465,20 @@ class BasicTest(BaseTest):
         "Tests that wires can be passed as keyword arguments."
         self.logTestName()
 
-        def circuit(x, q=None):
+        default_q = 0
+
+        def circuit(x, q=default_q):
             qml.RX(x, [q])
             return qml.expval.PauliZ(q)
 
-        circuit = qml.QNode(circuit, self.dev1)
+        circuit = qml.QNode(circuit, self.dev2)
 
-        c = circuit(np.pi, q=0)
+        c = circuit(np.pi, q=1)
+        self.assertEqual(circuit.queue[0].wires, [1])
+        self.assertAlmostEqual(c, -1., delta=self.tol)
+
+        c = circuit(np.pi)
+        self.assertEqual(circuit.queue[0].wires, [default_q])
         self.assertAlmostEqual(c, -1., delta=self.tol)
 
 

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -49,6 +49,7 @@ a_shapes = [(64,),
 b = np.linspace(-1., 1., 8)
 b_shapes = [(8,), (8,1), (4,2), (2,2,2), (2,1,2,1,2)]
 
+
 class BasicTest(BaseTest):
     """Qnode basic tests.
     """

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -460,6 +460,20 @@ class BasicTest(BaseTest):
         self.assertAllAlmostEqual(c, [-1., -1.], delta=self.tol)
 
 
+    def test_keywordargs_for_wires(self):
+        "Tests that wires use keyword arguments."
+        self.logTestName()
+
+        def circuit(x, q=None):
+            qml.RX(x, [q])
+            return qml.expval.PauliZ(q)
+
+        circuit = qml.QNode(circuit, self.dev1)
+
+        c = circuit(np.pi, q=0)
+        self.assertAlmostEqual(c, -1., delta=self.tol)
+
+
     def test_keywordargs_used(self):
         "Tests that qnodes use keyword arguments."
         self.logTestName()

--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -462,7 +462,7 @@ class BasicTest(BaseTest):
 
 
     def test_keywordargs_for_wires(self):
-        "Tests that wires use keyword arguments."
+        "Tests that wires can be passed as keyword arguments."
         self.logTestName()
 
         def circuit(x, q=None):


### PR DESCRIPTION
**Description of the Change:**

This PR supports wires being `Variable` objects.

**Benefits:**
This allows us to support the use case where the wire number may be passed as a keyword argument.

**Possible Drawbacks:**

None, as far as I can tell.

**Related GitHub Issues:**

#150 
