### PR TITLE
Documentation: change installation instruction about source code

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -134,6 +134,7 @@ PennyLane is **free** and **open source**, released under the Apache License, Ve
    installing
    plugins
    research
+   Get Help<https://discuss.pennylane.ai/>
 
 .. toctree::
    :maxdepth: 1

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -35,10 +35,12 @@ Installation of PennyLane, as well as all required Python packages mentioned abo
 
 Make sure you are using the Python 3 version of pip.
 
-Alternatively, you can install PennyLane from the source code by navigating to the top-level directory and running
+Alternatively, you can install PennyLane from the source code on Github by navigating to the top-level directory and running
 ::
 
-	$ python setup.py install
+	$ git clone https://github.com/XanaduAI/pennylane
+        $ cd pennylane
+        $ pip install -e .
 
 
 Software tests


### PR DESCRIPTION
**Description of the Change:**

1. Adding detailed commands for installation from source code like we discussed in an earlier PR. 

2. Adding the discussion forum  as a direct link. 

**Benefits:**
Having a direct visible help tab called `Get Help` in the side gallery is easier to spot. It does not depend on the user scrolling down the front page or going through all the side tabs to find the page on `Support`. I personally always look for the `Help` tab on a website when I have issues. We can also rename it to `Discussion Forum `. What do you guys think ?  
