### PR TITLE
Fixes a bug in operation and expectation validation on devices

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -301,11 +301,11 @@ class Device(abc.ABC):
             expectations (Iterable[~.operation.Expectation]): expectations which are intended to be evaluated in the device
         """
         for o in queue:
-            if not self.supported(o.name):
+            if o.name not in self.operations:
                 raise DeviceError("Gate {} not supported on device {}".format(o.name, self.short_name))
 
         for e in expectations:
-            if not self.supported(e.name):
+            if e.name not in self.expectations:
                 raise DeviceError("Expectation {} not supported on device {}".format(e.name, self.short_name))
 
     @abc.abstractmethod


### PR DESCRIPTION
**Description of the Change:**

The `Device.supported` method is a union between the sets of supported operation names and expectation names. However, some of the expectations and operations have the same name, i.e., `PauliX`, `PauliZ`, `PauliY`, `Hadamard`. Thus, if the `PauliX` operation is supported, this will also accidentally mark the `PauliX` expectation as supported.

To fix this, the `check_validity` method now explicitly checks the operation/expectation against the `Device.operations` and `Device.expectations` methods.

**Benefits:**

Correctly raises error for plugins such as the Qiskit plugin, where only `PauliZ` expectations are allowed, but all `Pauli` operations are allowed.

**Possible Drawbacks:**

We should fix the `Device.supported` method, adding a keyword argument to switch between expvals and operations, and remove the set union.

**Related GitHub Issues:** n/a