### PR TITLE
Adds `Device.parameters` so that devices can access free parameter mappings

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -184,7 +184,7 @@ class Device(abc.ABC):
         """
         return cls._capabilities
 
-    def execute(self, queue, observables, parameters=None):
+    def execute(self, queue, observables, parameters):
         """Execute a queue of quantum operations on the device and then measure the given observables.
 
         For plugin developers: Instead of overwriting this, consider implementing a suitable subset of

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -183,7 +183,7 @@ class Device(abc.ABC):
         """
         return cls._capabilities
 
-    def execute(self, queue, observables):
+    def execute(self, queue, observables, parameters=None):
         """Execute a queue of quantum operations on the device and then measure the given observables.
 
         For plugin developers: Instead of overwriting this, consider implementing a suitable subset of
@@ -193,6 +193,10 @@ class Device(abc.ABC):
         Args:
             queue (Iterable[~.operation.Operation]): operations to execute on the device
             observables (Iterable[~.operation.Observable]): observables to measure and return
+            parameters (dict[int->list[(int, int)]]): Mapping from free parameter index to the list of
+                :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
+                The first element of the tuple is the index of the Operation in the program queue,
+                the second the index of the parameter within the Operation.
 
         Returns:
             array[float]: measured value(s)
@@ -200,6 +204,7 @@ class Device(abc.ABC):
         self.check_validity(queue, observables)
         self._op_queue = queue
         self._obs_queue = observables
+        self._parameters = parameters
 
         results = []
 
@@ -228,6 +233,7 @@ class Device(abc.ABC):
 
             self._op_queue = None
             self._obs_queue = None
+            self._parameters = None
 
             # Ensures that a combination with sample does not put
             # expvals and vars in superfluous arrays
@@ -265,6 +271,24 @@ class Device(abc.ABC):
         """
         if self._obs_queue is None:
             raise ValueError("Cannot access the observable value queue outside of the execution context!")
+
+        return self._obs_queue
+
+    @property
+    def parameters(self):
+        """Mapping from free parameter index to the list of
+        :class:`Operations <~.Operation>` in the device queue that depend on it.
+
+        Note that this property can only be accessed within the execution context
+        of :meth:`~.execute`.
+
+        Returns:
+            dict[int->list[(int, int)]]: the first element of the tuple is the index
+            of the Operation in the program queue, the second the index of the parameter
+            within the Operation.
+        """
+        if self._parameters is None:
+            raise ValueError("Cannot access the free parameter mapping outside of the execution context!")
 
         return self._obs_queue
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -120,6 +120,7 @@ class Device(abc.ABC):
 
         self._op_queue = None
         self._obs_queue = None
+        self._parameters = None
 
     def __repr__(self):
         """String representation."""
@@ -290,7 +291,7 @@ class Device(abc.ABC):
         if self._parameters is None:
             raise ValueError("Cannot access the free parameter mapping outside of the execution context!")
 
-        return self._obs_queue
+        return self._parameters
 
     def pre_apply(self):
         """Called during :meth:`execute` before the individual operations are executed."""

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -184,7 +184,7 @@ class Device(abc.ABC):
         """
         return cls._capabilities
 
-    def execute(self, queue, observables, parameters):
+    def execute(self, queue, observables, parameters={}):
         """Execute a queue of quantum operations on the device and then measure the given observables.
 
         For plugin developers: Instead of overwriting this, consider implementing a suitable subset of
@@ -205,7 +205,8 @@ class Device(abc.ABC):
         self.check_validity(queue, observables)
         self._op_queue = queue
         self._obs_queue = observables
-        self._parameters = parameters
+        self._parameters = {}
+        self._parameters.update(parameters)
 
         results = []
 

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -54,13 +54,17 @@ def about():
     """
     Prints the information for pennylane installation.
     """
-    plugin_devices = [entry.name for entry in iter_entry_points("pennylane.plugins")]
+    plugin_devices = iter_entry_points("pennylane.plugins")
     _internal.main(["show", "pennylane"])
-    print("Python Version:          {0}.{1}.{2}".format(*sys.version_info[0:3]))
-    print("Platform Info:           {}{}".format(platform.system(), platform.machine()))
-    print("Installed plugins:       {}".format(plugin_devices))
-    print("Numpy Version:           {}".format(numpy.__version__))
-    print("Scipy Version:           {}".format(scipy.__version__))
+    print("Python version:          {0}.{1}.{2}".format(*sys.version_info[0:3]))
+    print("Platform info:           {}{}".format(platform.system(), platform.machine()))
+    print("Numpy version:           {}".format(numpy.__version__))
+    print("Scipy version:           {}".format(scipy.__version__))
+
+    print("Installed devices:")
+
+    for d in plugin_devices:
+        print("- {} ({}-{})".format(d.name, d.dist.project_name, d.dist.version))
 
 
 if __name__ == "__main__":

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -593,7 +593,7 @@ class QNode:
         for op in self.ops:
             check_op(op)
 
-        ret = self.device.execute(self.queue, self.ev)
+        ret = self.device.execute(self.queue, self.ev, parameters=self.variable_ops)
         return self.output_conversion(ret)
 
     def evaluate_obs(self, obs, args, **kwargs):
@@ -618,7 +618,7 @@ class QNode:
         Variable.kwarg_values = keyword_values
 
         self.device.reset()
-        ret = self.device.execute(self.queue, obs)
+        ret = self.device.execute(self.queue, obs, parameters=self.variable_ops)
         return ret
 
     def jacobian(self, params, which=None, *, method='B', h=1e-7, order=1, **kwargs):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -593,7 +593,7 @@ class QNode:
         for op in self.ops:
             check_op(op)
 
-        ret = self.device.execute(self.queue, self.ev, parameters=self.variable_ops)
+        ret = self.device.execute(self.queue, self.ev, self.variable_ops)
         return self.output_conversion(ret)
 
     def evaluate_obs(self, obs, args, **kwargs):
@@ -618,7 +618,7 @@ class QNode:
         Variable.kwarg_values = keyword_values
 
         self.device.reset()
-        ret = self.device.execute(self.queue, obs, parameters=self.variable_ops)
+        ret = self.device.execute(self.queue, obs, self.variable_ops)
         return ret
 
     def jacobian(self, params, which=None, *, method='B', h=1e-7, order=1, **kwargs):

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -17,12 +17,18 @@ Unit tests for the :mod:`pennylane` configuration classe :class:`Configuration`.
 # pylint: disable=protected-access
 import pennylane
 import pytest
+import re
 
 
 def test_about(capfd):
-	"""
-	about: Tests if the about string prints correct.
-	"""
-	pennylane.about()
-	out, err = capfd.readouterr()
-	assert (type(out) == str)
+    """
+    about: Tests if the about string prints correct.
+    """
+    pennylane.about()
+    out, err = capfd.readouterr()
+    assert "Version:" in out
+    pl_version_match = re.search(r"Version:\s+([\S]+)\n", out).group(1)
+    assert pennylane.version().replace("-", ".") in pl_version_match
+    assert "Numpy version" in out
+    assert "Scipy version" in out
+    assert "Installed devices" in out

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -31,4 +31,5 @@ def test_about(capfd):
     assert pennylane.version().replace("-", ".") in pl_version_match
     assert "Numpy version" in out
     assert "Scipy version" in out
-    assert "Installed devices" in out
+    assert "default.qubit" in out
+    assert "default.gaussian" in out

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -26,7 +26,7 @@ from pennylane import Configuration
 log.getLogger('defaults')
 
 config_path = 'default_config.toml'
-    
+
 @pytest.fixture(scope="function")
 def default_config():
     return Configuration(name=config_path)
@@ -41,7 +41,7 @@ class TestConfigurationFileInteraction:
     def test_loading_current_directory(self, monkeypatch, default_config_toml):
         """Test that the default configuration file can be loaded
         from the current directory."""
-        
+
         monkeypatch.chdir(".")
         monkeypatch.setenv("PENNYLANE_CONF", "")
         config = Configuration(name=config_path)
@@ -76,12 +76,12 @@ class TestConfigurationFileInteraction:
 
     def test_not_found_warning(self, caplog):
         """Test that a warning is raised if no configuration file found."""
-        
+
         caplog.clear()
         caplog.set_level(log.INFO)
 
         Configuration("noconfig")
-        
+
         assert len(caplog.records) == 1
         assert caplog.records[0].message == "No PennyLane configuration file found."
 
@@ -146,7 +146,7 @@ class TestProperties:
         # test false if no config is loaded
         config = Configuration('noconfig')
 
-        assert not config   
+        assert not config
         assert default_config
 
 class TestPennyLaneInit:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -378,6 +378,63 @@ class TestObservables:
             mock_device_with_paulis_and_methods.execute(queue, observables)
 
 
+class TestParameters:
+    """Test for checking device parameter mappings"""
+
+    @pytest.fixture
+    def mock_device(self):
+        with patch.multiple(
+            Device,
+            __abstractmethods__=set(),
+            operations=PropertyMock(return_value=["PauliY", "RX", "Rot"]),
+            observables=PropertyMock(return_value=["PauliZ"]),
+            short_name=PropertyMock(return_value="MockDevice"),
+            expval=MagicMock(return_value=0),
+            var=MagicMock(return_value=0),
+            sample=MagicMock(return_value=[0]),
+            apply=MagicMock()
+        ):
+            yield Device()
+
+    def test_parameters_accessed_outside_execution_context(self, mock_device):
+        """Tests that a call to parameters outside the execution context raises the correct error"""
+
+        with pytest.raises(
+            ValueError,
+            match="Cannot access the free parameter mapping outside of the execution context!",
+        ):
+            mock_device.parameters
+
+    def test_parameters_available_at_pre_measure(self, mock_device):
+        """Tests that the parameter mapping is available when pre_measure is called and that accessing
+           Device.parameters raises no error"""
+
+
+        p0 = 0.54
+        p1 = -0.32
+
+        queue = [
+            qml.RX(p0, wires=0, do_queue=False),
+            qml.PauliY(wires=1, do_queue=False),
+            qml.Rot(0.432, 0.123, p1, wires=2, do_queue=False),
+        ]
+
+        parameters = {0: (0, 0), 1: (2, 3)}
+
+        observables = [
+            qml.expval(qml.PauliZ(0, do_queue=False)),
+            qml.var(qml.PauliZ(1, do_queue=False)),
+            qml.sample(qml.PauliZ(2, do_queue=False), 1),
+        ]
+
+        p_mapping = {}
+
+        with patch.object(Device, "pre_measure", lambda self: p_mapping.update(self.parameters)):
+            mock_device.execute(queue, observables, parameters=parameters)
+
+        assert p_mapping == parameters
+
+
 class TestDeviceInit:
     """Tests for device loader in __init__.py"""
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -381,7 +381,7 @@ class TestObservables:
 class TestParameters:
     """Test for checking device parameter mappings"""
 
-    @pytest.fixture
+    @pytest.fixture(scope="function")
     def mock_device(self):
         with patch.multiple(
             Device,


### PR DESCRIPTION
**Description of the Change:**

* Adds a `Device.parameters` property, so that devices can view the `QNode.variable_ops` dictionary mapping free parameters to operation parameters. This property acts similarly to `Device.op_queue` and `Device.obs_queue`.

* Bug fixes to `pennylane.about()`, and updates the test correspondingly

**Benefits:**

* Should be backwards compatible with existing plugins

* Plugins for frameworks which support parametric compilation will only need to re-compile the program when the parameter mapping changes, potentially leading to a significant speedup for users during optimization.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** #221
