### PR TITLE
Add the ability to easily perform inverse operations

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -101,6 +101,7 @@ from autograd import jacobian as _jacobian
 from semantic_version import Version, Spec
 
 import pennylane.operation
+from pennylane.operation import QuantumOperationError
 import pennylane.expval
 
 from .configuration import Configuration

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -205,7 +205,10 @@ class Device(abc.ABC):
         with self.execution_context():
             self.pre_apply()
             for operation in queue:
-                self.apply(operation.name, operation.wires, operation.parameters)
+                apply_inverse = False
+                if operation.num_params == 0 and operation._inv:
+                    apply_inverse = True
+                self.apply(operation.name, operation.wires, operation.parameters, apply_inverse)
             self.post_apply()
 
             self.pre_expval()
@@ -309,7 +312,7 @@ class Device(abc.ABC):
                 raise DeviceError("Expectation {} not supported on device {}".format(e.name, self.short_name))
 
     @abc.abstractmethod
-    def apply(self, operation, wires, par):
+    def apply(self, operation, wires, par, apply_inverse=False):
         """Apply a quantum operation.
 
         For plugin developers: this function should apply the operation on the device.
@@ -318,6 +321,8 @@ class Device(abc.ABC):
             operation (str): name of the operation
             wires (Sequence[int]): subsystems the operation is applied on
             par (tuple): parameters for the operation
+            apply_inverse (bool): if ``True``, the device should calculate and apply
+                the *inverse* of the operation provided
         """
         raise NotImplementedError
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -206,7 +206,7 @@ class Device(abc.ABC):
             self.pre_apply()
             for operation in queue:
                 apply_inverse = False
-                if operation.num_params == 0 and operation._inv:
+                if operation.manual_inverse == 0:
                     apply_inverse = True
                 self.apply(operation.name, operation.wires, operation.parameters, apply_inverse)
             self.post_apply()

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -493,7 +493,7 @@ class Operation(abc.ABC):
         """Invert the operation"""
         # First, remove the operation from the queue
         if not self.supports_inverse:
-            raise QuantumOperationError("Operation {} does not support inversion".format(self.name))
+            raise QuantumOperationError("{} {} does not support inversion".format(self.__class__.__bases__[0].__name__, self.name))
 
         self._inv = True
         return self
@@ -534,7 +534,7 @@ class Expectation(Operation):
             there is some reason to run an Expectation outside of a QNode context.
     """
     # pylint: disable=abstract-method
-    pass
+    _supports_inverse = False
 
 
 #=============================================================================

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -196,6 +196,7 @@ class Operation(abc.ABC):
             This flag is useful if there is some reason to run an Operation
             outside of a QNode context.
     """
+    #pylint: disable=too-many-instance-attributes
     _grad_recipe = None
     _supports_inverse = True
     _no_param_self_inverse = True
@@ -480,7 +481,8 @@ class Operation(abc.ABC):
 
         ptmp = p[:]
         if self.par_domain == 'A':
-            ptmp[0] = np.linalg.inv(p[0]) # should this be p[0].conj().T by default?
+            # should this be p[0].conj().T by default?
+            ptmp[0] = np.linalg.inv(p[0]) #pylint: disable=no-member
             return ptmp
 
         ptmp[0] = -p[0]

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -496,10 +496,6 @@ class Operation(abc.ABC):
             raise QuantumOperationError("Operation {} does not support inversion".format(self.name))
 
         self._inv = True
-
-        if QNode._current_context:
-            QNode._current_context.queue[-1]._inv = True
-
         return self
 
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -178,12 +178,29 @@ class Operation(abc.ABC):
     * :attr:`~.Operation.num_wires`
     * :attr:`~.Operation.par_domain`
 
+    **Gradients**
+
     The following two class attributes are optional, but in most cases
     should be clearly defined to avoid unexpected behavior during
     differentiation.
 
     * :attr:`~.Operation.grad_method`
     * :attr:`~.Operation.grad_recipe`
+
+    **Inversion**
+
+    The following optional class attributes help determine how PennyLane
+    transforms operations in which the :attr:`~.Operation.inv` is called.
+
+    * :attr:`~.Operation.supports_inverse` (default ``True``)
+    * :attr:`~.Operation.self_inverse` (default ``False``)
+    * :attr:`~.Operation.inverse_parameters`
+
+    .. note::
+
+        If the device turns off inverse pre-processing, then the
+        above properties will be ignored, and the device will be responsible
+        for implementing all operation inversions.
 
     Args:
         args (tuple[float, int, array, Variable]): operation parameters
@@ -199,7 +216,7 @@ class Operation(abc.ABC):
     #pylint: disable=too-many-instance-attributes
     _grad_recipe = None
     _supports_inverse = True
-    _no_param_self_inverse = True
+    _no_param_self_inverse = False
 
     @abc.abstractproperty
     def num_params(self):
@@ -290,11 +307,11 @@ class Operation(abc.ABC):
     def self_inverse(self):
         r"""Indicates that a no-parameter operation is its own inverse; :math:`O^{-1} = O`.
 
-        By default, this is set to ``True``, but it can be set to ``False`` on a
-        case-by-case basis. Note that this class property only affects operations
+        By default, this is set to ``False``.
+        Note that this class property only affects operations
         that have both ``num_params = 0`` and ``supports_inverse = True``.
 
-        Set this property to ``False`` in your custom operation if you would like the plugin
+        Leave this property as ``False`` in your custom operation if you would like the plugin
         device to manually invert the operation. PennyLane will then pass the ``apply_inverse=True``
         keyword argument to the :meth:`~.Device.apply` method.
         """
@@ -497,6 +514,9 @@ class Operation(abc.ABC):
 
         self._inv = True
         return self
+
+    # an alias for .inv
+    H = inv
 
 
 #=============================================================================

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -23,6 +23,11 @@ computation.
 Here, we summarize the built-in operations supported by PennyLane, as well
 as the conventions chosen for their implementation.
 
+If an operation supports inversion, you may request the inverse operation via
+the following syntax:
+
+>>> Operation(parameters, wires=1).H
+
 .. note::
 
     When writing a plugin device for PennyLane, make sure that your plugin

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -557,6 +557,7 @@ class CoherentState(CVOperation):
     num_params = 2
     par_domain = 'R'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class SqueezedState(CVOperation):
@@ -578,6 +579,7 @@ class SqueezedState(CVOperation):
     num_params = 2
     par_domain = 'R'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class DisplacedSqueezedState(CVOperation):
@@ -609,6 +611,7 @@ class DisplacedSqueezedState(CVOperation):
     num_params = 4
     par_domain = 'R'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class ThermalState(CVOperation):
@@ -629,6 +632,7 @@ class ThermalState(CVOperation):
     num_params = 1
     par_domain = 'R'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class GaussianState(CVOperation):
@@ -650,6 +654,7 @@ class GaussianState(CVOperation):
     num_params = 2
     par_domain = 'A'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class FockState(CVOperation):
@@ -670,6 +675,7 @@ class FockState(CVOperation):
     num_params = 1
     par_domain = 'N'
     grad_method = None
+    supports_inverse = False
 
 
 class FockStateVector(CVOperation):
@@ -690,6 +696,7 @@ class FockStateVector(CVOperation):
     num_params = 1
     par_domain = 'A'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class FockDensityMatrix(CVOperation):
@@ -710,6 +717,7 @@ class FockDensityMatrix(CVOperation):
     num_params = 1
     par_domain = 'A'
     grad_method = 'F'
+    supports_inverse = False
 
 
 class CatState(CVOperation):
@@ -742,6 +750,7 @@ class CatState(CVOperation):
     num_params = 3
     par_domain = 'R'
     grad_method = 'F'
+    supports_inverse = False
 
 
 all_ops = [

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -339,6 +339,9 @@ class Rot(Operation):
     par_domain = 'R'
     grad_method = 'A'
 
+    def inverse_parameters(self, p):
+        return [-i for i in p[::-1]]
+
 
 #=============================================================================
 # Arbitrary operations
@@ -390,6 +393,7 @@ class BasisState(Operation):
     num_wires = 0
     par_domain = 'A'
     grad_method = None
+    supports_inverse = False
 
 
 class QubitStateVector(Operation):
@@ -410,6 +414,7 @@ class QubitStateVector(Operation):
     num_wires = 0
     par_domain = 'A'
     grad_method = 'F'
+    supports_inverse = False
 
 
 all_ops = [

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -68,6 +68,7 @@ class Hadamard(Operation):
 
     * Number of wires: 1
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
@@ -75,6 +76,7 @@ class Hadamard(Operation):
     num_params = 0
     num_wires = 1
     par_domain = None
+    self_inverse = True
 
 
 class PauliX(Operation):
@@ -87,6 +89,7 @@ class PauliX(Operation):
 
     * Number of wires: 1
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
@@ -94,6 +97,7 @@ class PauliX(Operation):
     num_params = 0
     num_wires = 1
     par_domain = None
+    self_inverse = True
 
 
 class PauliY(Operation):
@@ -106,6 +110,7 @@ class PauliY(Operation):
 
     * Number of wires: 1
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
@@ -113,6 +118,7 @@ class PauliY(Operation):
     num_params = 0
     num_wires = 1
     par_domain = None
+    self_inverse = True
 
 
 class PauliZ(Operation):
@@ -125,6 +131,7 @@ class PauliZ(Operation):
 
     * Number of wires: 1
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wire the operation acts on
@@ -132,6 +139,7 @@ class PauliZ(Operation):
     num_params = 0
     num_wires = 1
     par_domain = None
+    self_inverse = True
 
 
 class CNOT(Operation):
@@ -151,6 +159,7 @@ class CNOT(Operation):
 
     * Number of wires: 2
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wires the operation acts on
@@ -158,6 +167,7 @@ class CNOT(Operation):
     num_params = 0
     num_wires = 2
     par_domain = None
+    self_inverse = True
 
 
 class CZ(Operation):
@@ -177,6 +187,7 @@ class CZ(Operation):
 
     * Number of wires: 2
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wires the operation acts on
@@ -184,6 +195,7 @@ class CZ(Operation):
     num_params = 0
     num_wires = 2
     par_domain = None
+    self_inverse = True
 
 
 class SWAP(Operation):
@@ -203,6 +215,7 @@ class SWAP(Operation):
 
     * Number of wires: 2
     * Number of parameters: 0
+    * Self-inverse
 
     Args:
         wires (Sequence[int] or int): the wires the operation acts on
@@ -210,6 +223,7 @@ class SWAP(Operation):
     num_params = 0
     num_wires = 2
     par_domain = None
+    self_inverse = True
 
 
 class RX(Operation):
@@ -382,6 +396,7 @@ class BasisState(Operation):
     * Number of wires: None (applied to the entire system)
     * Number of parameters: 1
     * Gradient recipe: None (integer parameters not supported)
+    * Supports inversion: False
 
     Args:
         n (array): prepares the basis state :math:`\ket{n}`, where ``n`` is an
@@ -405,6 +420,7 @@ class QubitStateVector(Operation):
     * Number of wires: None (applied to the entire system)
     * Number of parameters: 1
     * Gradient recipe: None (uses finite difference)
+    * Supports inversion: False
 
     Args:
         state (array[complex]): a state vector of size 2**len(wires)

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -742,7 +742,7 @@ class DefaultGaussian(Device):
     def pre_apply(self):
         self.reset()
 
-    def apply(self, operation, wires, par):
+    def apply(self, operation, wires, par, apply_inverse=False):
         if operation == 'Displacement':
             self._state = displacement(self._state, wires[0], par[0]*np.exp(1j*par[1]))
             return # we are done here

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -293,7 +293,7 @@ class DefaultQubit(Device):
     def pre_apply(self):
         self.reset()
 
-    def apply(self, operation, wires, par):
+    def apply(self, operation, wires, par, apply_inverse=False):
         if operation == 'QubitStateVector':
             state = np.asarray(par[0], dtype=np.float64)
             if state.ndim == 1 and state.shape[0] == 2**self.num_wires:

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -644,7 +644,7 @@ class TestDefaultGaussianIntegration(BaseTest):
 
         @qml.qnode(dev)
         def circuit(x):
-            qml.Displacement(x, 0, wires=0).inv
+            qml.Displacement(x, 0, wires=0).H
             return qml.expval.X(0)
 
         x = 0.4

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -636,6 +636,23 @@ class TestDefaultGaussianIntegration(BaseTest):
 
             self.assertAllEqual(circuit(*p), reference(*p))
 
+    def test_inverse_gate(self):
+        """Test that the inverse displacement gate acts as expected"""
+        self.logTestName()
+
+        dev = qml.device('default.gaussian', wires=2)
+
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.Displacement(x, 0, wires=0).inv
+            return qml.expval.X(0)
+
+        x = 0.4
+
+        res = circuit(x)
+        expected = -2*x
+        self.assertAlmostEqual(res, expected, delta=self.tol)
+
 
 if __name__ == '__main__':
     print('Testing PennyLane version ' + qml.version() + ', default.gaussian plugin.')


### PR DESCRIPTION
**Description of the Change:**

* Adds the property `Operation().inv`, allowing the user to specify the inverse operation. This is useful for gates such as arbitrary unitaries. 
  
  **Note:** name is not final. Other options include `.dagger`, `.T`, `.hc` (hermitian conjugate), `.ct` (conjugate transpose). I quite like `.T`, since it stands out, is a single letter, and is familiar to those using NumPy. I also really like `.hc`, since this is commonly seen in the literature.

* For operations with parameters, by default the inversion will either

  1. negate the first parameter, or

  2. if `par_domain = 'A'`, will perform the matrix inverse of the first parameter.

  These defaults are determined by `Operation.inverse_parameters()` method. For operations where a custom parameter transform is required to invert the operation, this can be overridden manually (e.g., see `qml.ops.qubit.Rot`).

* Some operations shouldn't support an inverse, such as state preparation. To cause an exception to be raised if `.inv` is called on these methods, you can set the class property `supports_inverse = False`.

* For operations without parameters, it is assumed that the operation is its own inverse (i.e., the operation is Hermitian) by default. This default is simply because, for built-in operations, this is almost always the case. This can be overridden by setting the `self_inverse = False` class property.

  **Note:** Should this property be changed to `hermitian`? Or is `self_inverse` more general?

* If an operation does not have parameters, *and* it is not Hermitian, then `Operation.manual_inverse` will be set to `True`, and it will be up to the plugin device to perform the inversion as required. The plugin is made aware of this, as the `apply_inverse` keyword argument is passed to `Device.apply()`.

  **Note:** this particular change is a breaking change, all plugins' `apply` methods will have to be updated to accept this keyword argument.

* Tests have been added to `test_operation.py` (to test the new operation features) as well as `test_default_qubit.py` and `test_default_gaussian.py` for integration tests.

**Benefits:**

* PennyLane now supports operator inverses/hermitian conjugate natively, and (in most cases) without the plugin having to worry about it.

* Setting `_supports_inverse = False` in the base `Expectation` class provides a clean way to avoid this functionality for expectation values.

**Possible Drawbacks:**

The naming conventions. I coded this from start to end on a flight to Salt Lake City during a very long day, so none of the property/method names are final. I'm definitely leaning towards `.hc` over `.inv`.

**Related GitHub Issues:** #147 