### PR TITLE
Replace device.supported with separate methods for ops and expvals

### DIFF
--- a/doc/API/overview.rst
+++ b/doc/API/overview.rst
@@ -68,7 +68,7 @@ You must further tell PennyLane about the operations and expectations that your 
 
     operations = {"CNOT", "PauliX"}
 
-  This is used to decide whether an operation is supported by your device in the default implementation of the public method :meth:`~.Device.supported`.
+  This is used to decide whether an operation is supported by your device in the default implementation of the public method :meth:`~.Device.supports_operation`.
 
 * :attr:`~.Device.expectations`: set of the supported PennyLane expectations as strings, e.g.,
 
@@ -76,7 +76,7 @@ You must further tell PennyLane about the operations and expectations that your 
 
     expectations = {"Homodyne", "MeanPhoton", "X", "P"}
 
-  This is used to decide whether an expectation is supported by your device in the default implementation of the public method :meth:`~.Device.supported`.
+  This is used to decide whether an expectation is supported by your device in the default implementation of the public method :meth:`~.Device.supports_expectation`.
 
 * :attr:`~.Device._capabilities`: (optional) a dictionary containing information about the capabilities of the device. At the moment, only the key ``'model'`` is supported, which may return either ``'qubit'`` or ``'CV'``. Alternatively, you may use this class dictionary to return additional information to the user — this is accessible from the PennyLane frontend via the public method :meth:`~.Device.capabilities`.
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -278,16 +278,27 @@ class Device(abc.ABC):
 
         return MockContext()
 
-    def supported(self, name):
-        """Checks if an operation or expectation is supported by this device.
+    def supports_operation(self, name):
+        """Checks if an operation is supported by this device.
 
         Args:
-            name (str): name of the operation or expectation
+            name (str): name of the operation
 
         Returns:
             bool: True iff it is supported
         """
-        return name in self.operations.union(self.expectations)
+        return name in self.operations
+
+    def supports_expectation(self, name):
+        """Checks if an expectation is supported by this device.
+
+        Args:
+            name (str): name of the expectation
+
+        Returns:
+            bool: True iff it is supported
+        """
+        return name in self.expectations
 
     def check_validity(self, queue, expectations):
         """Checks whether the operations and expectations in queue are all supported by the device.

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -605,7 +605,7 @@ class TestDefaultGaussianIntegration(BaseTest):
 
         for g, qop in dev._operation_map.items():
             log.debug('\tTesting gate %s...', g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
             dev.reset()
 
             op = getattr(qml.ops, g)

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -668,7 +668,7 @@ class TestDefaultQubitIntegration(BaseTest):
 
         for g, qop in dev._operation_map.items():
             log.debug("\tTesting gate %s...", g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
             dev.reset()
 
             op = getattr(qml.ops, g)
@@ -732,7 +732,7 @@ class TestDefaultQubitIntegration(BaseTest):
 
         for g, qop in dev._expectation_map.items():
             log.debug("\tTesting observable %s...", g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_expectation(g))
             dev.reset()
 
             op = getattr(qml.expval, g)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -52,18 +52,27 @@ class DeviceTest(BaseTest):
         for name, dev in self.dev.items():
             self.assertEqual(dev.short_name, name)
 
-    def test_supported(self):
-        """check that a nonempty set of operations/expectations are supported"""
+    def test_supports_operation(self):
+        """check that a nonempty set of operations are supported"""
         self.logTestName()
 
         for dev in self.dev.values():
-            ops = dev.operations
-            exps = dev.expectations
-            self.assertTrue(len(ops) > 0)
-            self.assertTrue(len(exps) > 0)
+            operations = dev.operations
+            self.assertTrue(len(operations) > 0)
 
-            for op in ops.union(exps):
-                self.assertTrue(dev.supported(op))
+            for operation in operations:
+                self.assertTrue(dev.supports_operation(operation))
+
+    def test_supports_expectation(self):
+        """check that a nonempty set of expectations are supported"""
+        self.logTestName()
+
+        for dev in self.dev.values():
+            expectations = dev.expectations
+            self.assertTrue(len(expectations) > 0)
+
+            for expectation in expectations:
+                self.assertTrue(dev.supports_expectation(expectation))
 
     def test_check_validity(self):
         """test that the check_validity method correctly


### PR DESCRIPTION
**Description of the Change:**
The method device.supported was replace with the two separate methods
device.supports_operation and device.supports_expectation to get around
the problem that there are operations and expectations with the same
name.

Unit tests where added for the new methods and the unit test for the
old method removed. Additionally, unit tests for default.qubit and
default.gaussian had to be changed. The description in the documentation
was also altered to reflect the new methods.

**Benefits:**
The erroneous behaviour of `device.supported` is replaced with the clear `device.supports_operation` and `device.supports_expectation`.

**Possible Drawbacks:**
Compatibility will be broken because `device.supported` is removed.

**Related GitHub Issues:**
#205 

## PS
I did _not_ go for the variant 
```python
import pennylane as qml

mydevice.supports(qml.PauliX)
mydevice.supports(qml.expval.PauliX)
```
(for now), because this would mean a deeper change in multiple locations that would have to be discussed first. Right now, strings are used all over the place to identify gates (which is fine), and not using them only in `device.supports` would be inconsistent.

#### PPS
There was one test that did not run which was unrelated to my changes and possibly due to the fact that I'm on a Windows machine. 
```
  File "D:\dev\xanadu\pennylane\tests\test_default_qubit.py", line 769, in test_supported_observables
    self.assertAllEqual(circuit(H), reference(H))
  File "D:\dev\xanadu\pennylane\tests\defaults.py", line 78, in assertAllEqual
    return self.assertAllAlmostEqual(first, second, delta=0.0, msg=msg)
  File "D:\dev\xanadu\pennylane\tests\defaults.py", line 72, in assertAllAlmostEqual
    raise self.failureException(msg)
AssertionError: 0.9256130778506405 != (0.9256130778506405+2.7755575615628914e-17j) within 0.0 delta
```
I think it would be appropriate to change this to assertAllAlmostEqual, wouldn't it? Running comparisons on floats with 0.0 tolerance seems to be quite strict.
