### PR TITLE
Cleans up logging in PennyLane module files

### DIFF
--- a/pennylane/__init__.py
+++ b/pennylane/__init__.py
@@ -91,7 +91,6 @@ Code details
 ~~~~~~~~~~~~
 """
 import os
-import logging as log
 from pkg_resources import iter_entry_points
 
 from autograd import numpy
@@ -119,21 +118,6 @@ from .decorator import qnode
 
 # overwrite module docstrings
 numpy.__doc__ = "NumPy with automatic differentiation support, provided by Autograd."
-
-
-# set up logging
-numeric_level = 100  # info
-if "LOGGING" in os.environ:
-    logLevel = os.environ["LOGGING"]
-    numeric_level = getattr(log, logLevel.upper(), 10)
-
-
-log.basicConfig(
-    level=numeric_level,
-    format="%(asctime)s %(levelname)s %(message)s",
-    datefmt="%H:%M:%S",
-)
-log.captureWarnings(True)
 
 
 # Look for an existing configuration file

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -85,13 +85,9 @@ Code details
 ~~~~~~~~~~~~
 """
 # pylint: disable=too-many-format-args
-
 import abc
-import logging
 
 import autograd.numpy as np
-
-logging.getLogger()
 
 
 class DeviceError(Exception):

--- a/pennylane/configuration.py
+++ b/pennylane/configuration.py
@@ -155,7 +155,7 @@ class Configuration:
                 break
             except FileNotFoundError:
                 if idx == len(directories)-1:
-                    log.warning('No PennyLane configuration file found.')
+                    log.info('No PennyLane configuration file found.')
 
     def __str__(self):
         if self._config:

--- a/pennylane/decorator.py
+++ b/pennylane/decorator.py
@@ -109,12 +109,9 @@ via the `Autograd <https://github.com/HIPS/autograd>`_ package.
     <h3>Code details</h3>
 """
 # pylint: disable=redefined-outer-name
-import logging as log
 from functools import wraps, lru_cache
 
 from .qnode import QNode
-
-log.getLogger()
 
 
 def qnode(device, interface='numpy'):

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -111,15 +111,12 @@ Code details
 import abc
 import numbers
 from collections.abc import Sequence
-import logging as log
 
 import autograd.numpy as np
 
 from .qnode import QNode, QuantumFunctionError
 from .utils import _flatten, _unflatten
 from .variable import Variable
-
-log.getLogger()
 
 
 #=============================================================================

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -89,16 +89,12 @@ Code details
 ^^^^^^^^^^^^
 """
 # pylint: disable=attribute-defined-outside-init
-import logging as log
-
 import numpy as np
 
 from scipy.special import factorial as fac
 
 import pennylane as qml
 from pennylane import Device
-
-log.getLogger()
 
 # tolerance for numerical errors
 tolerance = 1e-10

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -74,14 +74,13 @@ Classes
 Code details
 ^^^^^^^^^^^^
 """
-import logging as log
+import warnings
 
 import numpy as np
 from scipy.linalg import expm, eigh
 
 from pennylane import Device
 
-log.getLogger()
 
 # tolerance for numerical errors
 tolerance = 1e-10
@@ -379,7 +378,7 @@ class DefaultQubit(Device):
         expectation = np.vdot(self._state, A @ self._state)
 
         if np.abs(expectation.imag) > tolerance:
-            log.warning('Nonvanishing imaginary part % in expectation value.', expectation.imag)
+            warnings.warn('Nonvanishing imaginary part {} in expectation value.'.format(expectation.imag), RuntimeWarning)
         return expectation.real
 
     def reset(self):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -135,8 +135,6 @@ from collections.abc import Sequence
 import inspect
 import copy
 
-import logging as log
-
 import numbers
 
 import autograd.numpy as np
@@ -147,9 +145,6 @@ import pennylane.operation
 
 from .variable  import Variable
 from .utils import _flatten, unflatten
-
-
-log.getLogger()
 
 
 class QuantumFunctionError(Exception):

--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -69,13 +69,10 @@ keyword arguments, its ``name``, to return the correct value to the operation.
 
     <h3>Code details</h3>
 """
-import logging
 from collections.abc import Sequence
 import copy
 
 import numpy as np
-
-logging.getLogger()
 
 
 class Variable:

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -76,7 +76,7 @@ class BasicTest(BaseTest):
         """Test that a warning is raised if no configuration file found."""
         self.logTestName()
 
-        with self.assertLogs(level='WARNING') as l:
+        with self.assertLogs(level='INFO') as l:
             Configuration('noconfig')
             self.assertEqual(len(l.output), 1)
             self.assertEqual(len(l.records), 1)

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -19,6 +19,8 @@ import unittest
 import inspect
 import logging as log
 
+import pytest
+
 from pennylane import numpy as np
 
 from defaults import pennylane as qml, BaseTest
@@ -504,11 +506,8 @@ class TestDefaultQubitDevice(BaseTest):
                 self.dev.ev(U_toffoli, [0])
 
             # text warning raised if matrix is complex
-            with self.assertLogs(level="WARNING") as l:
+            with pytest.warns(RuntimeWarning, match='Nonvanishing imaginary part'):
                 self.dev.ev(H + 1j, [0])
-                self.assertEqual(len(l.output), 1)
-                self.assertEqual(len(l.records), 1)
-                self.assertIn("Nonvanishing imaginary part", l.output[0])
 
 
 class TestDefaultQubitIntegration(BaseTest):


### PR DESCRIPTION
**Description of the Change:**

* Removes logging configuration from `__init__.py`

* Removes logging calls from modules that don't currently do any logging

* Converts some logging calls to warnings, where it makes sense

**Benefits:**

Imported Python libraries should *not* be configuring the logger, as this will override the users logging. See https://sweetness.hmmz.org/2013-11-18-use-of-logging-package-from-within-a-library.html.

> Except in very rare cases, the majority of logging configuration should be deferred to the consuming application's top level, where tools like `logging.config.fileConfig()` can be used to configure the entire system's logging using a standard convention, rather than package-specific or app-specific hard-wired values or environment variables or whatever else.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #207 
