### PR TITLE
Removes `do_queue` and adds a PolyXP subclass for overwriting queue

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -187,10 +187,6 @@ class Operation(abc.ABC):
     Keyword Args:
         wires (Sequence[int]): Subsystems it acts on. If not given, args[-1]
             is interpreted as wires.
-        do_queue (bool): Indicates whether the operation should be
-            immediately pushed into a :class:`QNode` circuit queue.
-            This flag is useful if there is some reason to run an Operation
-            outside of a QNode context.
     """
     _grad_recipe = None
 
@@ -250,7 +246,7 @@ class Operation(abc.ABC):
         """Setter for the grad_recipe property"""
         self._grad_recipe = value
 
-    def __init__(self, *args, wires=None, do_queue=True):
+    def __init__(self, *args, wires=None):
         # pylint: disable=too-many-branches
         self.name = self.__class__.__name__   #: str: name of the operation
 
@@ -296,8 +292,7 @@ class Operation(abc.ABC):
             # that they are valid for the given operation
             self.check_wires(self._wires)
 
-        if do_queue:
-            self.queue()
+        self.queue()
 
     def __str__(self):
         """Print the operation name and some information."""
@@ -429,12 +424,9 @@ class Expectation(Operation):
     Keyword Args:
         wires (Sequence[int]): subsystems it acts on.
             Currently, only one subsystem is supported.
-        do_queue (bool): Indicates whether the operation should be immediately
-            pushed into a :class:`QNode` circuit queue. This flag is useful if
-            there is some reason to run an Expectation outside of a QNode context.
     """
     # pylint: disable=abstract-method
-    def __init__(self, *args, wires=None, do_queue=True):
+    def __init__(self, *args, wires=None):
         # extract the arguments
         if wires is not None:
             params = args
@@ -442,7 +434,7 @@ class Expectation(Operation):
             params = args[:-1]
             wires = args[-1]
 
-        super().__init__(*params, wires=wires, do_queue=do_queue)
+        super().__init__(*params, wires=wires)
 
 
 

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -633,7 +633,7 @@ def poly_quad_expectations(mu, cov, wires, params, hbar=2.):
     N = len(mu)//2
 
     # HACK, we need access to the Poly instance in order to expand the matrix!
-    op = qml.expval.PolyXP(Q, wires=wires, do_queue=False)
+    op = qml.expval.PolyXP(Q, wires=wires)
     Q = op.heisenberg_obs(N)
 
     if Q.ndim == 1:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -80,8 +80,8 @@ class DeviceTest(BaseTest):
 
         # queue some gates
         queue = []
-        queue.append(qml.RX(0.543, wires=[0], do_queue=False))
-        queue.append(qml.CNOT(wires=[0, 1], do_queue=False))
+        queue.append(qml.RX(0.543, wires=[0]))
+        queue.append(qml.CNOT(wires=[0, 1]))
 
         dev = qml.device('default.qubit', wires=2)
 
@@ -91,7 +91,7 @@ class DeviceTest(BaseTest):
 
         # inside of the execute method, it works
         with self.assertLogs(level='INFO') as l:
-            dev.execute(queue, [qml.expval.PauliX(0, do_queue=False)])
+            dev.execute(queue, [qml.expval.PauliX(0)])
             self.assertEqual(len(l.output), 1)
             self.assertEqual(len(l.records), 1)
             self.assertIn('INFO:root:[<pennylane.ops.qubit.RX object', l.output[0])
@@ -103,8 +103,8 @@ class DeviceTest(BaseTest):
 
         # queue some gates
         queue = []
-        queue.append(qml.RX(0.543, wires=[0], do_queue=False))
-        queue.append(qml.CNOT(wires=[0, 1], do_queue=False))
+        queue.append(qml.RX(0.543, wires=[0]))
+        queue.append(qml.CNOT(wires=[0, 1]))
 
         dev = qml.device('default.qubit', wires=2)
 
@@ -114,7 +114,7 @@ class DeviceTest(BaseTest):
 
         # inside of the execute method, it works
         with self.assertLogs(level='INFO') as l:
-            dev.execute(queue, [qml.expval.PauliX(0, do_queue=False)])
+            dev.execute(queue, [qml.expval.PauliX(0)])
             self.assertEqual(len(l.output), 1)
             self.assertEqual(len(l.records), 1)
             self.assertIn('INFO:root:[<pennylane.expval.qubit.PauliX object', l.output[0])
@@ -142,13 +142,13 @@ class DeviceTest(BaseTest):
                 else:
                     params = np.random.random([op.num_params])
 
-                queue.append(op(*params, wires=list(range(op.num_wires)), do_queue=False))
+                queue.append(op(*params, wires=list(range(op.num_wires))))
 
             temp = [isinstance(op, qml.operation.CV) for op in queue]
             if all(temp):
-                expval = dev.execute(queue, [qml.expval.X(0, do_queue=False)])
+                expval = dev.execute(queue, [qml.expval.X(0)])
             else:
-                expval = dev.execute(queue, [qml.expval.PauliX(0, do_queue=False)])
+                expval = dev.execute(queue, [qml.expval.PauliX(0)])
 
             self.assertTrue(isinstance(expval, np.ndarray))
 
@@ -173,15 +173,15 @@ class DeviceTest(BaseTest):
                 else:
                     params = np.random.random([op.num_params])
 
-                queue = [op(*params, wires=list(range(op.num_wires)), do_queue=False)]
+                queue = [op(*params, wires=list(range(op.num_wires)))]
 
                 temp = isinstance(queue[0], qml.operation.CV)
 
                 with self.assertRaisesRegex(qml.DeviceError, 'not supported on device'):
                     if temp:
-                        expval = dev.execute(queue, [qml.expval.X(0, do_queue=False)])
+                        expval = dev.execute(queue, [qml.expval.X(0)])
                     else:
-                        expval = dev.execute(queue, [qml.expval.PauliX(0, do_queue=False)])
+                        expval = dev.execute(queue, [qml.expval.PauliX(0)])
 
             exps = dev.expectations
             all_exps = set(qml.expval.__all__)
@@ -199,15 +199,15 @@ class DeviceTest(BaseTest):
                 else:
                     params = np.random.random([op.num_params])
 
-                queue = [op(*params, wires=list(range(op.num_wires)), do_queue=False)]
+                queue = [op(*params, wires=list(range(op.num_wires)))]
 
                 temp = isinstance(queue[0], qml.operation.CV)
 
                 with self.assertRaisesRegex(qml.DeviceError, 'not supported on device'):
                     if temp:
-                        expval = dev.execute([qml.Rotation(0.5, wires=0, do_queue=False)], queue)
+                        expval = dev.execute([qml.Rotation(0.5, wires=0)], queue)
                     else:
-                        expval = dev.execute([qml.RX(0.5, wires=0, do_queue=False)], queue)
+                        expval = dev.execute([qml.RX(0.5, wires=0)], queue)
 
 
 class InitDeviceTests(BaseTest):

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -52,7 +52,7 @@ class BasicTest(BaseTest):
             else:
                 par = [-0.069125, 0.51778, 0.91133, 0.95904][:cls.num_params]
 
-            op = cls(*par, wires=ww, do_queue=False)
+            op = cls(*par, wires=ww)
 
             if issubclass(cls, oo.Expectation):
                 Q = op.heisenberg_obs(0)
@@ -125,27 +125,27 @@ class BasicTest(BaseTest):
                 pars = [0.0] * n
 
             # valid call
-            cls(*pars, wires=ww, do_queue=False)
+            cls(*pars, wires=ww)
 
             # too many parameters
             with self.assertRaisesRegex(ValueError, 'wrong number of parameters'):
-                cls(*(n+1)*[0], wires=ww, do_queue=False)
+                cls(*(n+1)*[0], wires=ww)
 
             # too few parameters
             if n > 0:
                 with self.assertRaisesRegex(ValueError, 'wrong number of parameters'):
-                    cls(*(n-1)*[0], wires=ww, do_queue=False)
+                    cls(*(n-1)*[0], wires=ww)
 
             if w > 0:
                 # too many or too few wires
                 with self.assertRaisesRegex(ValueError, 'wrong number of wires'):
-                    cls(*pars, wires=list(range(w+1)), do_queue=False)
+                    cls(*pars, wires=list(range(w+1)))
                 with self.assertRaisesRegex(ValueError, 'wrong number of wires'):
-                    cls(*pars, wires=list(range(w-1)), do_queue=False)
+                    cls(*pars, wires=list(range(w-1)))
                 # repeated wires
                 if w > 1:
                     with self.assertRaisesRegex(ValueError, 'wires must be unique'):
-                        cls(*pars, wires=w*[0], do_queue=False)
+                        cls(*pars, wires=w*[0])
 
             if n == 0:
                 return
@@ -154,28 +154,28 @@ class BasicTest(BaseTest):
             if cls.par_domain == 'A':
                 # params must be arrays
                 with self.assertRaisesRegex(TypeError, 'Array parameter expected'):
-                    cls(*n*[0.0], wires=ww, do_queue=False)
+                    cls(*n*[0.0], wires=ww)
                 # params must not be Variables
                 with self.assertRaisesRegex(TypeError, 'Array parameter expected'):
-                    cls(*n*[ov.Variable(0)], wires=ww, do_queue=False)
+                    cls(*n*[ov.Variable(0)], wires=ww)
             elif cls.par_domain == 'N':
                 # params must be natural numbers
                 with self.assertRaisesRegex(TypeError, 'Natural number'):
-                    cls(*n*[0.7], wires=ww, do_queue=False)
+                    cls(*n*[0.7], wires=ww)
                 with self.assertRaisesRegex(TypeError, 'Natural number'):
-                    cls(*n*[-1], wires=ww, do_queue=False)
+                    cls(*n*[-1], wires=ww)
             elif cls.par_domain == 'R':
                 # params must be real numbers
                 with self.assertRaisesRegex(TypeError, 'Real scalar parameter expected'):
-                    cls(*n*[1j], wires=ww, do_queue=False)
+                    cls(*n*[1j], wires=ww)
 
             # if par_domain ever gets overridden to an unsupported value, should raise exception
             tmp = cls.par_domain
             with self.assertRaisesRegex(ValueError, 'Unknown parameter domain'):
                 cls.par_domain = 'junk'
-                cls(*n*[0.0], wires=ww, do_queue=False)
+                cls(*n*[0.0], wires=ww)
                 cls.par_domain = 7
-                cls(*n*[0.0], wires=ww, do_queue=False)
+                cls(*n*[0.0], wires=ww)
 
             cls.par_domain = tmp
 
@@ -205,9 +205,9 @@ class BasicTest(BaseTest):
         self.logTestName()
 
         try:
-            pennylane.qubit.Hadamard(wires=0, do_queue=False)
+            pennylane.qubit.Hadamard(wires=0)
         except pennylane.QuantumFunctionError:
-            self.fail("Operation failed to instantiate outside of QNode with do_queue=False.")
+            self.fail("Operation failed to instantiate outside of QNode with.")
 
 
 class DeveloperTests(BaseTest):
@@ -225,7 +225,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(ValueError, "wrong number of wires"):
-            DummyOp(0.5, wires=[0, 1], do_queue=False)
+            DummyOp(0.5, wires=[0, 1])
 
     def test_incorrect_num_params(self):
         """Test that an exception is raised if called with wrong number of parameters"""
@@ -239,7 +239,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(ValueError, "wrong number of parameters"):
-            DummyOp(0.5, 0.6, wires=0, do_queue=False)
+            DummyOp(0.5, 0.6, wires=0)
 
     def test_incorrect_param_domain(self):
         """Test that an exception is raised if an incorrect parameter domain is requested"""
@@ -253,7 +253,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(ValueError, "Unknown parameter domain"):
-            DummyOp(0.5, wires=0, do_queue=False)
+            DummyOp(0.5, wires=0)
 
     def test_incorrect_grad_recipe_length(self):
         """Test that an exception is raised if len(grad_recipe)!=len(num_params)"""
@@ -268,7 +268,7 @@ class DeveloperTests(BaseTest):
             grad_recipe = [(0.5, 0.1), (0.43, 0.1)]
 
         with self.assertRaisesRegex(AssertionError, "Gradient recipe must have one entry for each parameter"):
-            DummyOp(0.5, wires=[0, 1], do_queue=False)
+            DummyOp(0.5, wires=[0, 1])
 
     def test_grad_method_with_integer_params(self):
         """Test that an exception is raised if a non-None grad-method is provided for natural number params"""
@@ -282,7 +282,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(AssertionError, "An operation may only be differentiated with respect to real scalar parameters"):
-            DummyOp(5, wires=[0, 1], do_queue=False)
+            DummyOp(5, wires=[0, 1])
 
     def test_analytic_grad_with_array_param(self):
         """Test that an exception is raised if an analytic gradient is requested with an array param"""
@@ -296,7 +296,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(AssertionError, "Operations that depend on arrays containing free variables may only be differentiated using the F method"):
-            DummyOp(np.array([1.]), wires=[0, 1], do_queue=False)
+            DummyOp(np.array([1.]), wires=[0, 1])
 
     def test_numerical_grad_with_grad_recipe(self):
         """Test that an exception is raised if a numerical gradient is requested with a grad recipe"""
@@ -311,7 +311,7 @@ class DeveloperTests(BaseTest):
             grad_recipe = [(0.5, 0.1)]
 
         with self.assertRaisesRegex(AssertionError, "Gradient recipe is only used by the A method"):
-            DummyOp(0.5, wires=[0, 1], do_queue=False)
+            DummyOp(0.5, wires=[0, 1])
 
     def test_variable_instead_of_array(self):
         """Test that an exception is raised if an array is expected but a variable is passed"""
@@ -325,7 +325,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'A'
 
         with self.assertRaisesRegex(TypeError, "Array parameter expected, got a Variable"):
-            DummyOp(ov.Variable(0), wires=[0], do_queue=False)
+            DummyOp(ov.Variable(0), wires=[0])
 
     def test_array_instead_of_flattened_array(self):
         """Test that an exception is raised if an array is expected, but an array is passed
@@ -341,7 +341,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'F'
 
         with self.assertRaisesRegex(TypeError, "Flattened array parameter expected"):
-            op = DummyOp(np.array([1]), wires=[0], do_queue=False)
+            op = DummyOp(np.array([1]), wires=[0])
             op.check_domain(np.array([1]), True)
 
     def test_scalar_instead_of_array(self):
@@ -356,7 +356,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'F'
 
         with self.assertRaisesRegex(TypeError, "Array parameter expected, got"):
-            op = DummyOp(0.5, wires=[0], do_queue=False)
+            op = DummyOp(0.5, wires=[0])
 
     def test_array_instead_of_real(self):
         """Test that an exception is raised if a real number is expected but an array is passed"""
@@ -370,7 +370,7 @@ class DeveloperTests(BaseTest):
             grad_method = 'F'
 
         with self.assertRaisesRegex(TypeError, "Real scalar parameter expected, got"):
-            op = DummyOp(np.array([1.]), wires=[0], do_queue=False)
+            op = DummyOp(np.array([1.]), wires=[0])
 
     def test_not_natural_param(self):
         """Test that an exception is raised if a natural number is expected but not passed"""
@@ -384,10 +384,10 @@ class DeveloperTests(BaseTest):
             grad_method = None
 
         with self.assertRaisesRegex(TypeError, "Natural number parameter expected, got"):
-            op = DummyOp(0.5, wires=[0], do_queue=False)
+            op = DummyOp(0.5, wires=[0])
 
         with self.assertRaisesRegex(TypeError, "Natural number parameter expected, got"):
-            op = DummyOp(-2, wires=[0], do_queue=False)
+            op = DummyOp(-2, wires=[0])
 
     def test_no_wires_passed(self):
         """Test exception raised if no wires are passed"""
@@ -401,7 +401,7 @@ class DeveloperTests(BaseTest):
             grad_method = None
 
         with self.assertRaisesRegex(ValueError, "Must specify the wires"):
-            DummyOp(0.54, do_queue=False)
+            DummyOp(0.54)
 
     def test_wire_passed_positionally(self):
         """Test exception raised if wire is passed as a positional arg"""
@@ -415,7 +415,7 @@ class DeveloperTests(BaseTest):
             grad_method = None
 
         with self.assertRaisesRegex(ValueError, "Must specify the wires"):
-            DummyOp(0.54, 0, do_queue=False)
+            DummyOp(0.54, 0)
 
 
 if __name__ == '__main__':

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -186,15 +186,15 @@ class TestNonGaussian:
         Heisenberg transformation of non-Gaussian gates."""
         op = cv.Kerr
         with pytest.raises(RuntimeError, match=r"not a Gaussian operation"):
-            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires, do_queue=False)
+            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires)
             op_.heisenberg_tr(op.num_wires)
 
         op = cv.CrossKerr
         with pytest.raises(ValueError):
-            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires, do_queue=False)
+            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires)
             op_.heisenberg_tr(op.num_wires)
 
         op = cv.CubicPhase
         with pytest.raises(RuntimeError):
-            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires, do_queue=False)
+            op_ = op(*[0.1] * op.num_params, wires=[0] * op.num_wires)
             op_.heisenberg_tr(op.num_wires)


### PR DESCRIPTION
**Description of the Change:**

This PR removes the keyword argument `do_queue` from the operations as suggested by @cgogolin. 

**Benefits:**
As @cgogolin puts it
" It not only clutters the docs (unless manual docstrings are given) but it is also not very well documented and the feature should be irrelevant (and thus hidden, imo) from the user"

**Possible Drawbacks:**
Need to have a way to test operations without invoking a QNode. I am not sure what is the best way to go here. For the current case, I am going to make a PolyXP subclass implementing the suggestion of an "overwritten queue() method that does nothing and use that instead of the regular, user facing, PolyXP in these to places."


**Related GitHub Issues:**
#161 