### PR TITLE
Added ability to update stepsizes of the optimizers

### DIFF
--- a/pennylane/optimize/adagrad.py
+++ b/pennylane/optimize/adagrad.py
@@ -71,7 +71,7 @@ class AdagradOptimizer(GradientDescentOptimizer):
         else:
             self.accumulation = [a + g*g for a, g in zip(self.accumulation, grad_flat)]
 
-        x_new_flat = [e - (self.stepsize / np.sqrt(a + self.eps)) * g for a, g, e in zip(self.accumulation, grad_flat, x_flat)]
+        x_new_flat = [e - (self._stepsize / np.sqrt(a + self.eps)) * g for a, g, e in zip(self.accumulation, grad_flat, x_flat)]
 
         return unflatten(x_new_flat, x)
 

--- a/pennylane/optimize/adam.py
+++ b/pennylane/optimize/adam.py
@@ -53,7 +53,6 @@ class AdamOptimizer(GradientDescentOptimizer):
     """
     def __init__(self, stepsize=0.01, beta1=0.9, beta2=0.99, eps=1e-8):
         super().__init__(stepsize)
-        self.stepsize = stepsize
         self.beta1 = beta1
         self.beta2 = beta2
         self.eps = eps
@@ -92,7 +91,7 @@ class AdamOptimizer(GradientDescentOptimizer):
             self.sm = [self.beta2 * f + (1 - self.beta2) * g * g for f, g in zip(self.sm, grad_flat)]
 
         # Update step size (instead of correcting for bias)
-        new_stepsize = self.stepsize*np.sqrt(1-self.beta2**self.t)/(1-self.beta1**self.t)
+        new_stepsize = self._stepsize*np.sqrt(1-self.beta2**self.t)/(1-self.beta1**self.t)
 
         x_new_flat = [e - new_stepsize * f / (np.sqrt(s)+self.eps) for f, s, e in zip(self.fm, self.sm, x_flat)]
 

--- a/pennylane/optimize/gradient_descent.py
+++ b/pennylane/optimize/gradient_descent.py
@@ -34,7 +34,17 @@ class GradientDescentOptimizer(object):
         stepsize (float): the user-defined hyperparameter :math:`\eta`
     """
     def __init__(self, stepsize=0.01):
-        self.stepsize = stepsize
+        self._stepsize = stepsize
+
+    def update_stepsize(self, stepsize):
+        r"""Update the initialized stepsize value :math:`\eta`.
+
+        This allows for techniques such as learning rate scheduling.
+
+        Args:
+            stepsize (float): the user-defined hyperparameter :math:`\eta`
+        """
+        self._stepsize = stepsize
 
     def step(self, objective_fn, x, grad_fn=None):
         """Update x with one step of the optimizer.
@@ -93,6 +103,6 @@ class GradientDescentOptimizer(object):
         x_flat = _flatten(x)
         grad_flat = _flatten(grad)
 
-        x_new_flat = [e - self.stepsize * g for g, e in zip(grad_flat, x_flat)]
+        x_new_flat = [e - self._stepsize * g for g, e in zip(grad_flat, x_flat)]
 
         return unflatten(x_new_flat, x)

--- a/pennylane/optimize/momentum.py
+++ b/pennylane/optimize/momentum.py
@@ -59,9 +59,9 @@ class MomentumOptimizer(GradientDescentOptimizer):
         x_flat = _flatten(x)
 
         if self.accumulation is None:
-            self.accumulation = [self.stepsize * g for g in grad_flat]
+            self.accumulation = [self._stepsize * g for g in grad_flat]
         else:
-            self.accumulation = [self.momentum * a + self.stepsize * g for a, g in zip(self.accumulation, grad_flat)]
+            self.accumulation = [self.momentum * a + self._stepsize * g for a, g in zip(self.accumulation, grad_flat)]
 
         x_new_flat = [e-a for a, e in zip(self.accumulation, x_flat)]
 

--- a/pennylane/optimize/rms_prop.py
+++ b/pennylane/optimize/rms_prop.py
@@ -68,6 +68,6 @@ class RMSPropOptimizer(AdagradOptimizer):
         else:
             self.accumulation = [self.decay*a + (1-self.decay)*g*g for a, g in zip(self.accumulation, grad_flat)]
 
-        x_new_flat = [e - (self.stepsize / np.sqrt(a + self.eps)) * g for a, g, e in zip(self.accumulation, grad_flat, x_flat)]
+        x_new_flat = [e - (self._stepsize / np.sqrt(a + self.eps)) * g for a, g, e in zip(self.accumulation, grad_flat, x_flat)]
 
         return unflatten(x_new_flat, x)

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -504,6 +504,18 @@ class BasicTest(BaseTest):
                     x_twosteps_target = x_onestep - adapted_stepsize * firstmoment / (np.sqrt(secondmoment) + 1e-8)
                     self.assertAllAlmostEqual(x_twosteps, x_twosteps_target, delta=self.tol)
 
+    def test_update_stepsize(self):
+        """Tests that the stepsize correctly updates"""
+        self.logTestName()
+
+        eta = 0.5
+        opt = AdamOptimizer(eta)
+        self.assertAlmostEqual(opt._stepsize, eta)
+
+        eta2 = 0.1
+        opt.update_stepsize(eta2)
+        self.assertAlmostEqual(opt._stepsize, eta2)
+
 
 if __name__ == '__main__':
     print('Testing PennyLane version ' + qml.version() + ', basic optimizers.')


### PR DESCRIPTION
**Description of the Change:**

* Makes `GradientDescentOptimizer.stepsize` a private attribute `GradientDescentOptimizer._stepsize`
* Adds the method `GradientDescentOptimizer.update_stepsize`. This is inherited by all other optimizers.

**Benefits:**

* You can now update the stepsize after initialization of the optimizer.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #158 
