### PR TITLE
Fix for Issue #245

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ notebooks/*
 .pytest_cache/*
 
 !formalism/tasks.pdf
+*.DS_Store

--- a/doc/tutorials/qubit_rotation.rst
+++ b/doc/tutorials/qubit_rotation.rst
@@ -182,7 +182,7 @@ be a valid quantum function, there are some important restrictions:
   As a result, the quantum function always returns a classical quantity, allowing the QNode to interface
   with other classical functions (and also other QNodes).
 
-  For a full list of quantum expectation values, see :mod:`supported expectations <pennylane.measure>`.
+  For a full list of quantum expectation values, see :mod:`supported observables <pennylane.measure>`.
 
 * **Quantum functions must not contain any classical processing of circuit parameters.**
 

--- a/doc/tutorials/qubit_rotation.rst
+++ b/doc/tutorials/qubit_rotation.rst
@@ -182,7 +182,7 @@ be a valid quantum function, there are some important restrictions:
   As a result, the quantum function always returns a classical quantity, allowing the QNode to interface
   with other classical functions (and also other QNodes).
 
-  For a full list of quantum expectation values, see :mod:`supported expectations <pennylane.expval>`.
+  For a full list of quantum expectation values, see :mod:`supported expectations <pennylane.measure>`.
 
 * **Quantum functions must not contain any classical processing of circuit parameters.**
 


### PR DESCRIPTION
**Description of the Change:** This PR fixes a broken link in the tutorial documentation. 

**Benefits:** Fixes a broken link in the documentation and links to the correct location. This change is a result of `expval` being merged into `measure`

**Possible Drawbacks:** None, in the foreseeable future.

**Related GitHub Issues:** Issue #245 
