### PR TITLE
Allow reference plugins to use > 2 wire operations and expvals

### DIFF
--- a/pennylane/expval/qubit.py
+++ b/pennylane/expval/qubit.py
@@ -150,13 +150,14 @@ class Hermitian(Expectation):
     .. math::
         \braket{A} = \braketT{\psi}{\cdots \otimes I\otimes A\otimes I\cdots}{\psi}
 
-    where :math:`A` acts on the requested wire.
+    where :math:`A` acts on the requested wires.
 
-    The matrix A can be N^2\times N^2 acting on N wires.
+    If acting on :math:`N` wires, then the matrix :math:`A` must be of size
+    :math:`2^N\times 2^N`.
 
     Args:
         A (array): square hermitian matrix
-        wires (Sequence[int] or int): the wire the operation acts on
+        wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_wires = 0
     num_params = 1

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -765,13 +765,6 @@ class DefaultGaussian(Device):
             self._state = self._operation_map[operation](*par, hbar=self.hbar)
             return # we are done here
 
-        if operation == 'Interferometer':
-            if par[0].shape[0] != len(wires):
-                raise ValueError("Interferomer unitary matrix applied to the incorrect "
-                                 "number of subsystems.")
-            if len(wires) > 2:
-                raise ValueError("Only 2-mode interferometers are currently supported.")
-
         if 'State' in operation:
             # set the new device state
             mu, cov = self._operation_map[operation](*par, hbar=self.hbar)
@@ -783,10 +776,7 @@ class DefaultGaussian(Device):
         S = self._operation_map[operation](*par)
 
         # expand the symplectic to act on the proper subsystem
-        if len(wires) == 1:
-            S = self.expand_one(S, wires[0])
-        elif len(wires) == 2:
-            S = self.expand_two(S, wires)
+        S = self.expand(S, wires)
 
         # apply symplectic matrix to the means vector
         means = S @ self._state[0]
@@ -795,42 +785,36 @@ class DefaultGaussian(Device):
 
         self._state = [means, cov]
 
-    def expand_one(self, S, wire):
-        r"""Expands a one-mode Symplectic matrix S to act on the entire subsystem.
+    def expand(self, S, wires):
+        r"""Expands a Symplectic matrix S to act on the entire subsystem.
 
         Args:
-            S (array): :math:`2\times 2` Symplectic matrix
-            wire (int): the wire S acts on
+            S (array): a :math:`2M\times 2M` Symplectic matrix
+            wires (Sequence[int]): the wires of modes S acts on
 
         Returns:
             array: the resulting :math:`2N\times 2N` Symplectic matrix
         """
-        S2 = np.identity(2*self.num_wires)
+        if self.num_wires == 1:
+            # total number of wires is 1, simply return the matrix
+            return S
 
-        ind = np.concatenate([np.array([wire]), np.array([wire])+self.num_wires])
-        rows = ind.reshape(-1, 1)
-        cols = ind.reshape(1, -1)
-        S2[rows, cols] = S.copy()
+        N = self.num_wires
+        w = np.asarray(wires)
 
-        return S2
+        if np.any(w < 0) or np.any(w >= N) or len(set(w)) != len(w):
+            raise ValueError('Bad target subsystems.')
 
-    def expand_two(self, S, wires):
-        r"""Expands a two-mode Symplectic matrix S to act on the entire subsystem.
+        M = len(S) // 2
+        S2 = np.identity(2 * N)
 
-        Args:
-            S (array): :math:`4\times 4` Symplectic matrix
-            wires (Sequence[int]): the list of two wires S acts on
+        if M != len(wires):
+            raise ValueError('Incorrect number of subsystems for provided operation.')
 
-        Returns:
-            array: the resulting :math:`2N\times 2N` Symplectic matrix
-        """
-        S2 = np.identity(2*self.num_wires)
-        w = np.array(wires)
-
-        S2[w.reshape(-1, 1), w.reshape(1, -1)] = S[:2, :2].copy() #X
-        S2[(w+self.num_wires).reshape(-1, 1), (w+self.num_wires).reshape(1, -1)] = S[2:, 2:].copy() #P
-        S2[w.reshape(-1, 1), (w+self.num_wires).reshape(1, -1)] = S[:2, 2:].copy() #XP
-        S2[(w+self.num_wires).reshape(-1, 1), w.reshape(1, -1)] = S[2:, :2].copy() #PX
+        S2[w.reshape(-1, 1), w.reshape(1, -1)] = S[:M, :M].copy()  # X
+        S2[(w + N).reshape(-1, 1), (w + N).reshape(1, -1)] = S[M:, M:].copy()  # P
+        S2[w.reshape(-1, 1), (w + N).reshape(1, -1)] = S[:M, M:].copy()  # XP
+        S2[(w + N).reshape(-1, 1), w.reshape(1, -1)] = S[M:, :M].copy()  # PX
 
         return S2
 

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -765,6 +765,11 @@ class DefaultGaussian(Device):
             self._state = self._operation_map[operation](*par, hbar=self.hbar)
             return # we are done here
 
+        if operation == 'Interferometer':
+            if par[0].shape[0] != len(wires):
+                raise ValueError("Interferometer unitary matrix applied to the incorrect "
+                                 "number of subsystems.")
+
         if 'State' in operation:
             # set the new device state
             mu, cov = self._operation_map[operation](*par, hbar=self.hbar)

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -765,11 +765,6 @@ class DefaultGaussian(Device):
             self._state = self._operation_map[operation](*par, hbar=self.hbar)
             return # we are done here
 
-        if operation == 'Interferometer':
-            if par[0].shape[0] != len(wires):
-                raise ValueError("Interferometer unitary matrix applied to the incorrect "
-                                 "number of subsystems.")
-
         if 'State' in operation:
             # set the new device state
             mu, cov = self._operation_map[operation](*par, hbar=self.hbar)

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -318,12 +318,7 @@ class DefaultQubit(Device):
         A = self._get_operator_matrix(operation, par)
 
         # apply unitary operations
-        if len(wires) == 1:
-            U = self.expand_one(A, wires)
-        elif len(wires) == 2:
-            U = self.expand_two(A, wires)
-        else:
-            raise ValueError('This plugin supports only one- and two-qubit gates.')
+        U = self.expand(A, wires)
 
         self._state = U @ self._state
 
@@ -367,14 +362,7 @@ class DefaultQubit(Device):
         Returns:
           float: expectation value :math:`\expect{A} = \bra{\psi}A\ket{\psi}`
         """
-        if A.shape == (2, 2):
-            A = self.expand_one(A, wires)
-        elif A.shape == (4, 4):
-            A = self.expand_two(A, wires)
-        else:
-            raise ValueError('Only one and two-qubit expectation is supported.')
-            # A muti-qubit expansion function extends this.
-            # A = self.expand_multi(A, wires)
+        A = self.expand(A, wires)
 
         expectation = np.vdot(self._state, A @ self._state)
 
@@ -388,68 +376,7 @@ class DefaultQubit(Device):
         self._state = np.zeros(2**self.num_wires, dtype=complex)
         self._state[0] = 1
 
-    def expand_one(self, U, wires):
-        r"""Expand a one-qubit operator into a full system operator.
-
-        Args:
-          U (array): :math:`2\times 2` matrix
-          wires (Sequence[int]): target subsystem
-
-        Returns:
-          array: :math:`2^n\times 2^n` matrix
-        """
-        if U.shape != (2, 2):
-            raise ValueError('2x2 matrix required.')
-        if len(wires) != 1:
-            raise ValueError('One target subsystem required.')
-        wires = wires[0]
-        before = 2**wires
-        after = 2**(self.num_wires-wires-1)
-        U = np.kron(np.kron(np.eye(before), U), np.eye(after))
-        return U
-
-    def expand_two(self, U, wires):
-        r"""Expand a two-qubit operator into a full system operator.
-
-        Args:
-          U (array): :math:`4\times 4` matrix
-          wires (Sequence[int]): two target subsystems (order matters!)
-
-        Returns:
-          array: :math:`2^n\times 2^n` matrix
-        """
-        if U.shape != (4, 4):
-            raise ValueError('4x4 matrix required.')
-        if len(wires) != 2:
-            raise ValueError('Two target subsystems required.')
-        wires = np.asarray(wires)
-        if np.any(wires < 0) or np.any(wires >= self.num_wires) or wires[0] == wires[1]:
-            raise ValueError('Bad target subsystems.')
-
-        a = np.min(wires)
-        b = np.max(wires)
-        n_between = b-a-1  # number of qubits between a and b
-        # dimensions of the untouched subsystems
-        before = 2**a
-        after = 2**(self.num_wires-b-1)
-        between = 2**n_between
-
-        U = np.kron(U, np.eye(between))
-        # how U should be reordered
-        if wires[0] < wires[1]:
-            p = [0, 2, 1]
-        else:
-            p = [1, 2, 0]
-        dim = [2, 2, between]
-        p = np.array(p)
-        perm = np.r_[p, p+3]
-        # reshape U into another array which has one index per subsystem, permute dimensions, back into original-shape array
-        temp = np.prod(dim)
-        U = U.reshape(dim * 2).transpose(perm).reshape([temp, temp])
-        U = np.kron(np.kron(np.eye(before), U), np.eye(after))
-        return U
-
-    def expand_multi(self, U, wires):
+    def expand(self, U, wires):
         r"""Expand a multi-qubit operator into a full system operator.
 
         Args:
@@ -459,7 +386,34 @@ class DefaultQubit(Device):
         Returns:
           array: :math:`2^N\times 2^N` matrix. The full system operator.
         """
-        raise NotImplementedError
+        N = self.num_wires
+        wires = np.asarray(wires)
+
+        if np.any(wires < 0) or np.any(wires >= N) or len(set(wires)) != len(wires):
+            raise ValueError('Bad target subsystems.')
+
+        if N == 1:
+            # total number of wires is 1, simply return the matrix
+            return U
+
+        # generate N qubit basis states via the cartesian product
+        tuples = np.stack(np.meshgrid(*[[0, 1] for _ in range(N)]), -1).reshape(-1, N)
+        tuples[:, [0, 1]] = tuples[:, [1, 0]]
+
+        # wires not acted on by the operator
+        inactive_wires = list(set(range(N))-set(wires))
+
+        # expand U to act on the entire system
+        U = np.kron(U, np.identity(2**len(inactive_wires)))
+
+        # move active wires to beginning of the list of wires
+        rearanged_wires = np.array(list(wires)+inactive_wires)
+
+        # convert to computational basis
+        perm = np.sum(2**np.arange(N-1, -1, -1)*tuples[:, rearanged_wires], axis=1)
+
+        # permute U to take into account rearranged wires
+        return U[:, perm][perm]
 
     @property
     def operations(self):

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -386,15 +386,15 @@ class DefaultQubit(Device):
         Returns:
           array: :math:`2^N\times 2^N` matrix. The full system operator.
         """
+        if self.num_wires == 1:
+            # total number of wires is 1, simply return the matrix
+            return U
+
         N = self.num_wires
         wires = np.asarray(wires)
 
         if np.any(wires < 0) or np.any(wires >= N) or len(set(wires)) != len(wires):
             raise ValueError('Bad target subsystems.')
-
-        if N == 1:
-            # total number of wires is 1, simply return the matrix
-            return U
 
         # generate N qubit basis states via the cartesian product
         tuples = np.stack(np.meshgrid(*[[0, 1] for _ in range(N)]), -1).reshape(-1, N)

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -410,7 +410,10 @@ class DefaultQubit(Device):
         rearanged_wires = np.array(list(wires)+inactive_wires)
 
         # convert to computational basis
-        perm = np.sum(2**np.arange(N-1, -1, -1)*tuples[:, rearanged_wires], axis=1)
+        # i.e., converting the list of basis state bit strings into
+        # a list of decimal numbers that correspond to the computational
+        # basis state. For example, [0, 1, 0, 1, 1] = 2^3+2^1+2^0 = 11.
+        perm = np.ravel_multi_index(tuples[:, rearanged_wires].T, [2]*N)
 
         # permute U to take into account rearranged wires
         return U[:, perm][perm]

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -74,6 +74,7 @@ Classes
 Code details
 ^^^^^^^^^^^^
 """
+import itertools
 import logging as log
 
 import numpy as np
@@ -397,8 +398,7 @@ class DefaultQubit(Device):
             raise ValueError('Bad target subsystems.')
 
         # generate N qubit basis states via the cartesian product
-        tuples = np.stack(np.meshgrid(*[[0, 1] for _ in range(N)]), -1).reshape(-1, N)
-        tuples[:, [0, 1]] = tuples[:, [1, 0]]
+        tuples = np.array(list(itertools.product([0, 1], repeat=N)))
 
         # wires not acted on by the operator
         inactive_wires = list(set(range(N))-set(wires))

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -394,14 +394,14 @@ class TestDefaultGaussianDevice(BaseTest):
             p = [thermal_state(0.5)]
             self.dev.apply('GaussianState', wires=[0], par=[p])
 
-        with self.assertRaisesRegex(ValueError, 'incorrect number of subsystems'):
+        with self.assertRaisesRegex(ValueError, 'Incorrect number of subsystems'):
             p = U
             self.dev.apply('Interferometer', wires=[0], par=[p])
 
-        with self.assertRaisesRegex(ValueError, 'Only 2-mode interferometers are currently supported.'):
+        with self.assertRaisesRegex(ValueError, 'Bad target subsystems'):
             p = U2
             dev = DefaultGaussian(wires=4, shots=0, hbar=hbar)
-            self.dev.apply('Interferometer', wires=[0, 1, 2, 3], par=[p])
+            self.dev.apply('Interferometer', wires=[0, 1, 2], par=[p])
 
     def test_expectation(self):
         """Test that expectation values are calculated correctly"""

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -264,27 +264,19 @@ class TestDefaultQubitDevice(BaseTest):
         dev = DefaultQubit(wires=3)
 
         # test applied to wire 0
-        res = dev.expand_one(U, [0])
+        res = dev.expand(U, [0])
         expected = np.kron(np.kron(U, I), I)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
         # test applied to wire 1
-        res = dev.expand_one(U, [1])
+        res = dev.expand(U, [1])
         expected = np.kron(np.kron(I, U), I)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
         # test applied to wire 2
-        res = dev.expand_one(U, [2])
+        res = dev.expand(U, [2])
         expected = np.kron(np.kron(I, I), U)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test exception raised if U is not 2x2 matrix
-        with self.assertRaisesRegex(ValueError, "2x2 matrix required"):
-            dev.expand_one(U2, [0])
-
-        # test exception raised if more than one subsystem provided
-        with self.assertRaisesRegex(ValueError, "One target subsystem required"):
-            dev.expand_one(U, [0, 1])
 
     def test_expand_two(self):
         """Test that a 2 qubit gate correctly expands to 3 qubits."""
@@ -293,42 +285,29 @@ class TestDefaultQubitDevice(BaseTest):
         dev = DefaultQubit(wires=4)
 
         # test applied to wire 0+1
-        res = dev.expand_two(U2, [0, 1])
+        res = dev.expand(U2, [0, 1])
         expected = np.kron(np.kron(U2, I), I)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
         # test applied to wire 1+2
-        res = dev.expand_two(U2, [1, 2])
+        res = dev.expand(U2, [1, 2])
         expected = np.kron(np.kron(I, U2), I)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
         # test applied to wire 2+3
-        res = dev.expand_two(U2, [2, 3])
+        res = dev.expand(U2, [2, 3])
         expected = np.kron(np.kron(I, I), U2)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
         # CNOT with target on wire 1
-        res = dev.expand_two(CNOT, [1, 0])
+        res = dev.expand(CNOT, [1, 0])
         rows = np.array([0, 2, 1, 3])
         expected = np.kron(np.kron(CNOT[:, rows][rows], I), I)
         self.assertAllAlmostEqual(res, expected, delta=self.tol)
 
-        # test exception raised if U is not 4x4 matrix
-        with self.assertRaisesRegex(ValueError, "4x4 matrix required"):
-            dev.expand_two(U, [0])
-
-        # test exception raised if two subsystems are not provided
-        with self.assertRaisesRegex(ValueError, "Two target subsystems required"):
-            dev.expand_two(U2, [0])
-
         # test exception raised if unphysical subsystems provided
         with self.assertRaisesRegex(ValueError, "Bad target subsystems."):
-            dev.expand_two(U2, [-1, 5])
-
-    def test_expand_multi(self):
-        """Test that any arbitrary qubit gate correctly expands to the full
-        system."""
-        pass
+            dev.expand(U2, [-1, 5])
 
     def test_get_operator_matrix(self):
         """Test the the correct matrix is returned given an operation name"""
@@ -442,11 +421,6 @@ class TestDefaultQubitDevice(BaseTest):
         ):
             self.dev.apply("BasisState", wires=[0, 1, 2], par=[np.array([0, 1])])
 
-        with self.assertRaisesRegex(
-            ValueError, "This plugin supports only one- and two-qubit gates."
-        ):
-            self.dev.apply("QubitUnitary", wires=[0, 1, 2], par=[U2])
-
     def test_ev(self):
         """Test that expectation values are calculated correctly"""
         self.logTestName()
@@ -496,12 +470,6 @@ class TestDefaultQubitDevice(BaseTest):
 
             # verify the device is now in the expected state
             self.assertAllAlmostEqual(res, expected_out, delta=self.tol)
-
-            # text exception raised if matrix is not 2x2 or 4x4
-            with self.assertRaisesRegex(
-                ValueError, "Only one and two-qubit expectation is supported."
-            ):
-                self.dev.ev(U_toffoli, [0])
 
             # text warning raised if matrix is complex
             with self.assertLogs(level="WARNING") as l:


### PR DESCRIPTION
**Description of the Change:**

* Removes limit on `default.qubit` which previously only allowed 1 and 2 qubit operations/expvals. Now, you can apply arbitrary N-qubit operations, and measure arbitrary N-qubit observables. This is done by replacing the `DefaultQubit.expand_one` and `DefaultQubit.expand_two` with a single, more general `expand` method, that works for any unitary/Hermitian matrix.

* Removes limit on `default.gaussian` which previously only allowed 1 and 2 mode gates. It now supports N-mode operations. This is done by replacing the `DefaultGaussian.expand_one` and `DefaultGaussian.expand_two` with a single, more general `expand` method, that works for any sized symplectic matrix.

**Benefits:**

* Allows `qml.Interferometer()` to work on the `default.gaussian` plugin for >2 modes
* Allows `qml.QubitUnitary()` to work on the `default.qubit` plugin for >2 modes
* Allows `qml.expval.Hermitian()` to work on the `default.qubit` plugin for >2 modes

**Possible Drawbacks:**

n/a

**Related GitHub Issues:**

#175 
