### PR TITLE
Added enumerations to represent All and Any wires

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 ### New features since last release
 
-* The method `Device.supported` that listed all the supported operations and observables
-  was replaced with two separate methods `Device.supports_observable` and `Device.supports_operation`.
-  The methods can now be called with string arguments (`dev.supports_observable('PauliX')`) and with
-  class information arguments (`dev.supports_observable(qml.PauliX)`).
-  [#276](https://github.com/XanaduAI/pennylane/pull/276)
-
 * Sampling support: QNodes can now return a specified number of samples
   from a given observable via the top-level `pennylane.sample()` function.
   To support this on plugin devices, there is a new `Device.sample` method.
@@ -27,13 +21,46 @@
   scheme: `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and `NumberState` to `FockStateProjector`.
   [#243](https://github.com/XanaduAI/pennylane/pull/243)
 
+### Improvements
+
+* Introduces two enumerations: `Any` and `All`, representing any number of wires
+  and all wires in the system respectively. They can be imported from
+  `pennylane.operation`, and can be used when defining the `Operation.num_wires`
+  class attribute of operations.
+
+  As part of this change:
+
+  - `All` is equivalent to the integer 0, for backwards compatibility with the
+    existing test suite
+
+  - `Any` is equivalent to the integer -1 to allow numeric comparison
+    operators to continue working
+
+  - An additional validation is now added to the `Operation` class,
+    which will alert the user that an operation with `num_wires = All`
+    is being incorrectly.
+
+  [#277](https://github.com/XanaduAI/pennylane/pull/277)
+
+* The method `Device.supported` that listed all the supported operations and observables
+  was replaced with two separate methods `Device.supports_observable` and `Device.supports_operation`.
+  The methods can now be called with string arguments (`dev.supports_observable('PauliX')`) and with
+  class information arguments (`dev.supports_observable(qml.PauliX)`).
+  [#276](https://github.com/XanaduAI/pennylane/pull/276)
+
+### Bug fixes
+
+* Fixed a bug where a `PolyXP` observable would fail if applied to subsets
+  of wires on `default.gaussian`.
+  [#277](https://github.com/XanaduAI/pennylane/pull/277)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
 
 Aroosa Ijaz, Johannes Jakob Meyer.
 
-
+---
 
 # Release 0.4.0
 
@@ -81,7 +108,7 @@ Aroosa Ijaz, Johannes Jakob Meyer.
   - New random initialization functions supporting the templates available
     in the new submodule `pennylane.init`.
 
-  - Added a random circuit template (`RandomLayers()`), in which rotations and 2-qubit gates are randomly 
+  - Added a random circuit template (`RandomLayers()`), in which rotations and 2-qubit gates are randomly
     distributed over the wires
 
   - Add various embedding strategies

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -126,6 +126,9 @@ from .variable import Variable
 #=============================================================================
 
 class Wires(IntEnum):
+    """Integer enumeration class
+    to represent the number of wires
+    an operation acts on"""
     Any = -1
     All = 0
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -110,6 +110,7 @@ Code details
 ^^^^^^^^^^^^
 """
 import abc
+from enum import IntEnum
 import numbers
 from collections.abc import Sequence
 
@@ -119,6 +120,20 @@ from .qnode import QNode, QuantumFunctionError
 from .utils import _flatten, _unflatten
 from .variable import Variable
 
+
+#=============================================================================
+# Wire types
+#=============================================================================
+
+Wires = IntEnum("Wires", {"Any": -1, "All": 0})
+
+All = Wires.All
+"""IntEnum: An enumeration which represents all wires in the
+subsystem. It is equivalent to an integer with value 0."""
+
+Any = Wires.Any
+"""IntEnum: An enumeration which represents any wires in the
+subsystem. It is equivalent to an integer with value -1."""
 
 #=============================================================================
 # Class property
@@ -252,6 +267,11 @@ class Operation(abc.ABC):
         # pylint: disable=too-many-branches
         self.name = self.__class__.__name__   #: str: name of the operation
 
+        if self.num_wires == All:
+            if do_queue:
+                if set(wires) != set(range(QNode._current_context.num_wires)):
+                    raise ValueError("Operation {} must act on all wires".format(self.name))
+
         if wires is None:
             raise ValueError("Must specify the wires that {} acts on".format(self.name))
 
@@ -311,7 +331,7 @@ class Operation(abc.ABC):
         Returns:
             Number, array, Variable: p
         """
-        if self.num_wires != 0 and len(wires) != self.num_wires:
+        if self.num_wires != All and self.num_wires != Any and len(wires) != self.num_wires:
             raise ValueError("{}: wrong number of wires. "
                              "{} wires given, {} expected.".format(self.name, len(wires), self.num_wires))
 

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -65,7 +65,7 @@ from .qubit import __all__ as _qubit__all__
 from .qubit import ops as _qubit__ops__
 from .qubit import obs as _qubit__obs__
 
-from pennylane.operation import Observable, CVObservable
+from pennylane.operation import All, Any, Observable, CVObservable
 
 
 class Identity(CVObservable, Observable):
@@ -80,7 +80,7 @@ class Identity(CVObservable, Observable):
     corresponds to the trace of the quantum state, which in exact
     simulators should always be equal to 1.
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 0
     par_domain = None
     grad_method = None

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -56,6 +56,7 @@ Observables that can be used on both qubit and CV devices.
 from .cv import *
 from .qubit import *
 
+from pennylane.operation import Any, Observable, CVObservable
 
 from .cv import __all__ as _cv__all__
 from .cv import ops as _cv__ops__
@@ -64,8 +65,6 @@ from .cv import obs as _cv__obs__
 from .qubit import __all__ as _qubit__all__
 from .qubit import ops as _qubit__ops__
 from .qubit import obs as _qubit__obs__
-
-from pennylane.operation import All, Any, Observable, CVObservable
 
 
 class Identity(CVObservable, Observable):

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -53,10 +53,10 @@ Observables that can be used on both qubit and CV devices.
 """
 #pylint: disable=too-few-public-methods,function-redefined
 
+from pennylane.operation import Any, Observable, CVObservable
+
 from .cv import *
 from .qubit import *
-
-from pennylane.operation import Any, Observable, CVObservable
 
 from .cv import __all__ as _cv__all__
 from .cv import ops as _cv__ops__

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -91,7 +91,7 @@ Code details
 import numpy as np
 from scipy.linalg import block_diag
 
-from pennylane.operation import CVOperation, CVObservable
+from pennylane.operation import All, Any, CVOperation, CVObservable
 
 
 def _rotation(phi, bare=False):
@@ -567,9 +567,9 @@ class Interferometer(CVOperation):
 
     **Details:**
 
-    * None (applied to the entire subsystem)
+    * Number of wires: Any
     * Number of parameters: 1
-    * Gradient recipe: None (uses finite difference)
+    * Gradient recipe: None
     * Heisenberg representation:
 
       .. math:: M = \begin{bmatrix}
@@ -584,7 +584,7 @@ class Interferometer(CVOperation):
         wires (Sequence[int] or int): the wires the operation acts on
     """
     num_params = 1
-    num_wires = 0
+    num_wires = Any
     par_domain = "A"
     grad_method = None
     grad_recipe = None
@@ -709,16 +709,16 @@ class GaussianState(CVOperation):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire subsystem)
+    * Number of wires: Any
     * Number of parameters: 1
-    * Gradient recipe: None (uses finite difference)
+    * Gradient recipe: None
 
     Args:
         r (array): a length :math:`2N` vector of means, of the
             form :math:`(\x_0,\dots,\x_{N-1},\p_0,\dots,\p_{N-1})`
         V (array): the :math:`2N\times 2N` (real and positive definite) covariance matrix
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 2
     par_domain = "A"
     grad_method = "F"
@@ -750,7 +750,7 @@ class FockStateVector(CVOperation):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire subsystem)
+    * Number of wires: Any
     * Number of parameters: 1
     * Gradient recipe: None (uses finite difference)
 
@@ -758,7 +758,7 @@ class FockStateVector(CVOperation):
         state (array): a single ket vector, for single mode state preparation,
             or a multimode ket, with one array dimension per mode
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 1
     par_domain = "A"
     grad_method = "F"
@@ -770,7 +770,7 @@ class FockDensityMatrix(CVOperation):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire subsystem)
+    * Number of wires: Any
     * Number of parameters: 1
     * Gradient recipe: None (uses finite difference)
 
@@ -778,7 +778,7 @@ class FockDensityMatrix(CVOperation):
         state (array): a single mode matrix :math:`\rho_{ij}`, or
             a multimode tensor :math:`\rho_{ij,kl,\dots,mn}`, with two indices per mode
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 1
     par_domain = "A"
     grad_method = "F"
@@ -973,7 +973,7 @@ class PolyXP(CVObservable):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire system)
+    * Number of wires: Any
     * Number of parameters: 1
     * Observable order: 2nd order in the quadrature operators
     * Heisenberg representation: :math:`A`
@@ -981,7 +981,7 @@ class PolyXP(CVObservable):
     Args:
         q (array[float]): expansion coefficients
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 1
     par_domain = "A"
 
@@ -1021,7 +1021,7 @@ class FockStateProjector(CVObservable):
 
     **Details:**
 
-    * Number of wires: None (applied to any subset of wires)
+    * Number of wires: Any
     * Number of parameters: 1
     * Observable order: None (non-Gaussian)
 
@@ -1035,7 +1035,7 @@ class FockStateProjector(CVObservable):
             Note that ``len(n)==len(wires)``, and that ``len(n)`` cannot exceed the
             total number of wires in the QNode.
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 1
     par_domain = "A"
 

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -91,7 +91,7 @@ Code details
 import numpy as np
 from scipy.linalg import block_diag
 
-from pennylane.operation import All, Any, CVOperation, CVObservable
+from pennylane.operation import Any, CVOperation, CVObservable
 
 
 def _rotation(phi, bare=False):

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -490,13 +490,13 @@ class CRot(Operation):
 
 class QubitUnitary(Operation):
     r"""QubitUnitary(U, wires)
-    Apply an arbitrary unitary matrix
+    Apply an arbitrary fixed unitary matrix.
 
     **Details:**
 
-    * Number of wires: None (applied to the entire system)
+    * Number of wires: The operation can act on any number of wires.
     * Number of parameters: 1
-    * Gradient recipe: None (uses finite difference)
+    * Gradient recipe: None
 
     Args:
         U (array[complex]): square unitary matrix
@@ -505,7 +505,7 @@ class QubitUnitary(Operation):
     num_params = 1
     num_wires = 0
     par_domain = "A"
-    grad_method = "F"
+    grad_method = None
 
 
 # =============================================================================
@@ -543,7 +543,7 @@ class QubitStateVector(Operation):
 
     * Number of wires: None (applied to the entire system)
     * Number of parameters: 1
-    * Gradient recipe: None (uses finite difference)
+    * Gradient recipe: None
 
     Args:
         state (array[complex]): a state vector of size 2**len(wires)
@@ -552,7 +552,7 @@ class QubitStateVector(Operation):
     num_params = 1
     num_wires = 0
     par_domain = "A"
-    grad_method = "F"
+    grad_method = None
 
 
 # =============================================================================

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -530,7 +530,7 @@ class BasisState(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = All
+    num_wires = Any
     par_domain = "A"
     grad_method = None
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -71,7 +71,7 @@ Code details
 ~~~~~~~~~~~~
 """
 
-from pennylane.operation import Observable, Operation
+from pennylane.operation import All, Any, Observable, Operation
 
 
 class Hadamard(Observable, Operation):
@@ -503,7 +503,7 @@ class QubitUnitary(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = 0
+    num_wires = Any
     par_domain = "A"
     grad_method = None
 
@@ -519,7 +519,7 @@ class BasisState(Operation):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire system)
+    * Number of wires: All (applied to the entire system)
     * Number of parameters: 1
     * Gradient recipe: None (integer parameters not supported)
 
@@ -530,7 +530,7 @@ class BasisState(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = 0
+    num_wires = All
     par_domain = "A"
     grad_method = None
 
@@ -541,7 +541,7 @@ class QubitStateVector(Operation):
 
     **Details:**
 
-    * Number of wires: None (applied to the entire system)
+    * Number of wires: All (applied to the entire system)
     * Number of parameters: 1
     * Gradient recipe: None
 
@@ -550,7 +550,7 @@ class QubitStateVector(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = 0
+    num_wires = All
     par_domain = "A"
     grad_method = None
 
@@ -574,11 +574,17 @@ class Hermitian(Observable):
     If acting on :math:`N` wires, then the matrix :math:`A` must be of size
     :math:`2^N\times 2^N`.
 
+    **Details:**
+
+    * Number of wires: Any
+    * Number of parameters: 1
+    * Gradient recipe: None
+
     Args:
         A (array): square hermitian matrix
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
-    num_wires = 0
+    num_wires = Any
     num_params = 1
     par_domain = "A"
     grad_method = "F"

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -556,7 +556,7 @@ def set_state(state, wire, mu, cov):
 #========================================================
 
 
-def photon_number(mu, cov, wires, params, hbar=2.):
+def photon_number(mu, cov, wires, params, hbar=2., **kwargs):
     r"""Calculates the mean photon number for a given one-mode state.
 
     Args:
@@ -588,7 +588,7 @@ def homodyne(phi=None):
         value and variance.
     """
     if phi is not None:
-        def _homodyne(mu, cov, wires, params, hbar=2.):
+        def _homodyne(mu, cov, wires, params, hbar=2., **kwargs):
             """Arbitrary angle homodyne expectation."""
             # pylint: disable=unused-argument
             rot = rotation(phi)
@@ -597,7 +597,7 @@ def homodyne(phi=None):
             return muphi[0], covphi[0, 0]
         return _homodyne
 
-    def _homodyne(mu, cov, wires, params, hbar=2.):
+    def _homodyne(mu, cov, wires, params, hbar=2., **kwargs):
         """Arbitrary angle homodyne expectation."""
         # pylint: disable=unused-argument
         rot = rotation(params[0])
@@ -607,29 +607,29 @@ def homodyne(phi=None):
     return _homodyne
 
 
-def poly_quad_expectations(mu, cov, wires, params, hbar=2.):
+def poly_quad_expectations(mu, cov, wires, params, hbar=2., total_wires=None):
     r"""Calculates the expectation and variance for an arbitrary
     polynomial of quadrature operators.
 
     Args:
-        mu (array): length-2 vector of means
-        cov (array): :math:`2\times 2` covariance matrix
+        mu (array): vector of means
+        cov (array): covariance matrix
         wires (Sequence[int]): wires to calculate the expectation for
         params (array): a :math:`(2N+1)\times (2N+1)` array containing the linear
             and quadratic coefficients of the quadrature operators
             :math:`(\I, \x_0, \p_0, \x_1, \p_1,\dots)`
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
+        total_wires (int): total number of wires in the system
 
     Returns:
         tuple: the mean and variance of the quadrature-polynomial observable
     """
     Q = params[0]
-    N = len(mu)//2
 
     # HACK, we need access to the Poly instance in order to expand the matrix!
     op = qml.ops.PolyXP(Q, wires=wires, do_queue=False)
-    Q = op.heisenberg_obs(N)
+    Q = op.heisenberg_obs(total_wires)
 
     if Q.ndim == 1:
         d = np.r_[Q[1::2], Q[2::2]]
@@ -651,14 +651,14 @@ def poly_quad_expectations(mu, cov, wires, params, hbar=2.):
     ex = np.trace(A @ cov) + k2
     var = 2*np.trace(A @ cov @ A @ cov) + d2.T @ cov @ d2
 
-    modes = np.arange(2*N).reshape(2, -1).T
+    modes = np.arange(2*total_wires).reshape(2, -1).T
     groenewald_correction = np.sum([np.linalg.det(hbar*A[:, m][n]) for m in modes for n in modes])
     var -= groenewald_correction
 
     return ex, var
 
 
-def fock_expectation(mu, cov, wires, params, hbar=2.):
+def fock_expectation(mu, cov, wires, params, hbar=2., **kwargs):
     r"""Calculates the expectation and variance of a Fock state probability.
 
     Args:
@@ -814,9 +814,12 @@ class DefaultGaussian(Device):
         return S2
 
     def expval(self, observable, wires, par):
-        mu, cov = self.reduced_state(wires)
+        if observable == "PolyXP":
+            mu, cov = self._state
+        else:
+            mu, cov = self.reduced_state(wires)
 
-        ev, var = self._observable_map[observable](mu, cov, wires, par, hbar=self.hbar)
+        ev, var = self._observable_map[observable](mu, cov, wires, par, hbar=self.hbar, total_wires=self.num_wires)
 
         if self.shots != 0:
             # estimate the ev
@@ -828,7 +831,7 @@ class DefaultGaussian(Device):
 
     def var(self, observable, wires, par):
         mu, cov = self.reduced_state(wires)
-        _, var = self._observable_map[observable](mu, cov, wires, par, hbar=self.hbar)
+        _, var = self._observable_map[observable](mu, cov, wires, par, hbar=self.hbar, total_wires=self.num_wires)
         return var
 
     def sample(self, observable, wires, par, n=None):

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -556,7 +556,7 @@ def set_state(state, wire, mu, cov):
 #========================================================
 
 
-def photon_number(mu, cov, wires, params, hbar=2., **kwargs):
+def photon_number(mu, cov, wires, params, total_wires, hbar=2.):
     r"""Calculates the mean photon number for a given one-mode state.
 
     Args:
@@ -564,6 +564,7 @@ def photon_number(mu, cov, wires, params, hbar=2., **kwargs):
         cov (array): :math:`2\times 2` covariance matrix
         wires (Sequence[int]): wires to calculate the expectation for
         params (None): no parameters are used for this expectation value
+        total_wires (int): total number of wires in the system
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
 
@@ -588,7 +589,7 @@ def homodyne(phi=None):
         value and variance.
     """
     if phi is not None:
-        def _homodyne(mu, cov, wires, params, hbar=2., **kwargs):
+        def _homodyne(mu, cov, wires, params, total_wires, hbar=2.):
             """Arbitrary angle homodyne expectation."""
             # pylint: disable=unused-argument
             rot = rotation(phi)
@@ -597,7 +598,7 @@ def homodyne(phi=None):
             return muphi[0], covphi[0, 0]
         return _homodyne
 
-    def _homodyne(mu, cov, wires, params, hbar=2., **kwargs):
+    def _homodyne(mu, cov, wires, params, total_wires, hbar=2.):
         """Arbitrary angle homodyne expectation."""
         # pylint: disable=unused-argument
         rot = rotation(params[0])
@@ -607,7 +608,7 @@ def homodyne(phi=None):
     return _homodyne
 
 
-def poly_quad_expectations(mu, cov, wires, params, hbar=2., total_wires=None):
+def poly_quad_expectations(mu, cov, wires, params, total_wires, hbar=2.):
     r"""Calculates the expectation and variance for an arbitrary
     polynomial of quadrature operators.
 
@@ -618,9 +619,9 @@ def poly_quad_expectations(mu, cov, wires, params, hbar=2., total_wires=None):
         params (array): a :math:`(2N+1)\times (2N+1)` array containing the linear
             and quadratic coefficients of the quadrature operators
             :math:`(\I, \x_0, \p_0, \x_1, \p_1,\dots)`
+        total_wires (int): total number of wires in the system
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
-        total_wires (int): total number of wires in the system
 
     Returns:
         tuple: the mean and variance of the quadrature-polynomial observable
@@ -658,7 +659,7 @@ def poly_quad_expectations(mu, cov, wires, params, hbar=2., total_wires=None):
     return ex, var
 
 
-def fock_expectation(mu, cov, wires, params, hbar=2., **kwargs):
+def fock_expectation(mu, cov, wires, params, total_wires, hbar=2.):
     r"""Calculates the expectation and variance of a Fock state probability.
 
     Args:
@@ -666,6 +667,7 @@ def fock_expectation(mu, cov, wires, params, hbar=2., **kwargs):
         cov (array): :math:`2N\times 2N` covariance matrix
         wires (Sequence[int]): wires to calculate the expectation for
         params (Sequence[int]): the Fock state to return the expectation value for
+        total_wires (int): total number of wires in the system
         hbar (float): (default 2) the value of :math:`\hbar` in the commutation
             relation :math:`[\x,\p]=i\hbar`
 
@@ -819,7 +821,7 @@ class DefaultGaussian(Device):
         else:
             mu, cov = self.reduced_state(wires)
 
-        ev, var = self._observable_map[observable](mu, cov, wires, par, hbar=self.hbar, total_wires=self.num_wires)
+        ev, var = self._observable_map[observable](mu, cov, wires, par, self.num_wires, hbar=self.hbar)
 
         if self.shots != 0:
             # estimate the ev

--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -87,7 +87,7 @@ Classes
 Code details
 ^^^^^^^^^^^^
 """
-# pylint: disable=attribute-defined-outside-init
+# pylint: disable=attribute-defined-outside-init,too-many-arguments
 import numpy as np
 
 from scipy.special import factorial as fac

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -193,7 +193,7 @@ def CRotx(theta):
     Args:
         theta (float): rotation angle
     Returns:
-        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I} + |1\rangle\langle 1|\otimes R_x(\theta)`
+        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I}+|1\rangle\langle 1|\otimes R_x(\theta)`
     """
     return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.cos(theta/2), -1j*np.sin(theta/2)], [0, 0, -1j*np.sin(theta/2), np.cos(theta/2)]])
 
@@ -204,7 +204,7 @@ def CRoty(theta):
     Args:
         theta (float): rotation angle
     Returns:
-        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I} + |1\rangle\langle 1|\otimes R_y(\theta)`
+        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I}+|1\rangle\langle 1|\otimes R_y(\theta)`
     """
     return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.cos(theta/2), -np.sin(theta/2)], [0, 0, np.sin(theta/2), np.cos(theta/2)]])
 
@@ -215,7 +215,7 @@ def CRotz(theta):
     Args:
         theta (float): rotation angle
     Returns:
-        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I} + |1\rangle\langle 1|\otimes R_z(\theta)`
+        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I}+|1\rangle\langle 1|\otimes R_z(\theta)`
     """
     return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(-1j*theta/2), 0], [0, 0, 0, np.exp(1j*theta/2)]])
 
@@ -226,7 +226,7 @@ def CRot3(a, b, c):
     Args:
         a,b,c (float): rotation angles
     Returns:
-        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I} + |1\rangle\langle 1|\otimes R(a,b,c)`
+        array: unitary 4x4 rotation matrix :math:`|0\rangle\langle 0|\otimes \mathbb{I}+|1\rangle\langle 1|\otimes R(a,b,c)`
     """
     return np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(-1j*(a+c)/2)*np.cos(b/2), -np.exp(1j*(a-c)/2)*np.sin(b/2)], [0, 0, np.exp(-1j*(a-c)/2)*np.sin(b/2), np.exp(1j*(a+c)/2)*np.cos(b/2)]])
 
@@ -351,6 +351,8 @@ class DefaultQubit(Device):
                 self._state = state
             else:
                 raise ValueError('State vector must be of length 2**wires.')
+            if wires is not None and wires != [] and list(wires) != list(range(self.num_wires)):
+                raise ValueError("The default.qubit plugin can apply QubitStateVector only to all of the {} wires.".format(self.num_wires))
             return
         if operation == 'BasisState':
             n = len(par[0])

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -75,7 +75,7 @@ class TestExceptions(BaseTest):
         @qml.qnode(dev)
         def circuit():
             return qml.sample(qml.NumberOperator(0), 10)
-        
+
         with self.assertRaisesRegex(NotImplementedError, "Sampling is not supported in default.gaussian"):
             res = circuit()
 
@@ -567,8 +567,8 @@ class TestDefaultGaussianIntegration(BaseTest):
         for g in all_gates - gates:
             op = getattr(qml.ops, g)
 
-            if op.num_wires == 0:
-                wires = [0]
+            if op.num_wires <= 0:
+                wires = list(range(2))
             else:
                 wires = list(range(op.num_wires))
 
@@ -598,8 +598,8 @@ class TestDefaultGaussianIntegration(BaseTest):
         for g in all_obs - obs:
             op = getattr(qml.ops, g)
 
-            if op.num_wires == 0:
-                wires = [0]
+            if op.num_wires <= 0:
+                wires = list(range(2))
             else:
                 wires = list(range(op.num_wires))
 
@@ -677,7 +677,7 @@ class TestDefaultGaussianIntegration(BaseTest):
             dev.reset()
 
             op = getattr(qml.ops, g)
-            if op.num_wires == 0:
+            if op.num_wires <= 0:
                 wires = list(range(2))
             else:
                 wires = list(range(op.num_wires))

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -202,7 +202,7 @@ class TestAuxillaryFunctions(BaseTest):
         self.assertAllAlmostEqual(CRotx(0), np.identity(4), delta=self.tol)
 
         # test identity for theta=pi/2
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1/np.sqrt(2), -1j/np.sqrt(2)], [0, 0, -1j/np.sqrt(2), 1/np.sqrt(2)]]) 
+        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1/np.sqrt(2), -1j/np.sqrt(2)], [0, 0, -1j/np.sqrt(2), 1/np.sqrt(2)]])
         self.assertAllAlmostEqual(CRotx(np.pi / 2), expected, delta=self.tol)
 
         # test identity for theta=pi
@@ -217,7 +217,7 @@ class TestAuxillaryFunctions(BaseTest):
         self.assertAllAlmostEqual(CRoty(0), np.identity(4), delta=self.tol)
 
         # test identity for theta=pi/2
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1/np.sqrt(2), -1/np.sqrt(2)], [0, 0, 1/np.sqrt(2), 1/np.sqrt(2)]]) 
+        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1/np.sqrt(2), -1/np.sqrt(2)], [0, 0, 1/np.sqrt(2), 1/np.sqrt(2)]])
         self.assertAllAlmostEqual(CRoty(np.pi / 2), expected, delta=self.tol)
 
         # test identity for theta=pi
@@ -232,7 +232,7 @@ class TestAuxillaryFunctions(BaseTest):
         self.assertAllAlmostEqual(CRotz(0), np.identity(4), delta=self.tol)
 
         # test identity for theta=pi/2
-        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(-1j * np.pi / 4), 0], [0, 0, 0, np.exp(1j * np.pi / 4)]]) 
+        expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, np.exp(-1j * np.pi / 4), 0], [0, 0, 0, np.exp(1j * np.pi / 4)]])
         self.assertAllAlmostEqual(CRotz(np.pi / 2), expected, delta=self.tol)
 
         # test identity for theta=pi
@@ -547,9 +547,9 @@ class TestDefaultQubitDevice(BaseTest):
     def test_var_estimate(self):
         """Test that variance is not analytically calculated"""
         self.logTestName()
-        
+
         dev = qml.device('default.qubit', wires=1, shots=3)
-        
+
         @qml.qnode(dev)
         def circuit():
             return qml.var(qml.PauliX(0))
@@ -561,7 +561,7 @@ class TestDefaultQubitDevice(BaseTest):
         self.assertTrue(var != 1.0)
 
     def test_sample_dimensions(self):
-        """Tests if the samples returned by the sample function have 
+        """Tests if the samples returned by the sample function have
         the correct dimensions
         """
         self.logTestName()
@@ -588,7 +588,7 @@ class TestDefaultQubitDevice(BaseTest):
 
         self.dev.apply('RX', wires=[0], par=[1.5708])
 
-        s1 = self.dev.sample('PauliZ', [0], [], 10)        
+        s1 = self.dev.sample('PauliZ', [0], [], 10)
 
         # s1 should only contain 1 and -1, which is guaranteed if
         # they square to 1
@@ -604,7 +604,7 @@ class TestDefaultQubitDevice(BaseTest):
             ValueError, "Calling sample with n = 0 is not possible."
         ):
             self.dev.sample('PauliZ', [0], [], n = 0)
-            
+
         # self.def.shots = 0, so this should also fail
         with self.assertRaisesRegex(
             ValueError, "Calling sample with n = 0 is not possible."
@@ -622,7 +622,7 @@ class TestDefaultQubitDevice(BaseTest):
             ValueError, "The number of samples must be a positive integer."
         ):
             self.dev.sample('PauliZ', [0], [], n = -12)
-            
+
         # self.def.shots = 0, so this should also fail
         with self.assertRaisesRegex(
             ValueError, "The number of samples must be a positive integer."
@@ -784,7 +784,7 @@ class TestDefaultQubitIntegration(BaseTest):
 
             op = getattr(qml.ops, g)
             if op.num_wires == 0:
-                if g == "BasisState":
+                if g == "BasisState" or g == "QubitStateVector":
                     wires = [0, 1]
                 else:
                     wires = [0]

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -480,14 +480,14 @@ class TestDefaultQubitDevice(BaseTest):
                 O = fn
 
             # calculate the expected output
-            if op.num_wires == 1 or op.num_wires == 0:
+            if op.num_wires == 1 or op.num_wires <= 0:
                 expected_out = self.dev._state.conj() @ np.kron(O, I) @ self.dev._state
             elif op.num_wires == 2:
                 expected_out = self.dev._state.conj() @ O @ self.dev._state
             else:
                 raise NotImplementedError(
                     "Test for operations with num_wires="
-                    + op.num_wires
+                    + str(op.num_wires)
                     + " not implemented."
                 )
 
@@ -783,7 +783,7 @@ class TestDefaultQubitIntegration(BaseTest):
             dev.reset()
 
             op = getattr(qml.ops, g)
-            if op.num_wires == 0:
+            if op.num_wires <= 0:
                 if g == "BasisState" or g == "QubitStateVector":
                     wires = [0, 1]
                 else:
@@ -847,7 +847,7 @@ class TestDefaultQubitIntegration(BaseTest):
             dev.reset()
 
             op = getattr(qml.ops, g)
-            if op.num_wires == 0:
+            if op.num_wires <= 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -847,7 +847,7 @@ class TestDefaultQubitIntegration(BaseTest):
             dev.reset()
 
             op = getattr(qml.ops, g)
-            if op.num_wires <= 0:
+            if op.num_wires < 0:
                 wires = [0]
             else:
                 wires = list(range(op.num_wires))

--- a/tests/test_quantum_gradients.py
+++ b/tests/test_quantum_gradients.py
@@ -304,7 +304,7 @@ class CVGradientTest(BaseTest):
                 U = np.array([[0.51310276+0.81702166j, 0.13649626+0.22487759j],
                               [0.26300233+0.00556194j, -0.96414101-0.03508489j]])
 
-                if cls.num_wires == 0:
+                if cls.num_wires <= 0:
                     w = list(range(2))
                 else:
                     w = list(range(cls.num_wires))
@@ -533,7 +533,7 @@ class QubitGradientTest(BaseTest):
             return qml.sample(qml.PauliZ(0), 1), qml.sample(qml.PauliX(1), 1)
 
         with self.assertRaisesRegex(
-            qml.QuantumFunctionError, 
+            qml.QuantumFunctionError,
             "Circuits that include sampling can not be differentiated."
         ):
             grad_fn = autograd.jacobian(circuit)


### PR DESCRIPTION
**Context:**

All PennyLane operations must specify the required class attribute `num_wires` so that PennyLane knows how many wires it should apply to, and perform automatic validation.  This works fine for operations with a specific fixed number of wires (i.e., PauliX, CNOT, TwoModeSqueezing). However, it has led to confusion for operations that can correspond to _any_ number of wires in the system, or that must be restricted to _all_ wires in the system.

As a stop gap, we have been using `num_wires = 0` to represent both 'all' wires *and* 'any' wires, which has led to even more confusion.

**Description of the Change:**

This PR makes several improvements to address the past confusion.

* Introduces two enumerations: `Any` and `All`, representing any number of wires and all wires in the system respectively. They can be imported from `pennylane.operation`.

* `All` is equivalent to the integer 0, for backwards compatibility with the existing test suite

* `Any` is equivalent to the integer -1 (this requires some modification in the existing test suite)

* The additional validation is now added to the `Operation` class,

  ```python

  if self.num_wires == All:
      if do_queue:
          if set(wires) != set(range(QNode._current_context.num_wires)):
              raise ValueError("Operation {} must act on all wires".format(self.name))
  ```

  which will alert the user that an operation with `num_wires = All` is being incorrectly. Previously, this would fail later in the code with a more obfuscated message. No additional validation is required for `num_wires = Any`.

The reason for choosing enumerations rather than strings:

* They can be used in a similar manner to `None` (i.e., `op.num_wires is All`), while being more descriptive and explicit.

* The ability to associate each enumerated value with an integer is appealing (`op.num_wires == 0`), and helps with backwards compatibility

* If the user prints `op.num_wires`, they get more descriptive output than just using 0 or -1:

  ```python
  >>> print(qml.QubitStateVector.num_wires)
  Wires.All
  ```

* Typos such as `all` or `Alll` instead of `All` will be caught by the Python interpreter raising a `NameError`. Using strings, bugs like this would go unnoticed, and require much more validation.

**Benefits:**

* Removes confusion from the codebase and documentation regarding operations that apply to any or all wires.

* Fixes an adjacent bug, where `PolyXP` didn't work if applied to subsets of wires for `default.gaussian` (this worked using PennyLane-SF, and should have worked according to the PolyXP docstring). Thanks @AroosaIjaz!

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #268  #255 #269 
