### PR TITLE
Refactored default.qubit for more speed

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -325,7 +325,7 @@ class DefaultQubit(Device):
             wires (Sequence[int]): target subsystems
 
         Returns:
-            array: output vector after applying `mat` to input `vec` on specified subsystems
+            array: output vector after applying ``mat`` to input ``vec`` on specified subsystems
         """
 
         # TODO: use multi-index vectors/matrices to represent states/gates internally

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -73,7 +73,6 @@ Classes
 Code details
 ^^^^^^^^^^^^
 """
-import itertools
 import warnings
 
 import numpy as np

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -31,7 +31,7 @@ simulation of a qubit-based quantum circuit architecture.
 The following is the technical documentation of the implementation of the plugin. You will
 not need to read and understand this to use this plugin.
 
-Auxillary functions
+Auxiliary functions
 -------------------
 
 .. autosummary::
@@ -314,10 +314,19 @@ class DefaultQubit(Device):
             return
 
         A = self._get_operator_matrix(operation, par)
-        self._state = self._mat_vec_product(A, self._state, wires)
+        self._state = self.mat_vec_product(A, self._state, wires)
 
-    def _mat_vec_product(self, mat, vec, wires):
-        # apply multiplication of matrix `mat` to the subsystems of `vec` specified by `wires`
+    def mat_vec_product(self, mat, vec, wires):
+        r"""Apply multiplication of a matrix to subsystems of the quantum state.
+
+        Args:
+            mat (array): matrix to multiply
+            vec (array): state vector to multiply
+            wires (Sequence[int]): target subsystems
+
+        Returns:
+            array: output vector after applying `mat` to input `vec` on specified subsystems
+            """
 
         # TODO: use multi-index vectors/matrices to represent states/gates internally
         mat = np.reshape(mat, [2] * len(wires) * 2)
@@ -336,7 +345,17 @@ class DefaultQubit(Device):
         return np.reshape(state_multi_index, 2 ** self.num_wires)
 
     def expval(self, observable, wires, par):
-        # measurement/expectation value <psi|A|psi>
+        r"""Expectation value of observable on specified wires.
+
+        Args:
+          observable      (str): name of the observable
+          wires (Sequence[int]): target subsystems
+          par    (tuple[float]): parameter values
+
+        Returns:
+          float: expectation value :math:`\expect{A} = \bra{\psi}A\ket{\psi}`
+            """
+
         A = self._get_operator_matrix(observable, par)
         if self.shots == 0:
             # exact expectation value
@@ -366,16 +385,16 @@ class DefaultQubit(Device):
         return A(*par)
 
     def ev(self, A, wires):
-        r"""Evaluates a one-qubit expectation in the current state.
+        r"""Evaluates an expectation value of the current state.
 
         Args:
-          A (array): :math:`2\times 2` Hermitian matrix corresponding to the observable
-          wires (Sequence[int]): target subsystem
+          A (array): :math:`2^M\times 2^M` Hermitian matrix corresponding to the observable
+          wires (Sequence[int]): target subsystems
 
         Returns:
           float: expectation value :math:`\expect{A} = \bra{\psi}A\ket{\psi}`
         """
-        As = self._mat_vec_product(A, self._state, wires)
+        As = self.mat_vec_product(A, self._state, wires)
         expectation = np.vdot(self._state, As)
 
         if np.abs(expectation.imag) > tolerance:

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -326,7 +326,7 @@ class DefaultQubit(Device):
 
         Returns:
             array: output vector after applying `mat` to input `vec` on specified subsystems
-            """
+        """
 
         # TODO: use multi-index vectors/matrices to represent states/gates internally
         mat = np.reshape(mat, [2] * len(wires) * 2)

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -261,98 +261,6 @@ class TestDefaultQubitDevice(BaseTest):
             set(qml.ops._qubit__obs__) | {"Identity"}, set(self.dev._observable_map)
         )
 
-    def test_expand_one(self):
-        """Test that a 1 qubit gate correctly expands to 3 qubits."""
-        self.logTestName()
-
-        dev = DefaultQubit(wires=3)
-
-        # test applied to wire 0
-        res = dev.expand(U, [0])
-        expected = np.kron(np.kron(U, I), I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 1
-        res = dev.expand(U, [1])
-        expected = np.kron(np.kron(I, U), I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 2
-        res = dev.expand(U, [2])
-        expected = np.kron(np.kron(I, I), U)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-    def test_expand_two(self):
-        """Test that a 2 qubit gate correctly expands to 3 qubits."""
-        self.logTestName()
-
-        dev = DefaultQubit(wires=4)
-
-        # test applied to wire 0+1
-        res = dev.expand(U2, [0, 1])
-        expected = np.kron(np.kron(U2, I), I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 1+2
-        res = dev.expand(U2, [1, 2])
-        expected = np.kron(np.kron(I, U2), I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 2+3
-        res = dev.expand(U2, [2, 3])
-        expected = np.kron(np.kron(I, I), U2)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # CNOT with target on wire 1
-        res = dev.expand(CNOT, [1, 0])
-        rows = np.array([0, 2, 1, 3])
-        expected = np.kron(np.kron(CNOT[:, rows][rows], I), I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test exception raised if unphysical subsystems provided
-        with self.assertRaisesRegex(ValueError, "Invalid target subsystems provided in 'wires' argument"):
-            dev.expand(U2, [-1, 5])
-
-    def test_expand_three(self):
-        """Test that a 3 qubit gate correctly expands to 4 qubits."""
-        self.logTestName()
-
-        dev = DefaultQubit(wires=4)
-
-        # test applied to wire 0,1,2
-        res = dev.expand(U_toffoli, [0, 1, 2])
-        expected = np.kron(U_toffoli, I)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 1,2,3
-        res = dev.expand(U_toffoli, [1, 2, 3])
-        expected = np.kron(I, U_toffoli)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 0,2,3
-        res = dev.expand(U_toffoli, [0, 2, 3])
-        expected = np.kron(U_swap, np.kron(I, I)) @ np.kron(I, U_toffoli) @ np.kron(U_swap, np.kron(I, I))
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 0,1,3
-        res = dev.expand(U_toffoli, [0, 1, 3])
-        expected = np.kron(np.kron(I, I), U_swap) @ np.kron(U_toffoli, I) @ np.kron(np.kron(I, I), U_swap)
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 3, 1, 2
-        res = dev.expand(U_toffoli, [3, 1, 2])
-        # change the control qubit on the Toffoli gate
-        rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = np.kron(I, U_toffoli[:, rows][rows])
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
-        # test applied to wire 3, 0, 2
-        res = dev.expand(U_toffoli, [3, 0, 2])
-        # change the control qubit on the Toffoli gate
-        rows = np.array([0, 4, 1, 5, 2, 6, 3, 7])
-        expected = np.kron(U_swap, np.kron(I, I)) @ np.kron(I, U_toffoli[:, rows][rows]) @ np.kron(U_swap, np.kron(I, I))
-        self.assertAllAlmostEqual(res, expected, delta=self.tol)
-
     def test_get_operator_matrix(self):
         """Test the the correct matrix is returned given an operation name"""
         self.logTestName()
@@ -472,7 +380,6 @@ class TestDefaultQubitDevice(BaseTest):
 
         # loop through all supported observables
         for name, fn in self.dev._observable_map.items():
-            print(name)
             log.debug("\tTesting %s observable...", name)
 
             # start in the state |00>
@@ -495,8 +402,6 @@ class TestDefaultQubitDevice(BaseTest):
             else:
                 # otherwise, the operation is simply an array.
                 O = fn
-
-            print("op.num_wires=" + str(op.num_wires))
 
             # calculate the expected output
             if op.num_wires == 1 or op.num_wires == 0:

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -16,7 +16,6 @@ Unit tests for the :mod:`pennylane.plugin.DefaultQubit` device.
 """
 # pylint: disable=protected-access,cell-var-from-loop
 import unittest
-import inspect
 import logging as log
 
 import pytest


### PR DESCRIPTION
**Description of the Change:** Removed `expand` method from `default.qubit`. Both gate applications and expectations now use `tensordot` under the hood

**Benefits:** apparent 25x speed-up over current code

**Possible Drawbacks:** 

**Related GitHub Issues:**
