### PR TITLE
Feature/variable division

### DIFF
--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -123,7 +123,7 @@ class Variable:
         return temp
 
     def __truediv__(self, scalar):
-        """Right division by scalars."""
+        """Right division by scalars. Left division is not allowed."""
         temp = copy.copy(self)
         temp.mult /= scalar
         return temp

--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -122,6 +122,12 @@ class Variable:
         temp.mult *= scalar
         return temp
 
+    def __truediv__(self, scalar):
+        """Right division by scalars."""
+        temp = copy.copy(self)
+        temp.mult /= scalar
+        return temp
+
     __rmul__ = __mul__ # """Left multiplication by scalars."""
 
     @property

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -43,6 +43,7 @@ class BasicTest(BaseTest):
         self.assertEqual(str(p), "Variable 0: name = None, ")
         self.assertEqual(str(-p), "Variable 0: name = None,  * -1")
         self.assertEqual(str(1.2*p*0.4), "Variable 0: name = None,  * 0.48")
+        self.assertEqual(str(1.2*p/2.5), "Variable 0: name = None,  * 0.48")
 
         def check(par, res):
             "Apply the parameter mapping, compare with the expected result."
@@ -77,6 +78,7 @@ class BasicTest(BaseTest):
         self.assertEqual(str(p), "Variable 0: name = kw1, ")
         self.assertEqual(str(-p), "Variable 0: name = kw1,  * -1")
         self.assertEqual(str(1.2*p*0.4), "Variable 0: name = kw1,  * 0.48")
+        self.assertEqual(str(1.2*p/2.5), "Variable 0: name = kw1,  * 0.48")
 
         def check(par, res):
             "Apply the parameter mapping, compare with the expected result."


### PR DESCRIPTION
**Description of the Change:** Currently, QNode parameters can be scaled by a scalar constant inside a QNode. This PR simply allows the user to also divide a QNode parameter by a constant.

**Benefits:** Clearer to the user; if `x*0.5` is supported, `x/2` should also be.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #177 
