### PR TITLE
WIP: Broadcasting single-wire operations to multiwire.

### DIFF
--- a/tests/test_qnode.py
+++ b/tests/test_qnode.py
@@ -529,6 +529,32 @@ class BasicTest(BaseTest):
         c = classnode(0., x=np.pi)
         self.assertAllAlmostEqual(c, [1., -1.], delta=self.tol)
 
+    def test_multiwire_broadcast(self):
+        "Tests broadcasting of expectations to multiple wires."
+        self.logTestName()
+
+        # Check for single wire first
+        def circuit():
+            qml.QubitStateVector(np.array([1, 0, 0, 0]), wires=[0, 1])
+            qml.Hadamard(wires=[0])
+            qml.Hadamard(wires=[1])
+            return qml.expval.PauliX(0), qml.expval.PauliX(1)
+
+        circuit = qml.QNode(circuit, self.dev2)
+        exp_vals = circuit()
+        self.assertAllAlmostEqual(exp_vals, [1., 1.], delta=self.tol)
+
+        # Test for multiwire
+        def circuit():
+            qml.QubitStateVector(np.array([1, 0, 0, 0]), wires=[0, 1])
+            qml.Hadamard(wires=[0])
+            qml.Hadamard(wires=[1])
+            return qml.expval.PauliX(wires=[0, 1])
+
+        circuit = qml.QNode(circuit, self.dev2)
+        exp_vals = circuit()
+        self.assertAllAlmostEqual(exp_vals, [1., 1.], delta=self.tol)
+
 
 class GradientTest(BaseTest):
     """Qnode gradient tests.


### PR DESCRIPTION
**Description of the Change:**
WIP for broadcasting single-wire operations to multiwire.

I haven't yet figured out how the QNode computes expectation values (on a device or a plugin) and I am trying to follow the rabbit-hole using the Test-Driven-Dev (TDD) approach. This PR should eventually lead to broadcasting of single wire operations on multiple wires by replacing `return [qml.expval.PauliX(0), qml.expval.PauliX(1)]`  to `return qml.expval.PauliX(wires=[0, 1])` 

**Benefits:**
Concise code while creating quantum circuits.

**Related GitHub Issues:**
#170 


Also using the new `pennylane.about` functionality for fun.

```
Name: PennyLane
Version: 0.3.1
Summary: PennyLane is a Python quantum machine learning library by Xanadu Inc.
Home-page: http://xanadu.ai
Author: None
Author-email: None
License: Apache License 2.0
Location: /Users/shahnawaz/Dropbox/dev/pennylane
Requires: numpy, scipy, autograd, toml, appdirs, semantic-version
Required-by:
Python Version:          3.7.2
Platform Info:           Darwinx86_64
Installed plugins:       ['default.gaussian', 'default.qubit']
Numpy Version:           1.15.0
Scipy Version:           1.2.1
```