### PR TITLE
Fixed error in CVQNN docstring and added some more explanation

### DIFF
--- a/pennylane/template.py
+++ b/pennylane/template.py
@@ -179,7 +179,7 @@ def CVNeuralNet(weights, wires=None):
     :cite:`killoran2018continuous` for an arbitrary number of wires
     and layers.
 
-    The weights parameter is nested list. Its first dimension is equal to the number of layers. Each entry is again a
+    The weights parameter is a nested list. Its first dimension is equal to the number of layers. Each entry is again a
     list that contains the parameters feeding into :func:`CVNeuralNetLayer`.
 
     Args:

--- a/pennylane/template.py
+++ b/pennylane/template.py
@@ -214,7 +214,7 @@ def CVNeuralNetLayer(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_
         phi_r (array[float]): length :math:`N` arrays of squeezing angles for :class:`~.Squeezing` operations
         theta_2 (array[float]): length :math:`N(N-1)/2` array of transmittivity angles for second interferometer
         phi_2 (array[float]): length :math:`N(N-1)/2` array of phase angles for second interferometer
-        varphi_2 (array[float]): length :math:`N` array of rotation angles for second interferometer
+        varphi_2 (array[float]): length :math:`N` array of final rotation angles for second interferometer
         a (array[float]): length :math:`N` arrays of displacement magnitudes for :class:`~.Displacement` operations
         phi_a (array[float]): length :math:`N` arrays of displacement angles for :class:`~.Displacement` operations
         k (array[float]): length :math:`N` arrays of kerr parameters for :class:`~.Kerr` operations

--- a/pennylane/template.py
+++ b/pennylane/template.py
@@ -209,7 +209,7 @@ def CVNeuralNetLayer(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_
     Args:
         theta_1 (array[float]): length :math:`N(N-1)/2` array of transmittivity angles for first interferometer
         phi_1 (array[float]): length :math:`N(N-1)/2` array of phase angles for first interferometer
-        varphi_1 (array[float]): length :math:`N` array of rotation angles for first interferometer
+        varphi_1 (array[float]): length :math:`N` array of final rotation angles for first interferometer
         r (array[float]): length :math:`N` arrays of squeezing amounts for :class:`~.Squeezing` operations
         phi_r (array[float]): length :math:`N` arrays of squeezing angles for :class:`~.Squeezing` operations
         theta_2 (array[float]): length :math:`N(N-1)/2` array of transmittivity angles for second interferometer

--- a/pennylane/template.py
+++ b/pennylane/template.py
@@ -181,7 +181,7 @@ def CVNeuralNet(weights, wires=None):
 
     The weights parameter is nested list. Its first dimension is equal to the number of layers. Each entry is again a
     list that contains the parameters feeding into :func:`CVNeuralNetLayer`.
-    
+
     Args:
         weights (array[array]): array of arrays of weights for each
             layer of the CV neural network
@@ -194,7 +194,7 @@ def CVNeuralNet(weights, wires=None):
 
 
 def CVNeuralNetLayer(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_2, a, phi_a, k, wires=None):
-    """pennylane.template.CVNeuralNetLayer(theta_1, phi_1, s, theta_2, phi_2, r, k, wires)
+    """pennylane.template.CVNeuralNetLayer(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_2, a, phi_a, k, wires)
     A single layer of a CV Quantum Neural Network
 
     Implements a single layer from the the CV Quantum Neural Network (CVQNN)

--- a/pennylane/template.py
+++ b/pennylane/template.py
@@ -179,9 +179,9 @@ def CVNeuralNet(weights, wires=None):
     :cite:`killoran2018continuous` for an arbitrary number of wires
     and layers.
 
-    See :func:`CVNeuralNetLayer` for details of the expected format of
-    input parameters.
-
+    The weights parameter is nested list. Its first dimension is equal to the number of layers. Each entry is again a
+    list that contains the parameters feeding into :func:`CVNeuralNetLayer`.
+    
     Args:
         weights (array[array]): array of arrays of weights for each
             layer of the CV neural network
@@ -209,10 +209,12 @@ def CVNeuralNetLayer(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_
     Args:
         theta_1 (array[float]): length :math:`N(N-1)/2` array of transmittivity angles for first interferometer
         phi_1 (array[float]): length :math:`N(N-1)/2` array of phase angles for first interferometer
+        varphi_1 (array[float]): length :math:`N` array of rotation angles for first interferometer
         r (array[float]): length :math:`N` arrays of squeezing amounts for :class:`~.Squeezing` operations
         phi_r (array[float]): length :math:`N` arrays of squeezing angles for :class:`~.Squeezing` operations
         theta_2 (array[float]): length :math:`N(N-1)/2` array of transmittivity angles for second interferometer
         phi_2 (array[float]): length :math:`N(N-1)/2` array of phase angles for second interferometer
+        varphi_2 (array[float]): length :math:`N` array of rotation angles for second interferometer
         a (array[float]): length :math:`N` arrays of displacement magnitudes for :class:`~.Displacement` operations
         phi_a (array[float]): length :math:`N` arrays of displacement angles for :class:`~.Displacement` operations
         k (array[float]): length :math:`N` arrays of kerr parameters for :class:`~.Kerr` operations


### PR DESCRIPTION
The docstring was missing two parameter lists.

CVNeuralNet is however not usable with Pytorch, which is why we have to rewrite it in the long run. 