### PR TITLE
Interfaces setup bug fix

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Release 0.3.1
+
+### Bug fixes
+
+* Fixed a bug where the interfaces submodule was not correctly being packaged via setup.py
+
 # Release 0.3.0
 
 ### New features since last release

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -711,7 +711,7 @@ class DefaultGaussian(Device):
     """
     name = 'Default Gaussian PennyLane plugin'
     short_name = 'default.gaussian'
-    pennylane_requires = '0.3.0'
+    pennylane_requires = '0.3'
     version = '0.3.0'
     author = 'Xanadu Inc.'
 

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -251,7 +251,7 @@ class DefaultQubit(Device):
     """
     name = 'Default qubit PennyLane plugin'
     short_name = 'default.qubit'
-    pennylane_requires = '0.3.0'
+    pennylane_requires = '0.3'
     version = '0.3.0'
     author = 'Xanadu Inc.'
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ info = {
                     'pennylane.ops',
                     'pennylane.expval',
                     'pennylane.plugins',
-                    'pennylane.optimize'
+                    'pennylane.optimize',
+                    'pennylane.interfaces'
                 ],
     'entry_points': {
         'pennylane.plugins': [


### PR DESCRIPTION
**Description of the Change:** Adds the new `interfaces` submodule to `setup.py`

**Benefits:** will now properly package the `interfaces` module

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a