### PR TITLE
Fixes QubitStateVector bug in Default Qubit plugin

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -295,7 +295,7 @@ class DefaultQubit(Device):
 
     def apply(self, operation, wires, par):
         if operation == 'QubitStateVector':
-            state = np.asarray(par[0], dtype=np.complex64)
+            state = np.asarray(par[0], dtype=np.complex128)
             if state.ndim == 1 and state.shape[0] == 2**self.num_wires:
                 self._state = state
             else:

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -295,7 +295,7 @@ class DefaultQubit(Device):
 
     def apply(self, operation, wires, par):
         if operation == 'QubitStateVector':
-            state = np.asarray(par[0], dtype=np.float64)
+            state = np.asarray(par[0], dtype=np.complex64)
             if state.ndim == 1 and state.shape[0] == 2**self.num_wires:
                 self._state = state
             else:


### PR DESCRIPTION
**Description of the Change:** When using `qml.QubitStateVector` to prepare an arbitrary state, the `default.qubit` device was accidentally casting the state to `np.float64`. This PR fixes this, instead casting the result to a `np.complex128` array.

**Benefits:** fixes a bug that led to unphysical simulation.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #210 