### PR TITLE
Switch default.qubit to use tensordot

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -316,11 +316,21 @@ class DefaultQubit(Device):
             return
 
         A = self._get_operator_matrix(operation, par)
-
-        # apply unitary operations
-        U = self.expand(A, wires)
-
-        self._state = U @ self._state
+        # TODO: use multi-index vectors/matrices to represent states/gates internally
+        A = np.reshape(A, [2] * len(wires) * 2)
+        s = np.reshape(self._state, [2] * self.num_wires)
+        axes = (np.arange(len(wires), 2 * len(wires)), wires)
+        tdot = np.tensordot(A, s, axes=axes)
+        # tensordot causes the axes given in `wires` to end up in the first positions
+        # of the resulting tensor. This corresponds to a (partial) transpose of
+        # the correct output state
+        # We'll need to invert this permutation to put the indices in the correct place
+        unused_idxs = [idx for idx in range(self.num_wires) if idx not in wires]
+        perm = wires + unused_idxs
+        inv_perm = np.argsort(perm) # argsort gives inverse permutation
+        state_multi_index = np.transpose(tdot, inv_perm)
+        state_flat = np.reshape(state_multi_index, 2 ** self.num_wires)
+        self._state = state_flat
 
     def expval(self, expectation, wires, par):
         # measurement/expectation value <psi|A|psi>

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -316,6 +316,7 @@ class DefaultQubit(Device):
             return
 
         A = self._get_operator_matrix(operation, par)
+
         # TODO: use multi-index vectors/matrices to represent states/gates internally
         A = np.reshape(A, [2] * len(wires) * 2)
         s = np.reshape(self._state, [2] * self.num_wires)

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -322,6 +322,7 @@ class DefaultQubit(Device):
         s = np.reshape(self._state, [2] * self.num_wires)
         axes = (np.arange(len(wires), 2 * len(wires)), wires)
         tdot = np.tensordot(A, s, axes=axes)
+
         # tensordot causes the axes given in `wires` to end up in the first positions
         # of the resulting tensor. This corresponds to a (partial) transpose of
         # the correct output state

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -331,8 +331,7 @@ class DefaultQubit(Device):
         perm = wires + unused_idxs
         inv_perm = np.argsort(perm) # argsort gives inverse permutation
         state_multi_index = np.transpose(tdot, inv_perm)
-        state_flat = np.reshape(state_multi_index, 2 ** self.num_wires)
-        self._state = state_flat
+        self._state = np.reshape(state_multi_index, 2 ** self.num_wires)
 
     def expval(self, expectation, wires, par):
         # measurement/expectation value <psi|A|psi>


### PR DESCRIPTION
**Description of the Change:** Modified `default.qubit` plugin to use tensordot for gate applications instead of creating large dense arrays 

**Benefits:** speed improvement of 5-10x

**Possible Drawbacks:** This PR was the biggest bang-for-your-buck change, but code could still be optimized more for speed by using a multi-index representation of states/gates internally. 

**Related GitHub Issues:** none
