### PR TITLE
ignore the unused parameters to identity() in the default plugins

### DIFF
--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -685,21 +685,12 @@ def fock_expectation(mu, cov, wires, params, hbar=2.):
     return ex, var
 
 
-def identity(mu, cov, wires, params, hbar=2.):
+def identity(*_, **__):
     r"""Returns 1.
-
-    Args:
-        mu (array): vector of means
-        cov (array): covariance matrix
-        wires (Sequence[int]): wires to calculate the expectation for
-        params (Sequence[int]): None.
-        hbar (float): (default 2) the value of :math:`\hbar` in the commutation
-            relation :math:`[\x,\p]=i\hbar`
 
     Returns:
         tuple: the Fock state expectation and variance
     """
-    # pylint: disable=unused-argument
     return 1, 0
 
 

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -228,7 +228,7 @@ def hermitian(*args):
 
     return A
 
-def identity(*par): #pylint: disable=unused-argument
+def identity(*_):
     """Identity matrix for expectations.
 
     Returns:


### PR DESCRIPTION
A mini fix to ignore the parameters of `identity()` instead of suppressing the pylint error. See if you like that.