### PR TITLE
Keyword argument bug fixes

### DIFF
--- a/doc/tutorials/qubit_rotation.rst
+++ b/doc/tutorials/qubit_rotation.rst
@@ -249,7 +249,7 @@ We can then evaluate this gradient function at any point in the parameter space.
     >>> dcircuit(0.54, 0.12)
     (array(-0.510438652516502), array(-0.10267819945693203))
 
-    Keyword arguments may also be used in your custom quantum function. PennyLane does differentiate QNodes with respect to keyword arguments,
+    Keyword arguments may also be used in your custom quantum function. PennyLane does **not** differentiate QNodes with respect to keyword arguments,
     so they are useful for passing external data to your QNode.
 
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -205,7 +205,8 @@ class Device(abc.ABC):
         with self.execution_context():
             self.pre_apply()
             for operation in queue:
-                self.apply(operation.name, operation.wires, operation.parameters)
+                w = [int(i) for i in operation.wires]
+                self.apply(operation.name, w, operation.parameters)
             self.post_apply()
 
             self.pre_expval()

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -205,8 +205,7 @@ class Device(abc.ABC):
         with self.execution_context():
             self.pre_apply()
             for operation in queue:
-                w = [int(i) for i in operation.wires]
-                self.apply(operation.name, w, operation.parameters)
+                self.apply(operation.name, operation.wires, operation.parameters)
             self.post_apply()
 
             self.pre_expval()

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -373,7 +373,7 @@ class Operation(abc.ABC):
         """
         w = [i.val if isinstance(i, Variable) else i for i in self._wires]
         self.check_wires(w)
-        return w
+        return [int(i) for i in w]
 
     @property
     def parameters(self):


### PR DESCRIPTION
**Description of the Change:**

This PR fixes two bugs noted in https://discuss.pennylane.ai/t/passing-non-differentiable-arguments-to-qnode/135/5:

1. When QNode keyword arguments are used to specify wires of operations/expvals, complicated casting rules can cause them to be of type `np.int64` rather than the standard Python type `int`. This can cause issues with external plugin devices, for example, if the targeted framework performs validation to ensure that `isinstance(qubit, int)`. 

   To fix this, we explicitly cast the operation wires directly to integers in `Operation.wires`.

2. There is a typo in the qubit rotation tutorial; the line

   > PennyLane does differentiate QNodes with respect to keyword arguments,
    so they are useful for passing external data to your QNode.

   should instead say

   > PennyLane does **not** differentiate QNodes with respect to keyword arguments,
    so they are useful for passing external data to your QNode.

**Benefits:** Avoids exceptions occurring during supported behviour in some plugins.

**Possible Drawbacks:** None.

**Related GitHub Issues:** n/a