### PR TITLE
PyTest styled refactoring of tests.

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -35,7 +35,7 @@ def test_rotation_heisenberg(phi):
     true_matrix = np.array([[1, 0, 0],
                             [0, np.cos(phi), -np.sin(phi)],
                             [0, np.sin(phi), np.cos(phi)]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("phi", phis)
@@ -53,7 +53,7 @@ def test_squeezing_heisenberg(phi, mag):
                                                       np.sinh(r), np.cosh(r) +
                                                       np.cos(phi) *
                                                       np.sinh(r)]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("phi", phis)
@@ -66,7 +66,7 @@ def test_displacement_heisenberg(phi, mag):
     true_matrix = np.array([[1, 0, 0],
                             [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
                             [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("phi", phis)
@@ -83,7 +83,7 @@ def test_beamsplitter_heisenberg(phi, theta):
                             -np.sin(phi) * np.sin(theta), np.cos(theta), 0],
                             [0, np.sin(phi) * np.sin(theta),
                             np.cos(phi) * np.sin(theta), 0, np.cos(theta)]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("phi", phis)
@@ -101,7 +101,7 @@ def test_two_mode_squeezing_heisenberg(phi, mag):
                              np.sin(phi) * np.sinh(r), np.cosh(r), 0],
                             [0, np.sin(phi) * np.sinh(r),
                              -np.cos(phi) * np.sinh(r), 0, np.cosh(r)]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("s", s_vals)
@@ -111,7 +111,7 @@ def test_quadratic_phase_heisenberg(s):
     true_matrix = np.array([[1, 0, 0],
                             [0, 1, 0],
                             [0, s, 1]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("s", s_vals)
@@ -124,7 +124,7 @@ def test_controlled_addition_heisenberg(s):
                             [0, 0, 1, 0, -s],
                             [0, s, 0, 1, 0],
                             [0, 0, 0, 0, 1]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 @pytest.mark.parametrize("s", s_vals)
@@ -136,7 +136,7 @@ def test_controlled_phase_heisenberg(s):
                             [0, 0, 1, s, 0],
                             [0, 0, 0, 1, 0],
                             [0, s, 0, 0, 1]])
-    np.allclose(matrix, true_matrix)
+    assert np.allclose(matrix, true_matrix)
 
 
 class TestNonGaussian:
@@ -153,7 +153,7 @@ class TestNonGaussian:
         """ops: Tests that proper exceptions are raised if we try to call the
         Heisenberg transformation of non-Gaussian gates."""
         op = cv.Kerr
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match=r"not a Gaussian operation"):
             op_ = op(
                 *[0.1] * op.num_params,
                 [0] * op.num_wires,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -15,159 +15,163 @@
 Unit tests for the :mod:`pennylane.plugin.DefaultGaussian` device.
 """
 # pylint: disable=protected-access,cell-var-from-loop
-import unittest
-import inspect
-import logging as log
-
 from pennylane import numpy as np
 from scipy.linalg import block_diag
 
-from defaults import pennylane as qml, BaseTest
+from defaults import pennylane
 from pennylane.ops import cv
+import pytest
 
 
-log.getLogger('defaults')
-
-hbar = 2
+s_vals = np.linspace(-3, 3, 13)
 phis = np.linspace(-2 * np.pi, 2 * np.pi, 11)
 mags = np.linspace(0., 1., 7)
-s_vals = np.linspace(-3,3,13)
-
-nongaussian_gates = [cv.Kerr, cv.CrossKerr, cv.CubicPhase]
-
-class TestHeisenberg(BaseTest):
-    """Tests for the Heisenberg representation of gates."""
-
-    def test_rotation_heisenberg(self):
-        """Tests the Heisenberg representation of the Rotation gate."""
-        self.logTestName()
-
-        for phi in phis:
-            matrix = cv.Rotation._heisenberg_rep([phi])
-            true_matrix = np.array([[1, 0, 0],
-                                    [0, np.cos(phi), -np.sin(phi)],
-                                    [0, np.sin(phi), np.cos(phi)]])
-            self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
 
 
-    def test_squeezing_heisenberg(self):
-        """Tests the Heisenberg representation of the Squeezing gate."""
-        self.logTestName()
-
-        for r in mags:
-            for phi in phis:
-                matrix = cv.Squeezing._heisenberg_rep([r,phi])
-                true_matrix = np.array([[1, 0, 0],
-                                        [0, np.cosh(r) - np.cos(phi) * np.sinh(r), - np.sin(phi) * np.sinh(r)],
-                                        [0, -np.sin(phi) * np.sinh(r), np.cosh(r) + np.cos(phi) * np.sinh(r)]])
-                self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
+@pytest.mark.parametrize("phi", phis)
+def test_rotation_heisenberg(phi):
+    """ops: Tests the Heisenberg representation of the Rotation gate."""
+    matrix = cv.Rotation._heisenberg_rep([phi])
+    true_matrix = np.array([[1, 0, 0],
+                            [0, np.cos(phi), -np.sin(phi)],
+                            [0, np.sin(phi), np.cos(phi)]])
+    np.allclose(matrix, true_matrix)
 
 
-    def test_displacement_heisenberg(self):
-        """Tests the Heisenberg representation of the Displacement gate."""
-        self.logTestName()
-
-        for r in mags:
-            for phi in phis:
-                matrix = cv.Displacement._heisenberg_rep([r,phi])
-                true_matrix = np.array([[1, 0, 0],
-                                        [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
-                                        [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1]])
-                self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
-
-
-    def test_beamsplitter_heisenberg(self):
-        """Tests the Heisenberg representation of the Beamsplitter gate."""
-        self.logTestName()
-
-        for theta in phis:
-            for phi in phis:
-                matrix = cv.Beamsplitter._heisenberg_rep([theta,phi])
-                true_matrix = np.array([[1, 0, 0, 0, 0],
-                                        [0, np.cos(theta), 0, -np.cos(phi) * np.sin(theta), -np.sin(phi) * np.sin(theta)],
-                                        [0, 0, np.cos(theta), np.sin(phi) * np.sin(theta), -np.cos(phi) * np.sin(theta)],
-                                        [0, np.cos(phi) * np.sin(theta), -np.sin(phi) * np.sin(theta), np.cos(theta), 0],
-                                        [0, np.sin(phi) * np.sin(theta), np.cos(phi) * np.sin(theta), 0, np.cos(theta)]])
-                self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
+@pytest.mark.parametrize("phi", phis)
+@pytest.mark.parametrize("mag", mags)
+def test_squeezing_heisenberg(phi, mag):
+    """ops: Tests the Heisenberg representation of the Squeezing gate."""
+    r = mag
+    matrix = cv.Squeezing._heisenberg_rep([r, phi])
+    true_matrix = np.array([[1, 0, 0], [0, np.cosh(r) -
+                                        np.cos(phi) *
+                                        np.sinh(r), -
+                                        np.sin(phi) *
+                                        np.sinh(r)], [0, -
+                                                      np.sin(phi) *
+                                                      np.sinh(r), np.cosh(r) +
+                                                      np.cos(phi) *
+                                                      np.sinh(r)]])
+    np.allclose(matrix, true_matrix)
 
 
-    def test_two_mode_squeezing_heisenberg(self):
-        """Tests the Heisenberg representation of the Beamsplitter gate."""
-        self.logTestName()
-
-        for r in mags:
-            for phi in phis:
-                matrix = cv.TwoModeSqueezing._heisenberg_rep([r,phi])
-                true_matrix = np.array([[1, 0, 0, 0, 0],
-                                        [0, np.cosh(r), 0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r)],
-                                        [0, 0, np.cosh(r), np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r)],
-                                        [0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r), np.cosh(r), 0],
-                                        [0, np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r), 0, np.cosh(r)]])
-                self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
+@pytest.mark.parametrize("phi", phis)
+@pytest.mark.parametrize("mag", mags)
+def test_displacement_heisenberg(phi, mag):
+    """ops: Tests the Heisenberg representation of the Displacement gate."""
+    r = mag
+    hbar = 2
+    matrix = cv.Displacement._heisenberg_rep([r, phi])
+    true_matrix = np.array([[1, 0, 0],
+                            [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
+                            [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1]])
+    np.allclose(matrix, true_matrix)
 
 
-    def test_quadratic_phase_heisenberg(self):
-        """Tests the Heisenberg representation of the QuadraticPhase gate."""
-        self.logTestName()
-
-        for s in s_vals:
-            matrix = cv.QuadraticPhase._heisenberg_rep([s])
-            true_matrix = np.array([[1, 0, 0],
-                                    [0, 1, 0],
-                                    [0, s, 1]])
-            self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
-
-
-    def test_controlled_addition_heisenberg(self):
-        """Tests the Heisenberg representation of the ControlledAddition gate."""
-        self.logTestName()
-
-        for s in s_vals:
-            matrix = cv.ControlledAddition._heisenberg_rep([s])
-            true_matrix = np.array([[1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 0],
-                                    [0, 0, 1, 0, -s],
-                                    [0, s, 0, 1, 0],
-                                    [0, 0, 0, 0, 1]])
-            self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
+@pytest.mark.parametrize("phi", phis)
+@pytest.mark.parametrize("theta", phis)
+def test_beamsplitter_heisenberg(phi, theta):
+    """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
+    matrix = cv.Beamsplitter._heisenberg_rep([theta, phi])
+    true_matrix = np.array([[1, 0, 0, 0, 0],
+                            [0, np.cos(theta), 0, -np.cos(phi)*np.sin(theta),
+                            -np.sin(phi) * np.sin(theta)],
+                            [0, 0, np.cos(theta), np.sin(phi)*np.sin(theta),
+                            - np.cos(phi) * np.sin(theta)],
+                            [0, np.cos(phi) * np.sin(theta),
+                            -np.sin(phi) * np.sin(theta), np.cos(theta), 0],
+                            [0, np.sin(phi) * np.sin(theta),
+                            np.cos(phi) * np.sin(theta), 0, np.cos(theta)]])
+    np.allclose(matrix, true_matrix)
 
 
-    def test_controlled_phase_heisenberg(self):
-        """Tests the Heisenberg representation of the ControlledPhase gate."""
-        self.logTestName()
+@pytest.mark.parametrize("phi", phis)
+@pytest.mark.parametrize("mag", mags)
+def test_two_mode_squeezing_heisenberg(phi, mag):
+    """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
+    r = mag
+    matrix = cv.TwoModeSqueezing._heisenberg_rep([r, phi])
+    true_matrix = np.array([[1, 0, 0, 0, 0],
+                            [0, np.cosh(r), 0, np.cos(phi) * np.sinh(r),
+                             np.sin(phi) * np.sinh(r)],
+                            [0, 0, np.cosh(r), np.sin(phi) * np.sinh(r),
+                             -np.cos(phi) * np.sinh(r)],
+                            [0, np.cos(phi) * np.sinh(r),
+                             np.sin(phi) * np.sinh(r), np.cosh(r), 0],
+                            [0, np.sin(phi) * np.sinh(r),
+                             -np.cos(phi) * np.sinh(r), 0, np.cosh(r)]])
+    np.allclose(matrix, true_matrix)
 
-        for s in s_vals:
-            matrix = cv.ControlledPhase._heisenberg_rep([s])
-            true_matrix = np.array([[1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 0],
-                                    [0, 0, 1, s, 0],
-                                    [0, 0, 0, 1, 0],
-                                    [0, s, 0, 0, 1]])
-            self.assertAllAlmostEqual(matrix, true_matrix, delta=self.tol)
 
-class TestNonGaussian(BaseTest):
+@pytest.mark.parametrize("s", s_vals)
+def test_quadratic_phase_heisenberg(s):
+    """ops: Tests the Heisenberg representation of the QuadraticPhase gate."""
+    matrix = cv.QuadraticPhase._heisenberg_rep([s])
+    true_matrix = np.array([[1, 0, 0],
+                            [0, 1, 0],
+                            [0, s, 1]])
+    np.allclose(matrix, true_matrix)
+
+
+@pytest.mark.parametrize("s", s_vals)
+def test_controlled_addition_heisenberg(s):
+    """ops: Tests the Heisenberg representation of ControlledAddition gate.
+    """
+    matrix = cv.ControlledAddition._heisenberg_rep([s])
+    true_matrix = np.array([[1, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0],
+                            [0, 0, 1, 0, -s],
+                            [0, s, 0, 1, 0],
+                            [0, 0, 0, 0, 1]])
+    np.allclose(matrix, true_matrix)
+
+
+@pytest.mark.parametrize("s", s_vals)
+def test_controlled_phase_heisenberg(s):
+    """Tests the Heisenberg representation of the ControlledPhase gate."""
+    matrix = cv.ControlledPhase._heisenberg_rep([s])
+    true_matrix = np.array([[1, 0, 0, 0, 0],
+                            [0, 1, 0, 0, 0],
+                            [0, 0, 1, s, 0],
+                            [0, 0, 0, 1, 0],
+                            [0, s, 0, 0, 1]])
+    np.allclose(matrix, true_matrix)
+
+
+class TestNonGaussian:
     """Tests that non-Gaussian gates are properly handled."""
 
-    def test_heisenberg_rep_nonguassian(self):
-        """Tests that the `_heisenberg_rep` for a non-Gaussian gates is None"""
-        for op in nongaussian_gates:
-            self.assertTrue(op._heisenberg_rep(*[0.1] * op.num_params) is None)
+    @pytest.mark.parametrize("gate", [cv.Kerr, cv.CrossKerr, cv.CubicPhase])
+    def test_heisenberg_rep_nonguassian(self, gate):
+        """ops: Tests that the `_heisenberg_rep` for a non-Gaussian gates is
+        None
+        """
+        assert (gate._heisenberg_rep(*[0.1] * gate.num_params) is None)
 
     def test_heisenberg_transformation_nongaussian(self):
-        """Tests that proper exceptions are raised if we try to call the Heisenberg
-        transformation of non-Gaussian gates."""
-        self.logTestName()
+        """ops: Tests that proper exceptions are raised if we try to call the
+        Heisenberg transformation of non-Gaussian gates."""
+        op = cv.Kerr
+        with pytest.raises(RuntimeError):
+            op_ = op(
+                *[0.1] * op.num_params,
+                [0] * op.num_wires,
+                do_queue=False)
+            op_.heisenberg_tr(op.num_wires)
 
-        with self.assertRaisesRegex(RuntimeError, 'is not a Gaussian operation'):
-            for op in nongaussian_gates:
-                op_ = op(*[0.1] * op.num_params, [0] * op.num_wires, do_queue=False)
-                op_.heisenberg_tr(op.num_wires)
+        op = cv.CrossKerr
+        with pytest.raises(ValueError):
+            op_ = op(
+                *[0.1] * op.num_params,
+                [0] * op.num_wires,
+                do_queue=False)
+            op_.heisenberg_tr(op.num_wires)
 
-if __name__ == '__main__':
-    print('Testing PennyLane version ' + qml.version() + ', default.gaussian plugin.')
-    # run the tests in this file
-    suite = unittest.TestSuite()
-    for t in (TestHeisenberg,TestNonGaussian):
-        ttt = unittest.TestLoader().loadTestsFromTestCase(t)
-        suite.addTests(ttt)
-    unittest.TextTestRunner().run(suite)
+        op = cv.CubicPhase
+        with pytest.raises(RuntimeError):
+            op_ = op(
+                *[0.1] * op.num_params,
+                [0] * op.num_wires,
+                do_queue=False)
+            op_.heisenberg_tr(op.num_wires)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -25,16 +25,16 @@ import pytest
 
 s_vals = np.linspace(-3, 3, 13)
 phis = np.linspace(-2 * np.pi, 2 * np.pi, 11)
-mags = np.linspace(0., 1., 7)
+mags = np.linspace(0.0, 1.0, 7)
 
 
 @pytest.mark.parametrize("phi", phis)
 def test_rotation_heisenberg(phi):
     """ops: Tests the Heisenberg representation of the Rotation gate."""
     matrix = cv.Rotation._heisenberg_rep([phi])
-    true_matrix = np.array([[1, 0, 0],
-                            [0, np.cos(phi), -np.sin(phi)],
-                            [0, np.sin(phi), np.cos(phi)]])
+    true_matrix = np.array(
+        [[1, 0, 0], [0, np.cos(phi), -np.sin(phi)], [0, np.sin(phi), np.cos(phi)]]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -44,15 +44,13 @@ def test_squeezing_heisenberg(phi, mag):
     """ops: Tests the Heisenberg representation of the Squeezing gate."""
     r = mag
     matrix = cv.Squeezing._heisenberg_rep([r, phi])
-    true_matrix = np.array([[1, 0, 0], [0, np.cosh(r) -
-                                        np.cos(phi) *
-                                        np.sinh(r), -
-                                        np.sin(phi) *
-                                        np.sinh(r)], [0, -
-                                                      np.sin(phi) *
-                                                      np.sinh(r), np.cosh(r) +
-                                                      np.cos(phi) *
-                                                      np.sinh(r)]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0],
+            [0, np.cosh(r) - np.cos(phi) * np.sinh(r), -np.sin(phi) * np.sinh(r)],
+            [0, -np.sin(phi) * np.sinh(r), np.cosh(r) + np.cos(phi) * np.sinh(r)],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -63,9 +61,13 @@ def test_displacement_heisenberg(phi, mag):
     r = mag
     hbar = 2
     matrix = cv.Displacement._heisenberg_rep([r, phi])
-    true_matrix = np.array([[1, 0, 0],
-                            [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
-                            [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0],
+            [np.sqrt(2 * hbar) * r * np.cos(phi), 1, 0],
+            [np.sqrt(2 * hbar) * r * np.sin(phi), 0, 1],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -74,15 +76,39 @@ def test_displacement_heisenberg(phi, mag):
 def test_beamsplitter_heisenberg(phi, theta):
     """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
     matrix = cv.Beamsplitter._heisenberg_rep([theta, phi])
-    true_matrix = np.array([[1, 0, 0, 0, 0],
-                            [0, np.cos(theta), 0, -np.cos(phi)*np.sin(theta),
-                            -np.sin(phi) * np.sin(theta)],
-                            [0, 0, np.cos(theta), np.sin(phi)*np.sin(theta),
-                            - np.cos(phi) * np.sin(theta)],
-                            [0, np.cos(phi) * np.sin(theta),
-                            -np.sin(phi) * np.sin(theta), np.cos(theta), 0],
-                            [0, np.sin(phi) * np.sin(theta),
-                            np.cos(phi) * np.sin(theta), 0, np.cos(theta)]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [
+                0,
+                np.cos(theta),
+                0,
+                -np.cos(phi) * np.sin(theta),
+                -np.sin(phi) * np.sin(theta),
+            ],
+            [
+                0,
+                0,
+                np.cos(theta),
+                np.sin(phi) * np.sin(theta),
+                -np.cos(phi) * np.sin(theta),
+            ],
+            [
+                0,
+                np.cos(phi) * np.sin(theta),
+                -np.sin(phi) * np.sin(theta),
+                np.cos(theta),
+                0,
+            ],
+            [
+                0,
+                np.sin(phi) * np.sin(theta),
+                np.cos(phi) * np.sin(theta),
+                0,
+                np.cos(theta),
+            ],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -92,15 +118,15 @@ def test_two_mode_squeezing_heisenberg(phi, mag):
     """ops: Tests the Heisenberg representation of the Beamsplitter gate."""
     r = mag
     matrix = cv.TwoModeSqueezing._heisenberg_rep([r, phi])
-    true_matrix = np.array([[1, 0, 0, 0, 0],
-                            [0, np.cosh(r), 0, np.cos(phi) * np.sinh(r),
-                             np.sin(phi) * np.sinh(r)],
-                            [0, 0, np.cosh(r), np.sin(phi) * np.sinh(r),
-                             -np.cos(phi) * np.sinh(r)],
-                            [0, np.cos(phi) * np.sinh(r),
-                             np.sin(phi) * np.sinh(r), np.cosh(r), 0],
-                            [0, np.sin(phi) * np.sinh(r),
-                             -np.cos(phi) * np.sinh(r), 0, np.cosh(r)]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [0, np.cosh(r), 0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r)],
+            [0, 0, np.cosh(r), np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r)],
+            [0, np.cos(phi) * np.sinh(r), np.sin(phi) * np.sinh(r), np.cosh(r), 0],
+            [0, np.sin(phi) * np.sinh(r), -np.cos(phi) * np.sinh(r), 0, np.cosh(r)],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -108,9 +134,7 @@ def test_two_mode_squeezing_heisenberg(phi, mag):
 def test_quadratic_phase_heisenberg(s):
     """ops: Tests the Heisenberg representation of the QuadraticPhase gate."""
     matrix = cv.QuadraticPhase._heisenberg_rep([s])
-    true_matrix = np.array([[1, 0, 0],
-                            [0, 1, 0],
-                            [0, s, 1]])
+    true_matrix = np.array([[1, 0, 0], [0, 1, 0], [0, s, 1]])
     assert np.allclose(matrix, true_matrix)
 
 
@@ -119,11 +143,15 @@ def test_controlled_addition_heisenberg(s):
     """ops: Tests the Heisenberg representation of ControlledAddition gate.
     """
     matrix = cv.ControlledAddition._heisenberg_rep([s])
-    true_matrix = np.array([[1, 0, 0, 0, 0],
-                            [0, 1, 0, 0, 0],
-                            [0, 0, 1, 0, -s],
-                            [0, s, 0, 1, 0],
-                            [0, 0, 0, 0, 1]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, 0, -s],
+            [0, s, 0, 1, 0],
+            [0, 0, 0, 0, 1],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -131,11 +159,15 @@ def test_controlled_addition_heisenberg(s):
 def test_controlled_phase_heisenberg(s):
     """Tests the Heisenberg representation of the ControlledPhase gate."""
     matrix = cv.ControlledPhase._heisenberg_rep([s])
-    true_matrix = np.array([[1, 0, 0, 0, 0],
-                            [0, 1, 0, 0, 0],
-                            [0, 0, 1, s, 0],
-                            [0, 0, 0, 1, 0],
-                            [0, s, 0, 0, 1]])
+    true_matrix = np.array(
+        [
+            [1, 0, 0, 0, 0],
+            [0, 1, 0, 0, 0],
+            [0, 0, 1, s, 0],
+            [0, 0, 0, 1, 0],
+            [0, s, 0, 0, 1],
+        ]
+    )
     assert np.allclose(matrix, true_matrix)
 
 
@@ -147,31 +179,22 @@ class TestNonGaussian:
         """ops: Tests that the `_heisenberg_rep` for a non-Gaussian gates is
         None
         """
-        assert (gate._heisenberg_rep(*[0.1] * gate.num_params) is None)
+        assert gate._heisenberg_rep(*[0.1] * gate.num_params) is None
 
     def test_heisenberg_transformation_nongaussian(self):
         """ops: Tests that proper exceptions are raised if we try to call the
         Heisenberg transformation of non-Gaussian gates."""
         op = cv.Kerr
         with pytest.raises(RuntimeError, match=r"not a Gaussian operation"):
-            op_ = op(
-                *[0.1] * op.num_params,
-                [0] * op.num_wires,
-                do_queue=False)
+            op_ = op(*[0.1] * op.num_params, [0] * op.num_wires, do_queue=False)
             op_.heisenberg_tr(op.num_wires)
 
         op = cv.CrossKerr
         with pytest.raises(ValueError):
-            op_ = op(
-                *[0.1] * op.num_params,
-                [0] * op.num_wires,
-                do_queue=False)
+            op_ = op(*[0.1] * op.num_params, [0] * op.num_wires, do_queue=False)
             op_.heisenberg_tr(op.num_wires)
 
         op = cv.CubicPhase
         with pytest.raises(RuntimeError):
-            op_ = op(
-                *[0.1] * op.num_params,
-                [0] * op.num_wires,
-                do_queue=False)
+            op_ = op(*[0.1] * op.num_params, [0] * op.num_wires, do_queue=False)
             op_.heisenberg_tr(op.num_wires)


### PR DESCRIPTION
- Rewrote `test_ops.py` using pytest.
- Removed loops and used `pytest.mark.parameterize`

**Benefits:**
#99 

I noticed that the tests for `cv.CrossKerr`raises a ValueError error and the other two (cv.CrossKerr and cv.CubicPhase) raise RuntimeError for the same test. I did not understand what is the proper exception to check so I split the tests. @josh146 