### PR TITLE
Refactor test_device.py to pytest

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### Breaking changes
 
 * The method `Device.supported` was removed.
+  [#276](https://github.com/XanaduAI/pennylane/pull/276)
 
 * The following CV observables were renamed to comply with the new Operation/Observable
   scheme: `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and `NumberState` to `FockStateProjector`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### New features since last release
 
+* The method `Device.supported` that listed all the supported operations and observables
+  was replaced with two separate methods `Device.supports_observable` and `Device.supports_operation`.
+  The methods can now be called with string arguments (`dev.supports_observable('PauliX')`) and with
+  class information arguments (`dev.supports_observable(qml.PauliX)`).
+
 * Sampling support: QNodes can now return a specified number of samples
   from a given observable via the top-level `pennylane.sample()` function.
   To support this on plugin devices, there is a new `Device.sample` method.
@@ -13,6 +18,8 @@
   [#251](https://github.com/XanaduAI/pennylane/pull/251)
 
 ### Breaking changes
+
+* The method `Device.supported` was removed.
 
 * The following CV observables were renamed to comply with the new Operation/Observable
   scheme: `MeanPhoton` to `NumberOperator`, `Homodyne` to `QuadOperator` and `NumberState` to `FockStateProjector`.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,7 @@
   was replaced with two separate methods `Device.supports_observable` and `Device.supports_operation`.
   The methods can now be called with string arguments (`dev.supports_observable('PauliX')`) and with
   class information arguments (`dev.supports_observable(qml.PauliX)`).
+  [#276](https://github.com/XanaduAI/pennylane/pull/276)
 
 * Sampling support: QNodes can now return a specified number of samples
   from a given observable via the top-level `pennylane.sample()` function.

--- a/doc/API/overview.rst
+++ b/doc/API/overview.rst
@@ -68,7 +68,7 @@ You must further tell PennyLane about the operations and observables that your d
 
     operations = {"CNOT", "PauliX"}
 
-  This is used to decide whether an operation is supported by your device in the default implementation of the public method :meth:`~.Device.supported`.
+  This is used to decide whether an operation is supported by your device in the default implementation of the public method :meth:`~.Device.supports_operation`.
 
 * :attr:`~.Device.observables`: set of the supported PennyLane observables as strings, e.g.,
 
@@ -76,7 +76,7 @@ You must further tell PennyLane about the operations and observables that your d
 
     observables = {"QuadOperator", "NumberOperator", "X", "P"}
 
-  This is used to decide whether an observable is supported by your device in the default implementation of the public method :meth:`~.Device.supported`.
+  This is used to decide whether an observable is supported by your device in the default implementation of the public method :meth:`~.Device.supports_observable`.
 
 * :attr:`~.Device._capabilities`: (optional) a dictionary containing information about the capabilities of the device. At the moment, only the key ``'model'`` is supported, which may return either ``'qubit'`` or ``'CV'``. Alternatively, you may use this class dictionary to return additional information to the user — this is accessible from the PennyLane frontend via the public method :meth:`~.Device.capabilities`.
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -316,7 +316,7 @@ class Device(abc.ABC):
             return operation.__name__ in self.operations
         if isinstance(operation, str):
             return operation in self.operations
-        
+
         raise ValueError("The given operation must either be a pennylane.Operation class or a string.")
 
     def supports_observable(self, observable):

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -310,7 +310,7 @@ class Device(abc.ABC):
             operation (Operation/string): operation to be checked
 
         Returns:
-            bool: True iff it is supported
+            bool: ``True`` iff supplied operation is supported
         """
         if isinstance(operation, type) and issubclass(operation, Operation):
             return operation.__name__ in self.operations

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -307,7 +307,7 @@ class Device(abc.ABC):
         """Checks if an operation is supported by this device.
 
         Args:
-            operation (Operation/string): operation to be checked
+            operation (Operation,str): operation to be checked
 
         Returns:
             bool: ``True`` iff supplied operation is supported
@@ -323,10 +323,10 @@ class Device(abc.ABC):
         """Checks if an observable is supported by this device.
 
         Args:
-            operation (Observable/string): observable to be checked
+            operation (Observable,str): observable to be checked
 
         Returns:
-            bool: True iff it is supported
+            bool: ``True`` iff supplied observable is supported
         """
         if isinstance(observable, type) and issubclass(observable, Observable):
             return observable.__name__ in self.observables

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -90,7 +90,6 @@ Code details
 import abc
 
 import autograd.numpy as np
-import pennylane as qml
 from pennylane.operation import Operation, Observable
 
 
@@ -333,7 +332,7 @@ class Device(abc.ABC):
             return observable.__name__ in self.observables
         if isinstance(observable, str):
             return observable in self.observables
-        
+
         raise ValueError("The given operation must either be a pennylane.Observable class or a string.")
 
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -39,7 +39,8 @@ user interface:
 .. autosummary::
     short_name
     capabilities
-    supported
+    supports_operation
+    supports_observable
     execute
     reset
 
@@ -302,17 +303,6 @@ class Device(abc.ABC):
                 pass
 
         return MockContext()
-
-    def supported(self, name):
-        """Checks if an operation or observable is supported by this device.
-
-        Args:
-            name (str): name of the operation or observable
-
-        Returns:
-            bool: True iff it is supported
-        """
-        return name in self.operations.union(self.observables)
 
     def supports_operation(self, operation):
         """Checks if an operation is supported by this device.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -89,6 +89,8 @@ Code details
 import abc
 
 import autograd.numpy as np
+import pennylane as qml
+from pennylane.operation import Operation, Observable
 
 
 class DeviceError(Exception):
@@ -311,6 +313,39 @@ class Device(abc.ABC):
             bool: True iff it is supported
         """
         return name in self.operations.union(self.observables)
+
+    def supports_operation(self, operation):
+        """Checks if an operation is supported by this device.
+
+        Args:
+            operation (Operation/string): operation to be checked
+
+        Returns:
+            bool: True iff it is supported
+        """
+        if isinstance(operation, Operation):
+            return operation.name in self.operations
+        if isinstance(operation, str):
+            return operation in self.operations
+        
+        raise ValueError("The given operation must either be an instance of pennylane.Operation or a string.")
+
+    def supports_observable(self, observable):
+        """Checks if an observable is supported by this device.
+
+        Args:
+            operation (Observable/string): observable to be checked
+
+        Returns:
+            bool: True iff it is supported
+        """
+        if isinstance(observable, Observable):
+            return observable.name in self.observables
+        if isinstance(observable, str):
+            return observable in self.observables
+        
+        raise ValueError("The given observable must either be an instance of pennylane.Observable or a string.")
+
 
     def check_validity(self, queue, observables):
         """Checks whether the operations and observables in queue are all supported by the device.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -323,12 +323,12 @@ class Device(abc.ABC):
         Returns:
             bool: True iff it is supported
         """
-        if isinstance(operation, Operation):
-            return operation.name in self.operations
+        if isinstance(operation, type) and issubclass(operation, Operation):
+            return operation.__name__ in self.operations
         if isinstance(operation, str):
             return operation in self.operations
         
-        raise ValueError("The given operation must either be an instance of pennylane.Operation or a string.")
+        raise ValueError("The given operation must either be a pennylane.Operation class or a string.")
 
     def supports_observable(self, observable):
         """Checks if an observable is supported by this device.
@@ -339,12 +339,12 @@ class Device(abc.ABC):
         Returns:
             bool: True iff it is supported
         """
-        if isinstance(observable, Observable):
-            return observable.name in self.observables
+        if isinstance(observable, type) and issubclass(observable, Observable):
+            return observable.__name__ in self.observables
         if isinstance(observable, str):
             return observable in self.observables
         
-        raise ValueError("The given observable must either be an instance of pennylane.Observable or a string.")
+        raise ValueError("The given operation must either be a pennylane.Observable class or a string.")
 
 
     def check_validity(self, queue, observables):

--- a/tests/test_default_gaussian.py
+++ b/tests/test_default_gaussian.py
@@ -673,7 +673,7 @@ class TestDefaultGaussianIntegration(BaseTest):
 
         for g, qop in dev._operation_map.items():
             log.debug('\tTesting gate %s...', g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
             dev.reset()
 
             op = getattr(qml.ops, g)

--- a/tests/test_default_qubit.py
+++ b/tests/test_default_qubit.py
@@ -779,7 +779,7 @@ class TestDefaultQubitIntegration(BaseTest):
 
         for g, qop in dev._operation_map.items():
             log.debug("\tTesting gate %s...", g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_operation(g))
             dev.reset()
 
             op = getattr(qml.ops, g)
@@ -843,7 +843,7 @@ class TestDefaultQubitIntegration(BaseTest):
 
         for g, qop in dev._observable_map.items():
             log.debug("\tTesting observable %s...", g)
-            self.assertTrue(dev.supported(g))
+            self.assertTrue(dev.supports_observable(g))
             dev.reset()
 
             op = getattr(qml.ops, g)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -14,9 +14,9 @@
 """
 Unit tests for the :mod:`pennylane` :class:`Device` class.
 """
-import unittest
-from unittest.mock import DEFAULT, MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
+import pennylane as qml
 import pytest
 from pennylane import Device, DeviceError
 
@@ -73,7 +73,7 @@ class TestDeviceSupportedLogic:
     """Test the logic associated with the supported operations and observables"""
 
     def test_supports_operation_argument_types(self, mock_device_with_operations):
-        """Checks that device.supports_operations returns the correct result 
+        """Checks that device.supports_operations returns the correct result
            when passed both string and Operation class arguments"""
 
         assert mock_device_with_operations.supports_operation("PauliX")
@@ -83,7 +83,7 @@ class TestDeviceSupportedLogic:
         assert not mock_device_with_operations.supports_operation(qml.PauliY)
 
     def test_supports_observable_argument_types(self, mock_device_with_observables):
-        """Checks that device.supports_observable returns the correct result 
+        """Checks that device.supports_observable returns the correct result
            when passed both string and Operation class arguments"""
 
         assert mock_device_with_observables.supports_observable("PauliX")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -71,8 +71,8 @@ class DeviceTest(BaseTest):
 
     @patch.multiple(Device, __abstractmethods__=set(), operations=PropertyMock(return_value=['PauliX']))
     def test_supports_operation_argument_types(self):
-        """check that a the different argument types for the function
-           device.supports_operation are supported"""
+        """Checks that device.supports_operations returns the correct result 
+           when passed both string and Operation class arguments"""
         self.logTestName()
 
         mock_device = Device()
@@ -82,8 +82,8 @@ class DeviceTest(BaseTest):
 
     @patch.multiple(Device, __abstractmethods__=set(), observables=PropertyMock(return_value=['PauliX']))
     def test_supports_observable_argument_types(self):
-        """check that a the different argument types for the function
-           device.supports_observable are supported"""
+        """Checks that device.supports_observable returns the correct result 
+           when passed both string and Operation class arguments"""
         self.logTestName()
 
         mock_device = Device()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -238,7 +238,7 @@ class DeviceTest(BaseTest):
                 expval = dev.execute(queue, [qml.expval(qml.PauliX(0, do_queue=False))])
 
             self.assertTrue(isinstance(expval, np.ndarray))
-            
+
     def test_sample_attribute_error(self):
         """Check that an error is raised if a required attribute
            is not present in a sampled observable"""
@@ -249,7 +249,7 @@ class DeviceTest(BaseTest):
         queue = [qml.RX(0.543, wires=[0], do_queue=False)]
 
         # Make a sampling observable but delete its num_samples attribute
-        obs = qml.sample(qml.PauliZ(0, do_queue=False), n = 10)
+        obs = qml.sample(qml.PauliZ(0, do_queue=False), n=10)
         del obs.num_samples
         obs = [obs]
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,7 +15,7 @@
 Unit tests for the :mod:`pennylane` :class:`Device` class.
 """
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 import inspect
 import logging as log
 log.getLogger('defaults')
@@ -25,6 +25,7 @@ from autograd import numpy as np
 
 from defaults import pennylane as qml, BaseTest
 from pennylane.plugins import DefaultQubit
+from pennylane import Device
 
 
 class DeviceTest(BaseTest):
@@ -67,44 +68,56 @@ class DeviceTest(BaseTest):
 
             for obs in exps:
                 self.assertTrue(dev.supports_observable(obs))
-    
+
+    @patch.multiple(Device, __abstractmethods__=set(), operations=PropertyMock(return_value=['PauliX']))
     def test_supports_operation_argument_types(self):
         """check that a the different argument types for the function
            device.supports_operation are supported"""
         self.logTestName()
 
-        self.assertTrue(self.dev['default.qubit'].supports_operation('PauliX'))
-        self.assertTrue(self.dev['default.qubit'].supports_operation(qml.PauliX))
-    
+        mock_device = Device()
+
+        self.assertTrue(mock_device.supports_operation('PauliX'))
+        self.assertTrue(mock_device.supports_operation(qml.PauliX))
+
+    @patch.multiple(Device, __abstractmethods__=set(), observables=PropertyMock(return_value=['PauliX']))
     def test_supports_observable_argument_types(self):
         """check that a the different argument types for the function
            device.supports_observable are supported"""
         self.logTestName()
 
-        self.assertTrue(self.dev['default.qubit'].supports_observable('PauliX'))
-        self.assertTrue(self.dev['default.qubit'].supports_observable(qml.PauliX))
-    
+        mock_device = Device()
+
+        self.assertTrue(mock_device.supports_observable('PauliX'))
+        self.assertTrue(mock_device.supports_observable(qml.PauliX))
+
+    @patch.multiple(Device, __abstractmethods__=set())
     def test_supports_operation_exception(self):
         """check that a the function device.supports_operation raises proper errors
            if the argument is of the wrong type"""
         self.logTestName()
 
-        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Operation class or a string."):
-            self.dev['default.qubit'].supports_operation(3)
+        mock_device = Device()
 
         with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Operation class or a string."):
-            self.dev['default.qubit'].supports_operation(qml.Device)
-    
+            mock_device.supports_operation(3)
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Operation class or a string."):
+            mock_device.supports_operation(Device)
+
+    @patch.multiple(Device, __abstractmethods__=set())
     def test_supports_observable_exception(self):
         """check that a the function device.supports_observable raises proper errors
            if the argument is of the wrong type"""
         self.logTestName()
 
-        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Observable class or a string."):
-            self.dev['default.qubit'].supports_observable(3)
+        mock_device = Device()
 
         with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Observable class or a string."):
-            self.dev['default.qubit'].supports_observable(qml.Device)
+            mock_device.supports_observable(3)
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Observable class or a string."):
+            mock_device.supports_observable(qml.CNOT)
 
     def test_check_validity(self):
         """test that the check_validity method correctly

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -67,6 +67,44 @@ class DeviceTest(BaseTest):
 
             for obs in exps:
                 self.assertTrue(dev.supports_observable(obs))
+    
+    def test_supports_operation_argument_types(self):
+        """check that a the different argument types for the function
+           device.supports_operation are supported"""
+        self.logTestName()
+
+        self.assertTrue(self.dev['default.qubit'].supports_operation('PauliX'))
+        self.assertTrue(self.dev['default.qubit'].supports_operation(qml.PauliX))
+    
+    def test_supports_observable_argument_types(self):
+        """check that a the different argument types for the function
+           device.supports_observable are supported"""
+        self.logTestName()
+
+        self.assertTrue(self.dev['default.qubit'].supports_observable('PauliX'))
+        self.assertTrue(self.dev['default.qubit'].supports_observable(qml.PauliX))
+    
+    def test_supports_operation_exception(self):
+        """check that a the function device.supports_operation raises proper errors
+           if the argument is of the wrong type"""
+        self.logTestName()
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Operation class or a string."):
+            self.dev['default.qubit'].supports_operation(3)
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Operation class or a string."):
+            self.dev['default.qubit'].supports_operation(qml.Device)
+    
+    def test_supports_observable_exception(self):
+        """check that a the function device.supports_observable raises proper errors
+           if the argument is of the wrong type"""
+        self.logTestName()
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Observable class or a string."):
+            self.dev['default.qubit'].supports_observable(3)
+
+        with self.assertRaisesRegex(ValueError, "The given operation must either be a pennylane.Observable class or a string."):
+            self.dev['default.qubit'].supports_observable(qml.Device)
 
     def test_check_validity(self):
         """test that the check_validity method correctly

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -62,8 +62,11 @@ class DeviceTest(BaseTest):
             self.assertTrue(len(ops) > 0)
             self.assertTrue(len(exps) > 0)
 
-            for op in ops.union(exps):
-                self.assertTrue(dev.supported(op))
+            for op in ops:
+                self.assertTrue(dev.supports_operation(op))
+
+            for obs in exps:
+                self.assertTrue(dev.supports_observable(obs))
 
     def test_check_validity(self):
         """test that the check_validity method correctly


### PR DESCRIPTION
**Description of the Change:**
Refactor the test of the abstract `Device` class from unittest to pytest. On the way, all dependencies on `default.qubit` and `default.gaussian` where replaced with appropriate Mock instances of `Device`.
Also some tests that were basically tests of `default.qubit` and `default.gaussian` were removed, as well as the extensive loop tests.

**Benefits:**
* Uses the better pytest framework
* No more dependence on `default.qubit` and `default.gaussian`
* No more loop tests

**Possible Drawbacks:**
* Extensive use of `unittest.mock`

**Related GitHub Issues:**
#99, #199 