### PR TITLE
Update changelog, and simplify PR and issue template

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### New features since last release
 
+* Adds a `Device.parameters` property, so that devices can view a dictionary mapping free
+  parameters to operation parameters. This will allow plugin devices to take advantage
+  of parametric compilation.
+  [#283](https://github.com/XanaduAI/pennylane/pull/283)
+
 * The method `Device.supported` that listed all the supported operations and observables
   was replaced with two separate methods `Device.supports_observable` and `Device.supports_operation`.
   The methods can now be called with string arguments (`dev.supports_observable('PauliX')`) and with
@@ -31,7 +36,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Aroosa Ijaz, Johannes Jakob Meyer.
+Aroosa Ijaz, Josh Izaac, Johannes Jakob Meyer.
 
 
 
@@ -81,7 +86,7 @@ Aroosa Ijaz, Johannes Jakob Meyer.
   - New random initialization functions supporting the templates available
     in the new submodule `pennylane.init`.
 
-  - Added a random circuit template (`RandomLayers()`), in which rotations and 2-qubit gates are randomly 
+  - Added a random circuit template (`RandomLayers()`), in which rotations and 2-qubit gates are randomly
     distributed over the wires
 
   - Add various embedding strategies

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,23 @@
 #### Before posting an issue
 
 Search existing GitHub issues to make sure the issue does not already exist:
-  https://github.com/xanaduai/pennylane/issues
+https://github.com/xanaduai/pennylane/issues
 
-If posting a PennyLane issue, delete everything above the dashed line, and fill in the template.
+If posting a PennyLane issue, delete everything above the dashed line, and fill
+in the template.
 
-If making a feature request, delete the following template and describe, in detail, the feature and why it is needed.
+If making a feature request, delete the following template and describe, in detail,
+the feature and why it is needed.
 
-For general technical details:
-* Check out our documentation: https://pennylane.readthedocs.io
+For general technical details. check out our documentation:
+https://pennylane.readthedocs.io
 
------------------------------------------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------------
 
 #### Issue description
 
-Description of the issue - include code snippets and screenshots here if relevant.
+Description of the issue - include code snippets and screenshots here
+if relevant. You may use the following template below
 
 * *Expected behavior:* (What you expect to happen)
 
@@ -22,39 +25,14 @@ Description of the issue - include code snippets and screenshots here if relevan
 
 * *Reproduces how often:* (What percentage of the time does it reproduce?)
 
-
-#### System information
-
-* **Operating system:**
-  Include the operating system version if you can, e.g., Ubuntu Linux 16.04
-
-
-* **PennyLane version:**
-  This can be found by running
-  python -c "import pennylane as sf; print(sf.version())"
-
-* **Python version:**
-  This can be found by running: python --version
-
-
-* **NumPy and SciPy versions:**
-  These can be found by running
-  python -c "import numpy as np; import scipy as sp; print(np.__version__,sp.__version__)"
-
-* **Installation method:**
-
-  Did you install PennyLane via pip, or directly from the GitHub repository source code?
-
-  If installed via GitHub, what branch/commit did you use? You can get this information by opening a terminal in the
-  PennyLane source code directory, and pasting the output of:
-  git log -n 1 --pretty=format:"%H%n%an%n%ad%n%s"
-
+* *System information:* (post the output of `import pennylane as qml; qml.about()`)
 
 #### Source code and tracebacks
 
-Please include any additional code snippets and error tracebacks related to the issue here.
-
+Please include any additional code snippets and error tracebacks related
+to the issue here.
 
 #### Additional information
 
-Any additional information, configuration or data that might be necessary to reproduce the issue.
+Any additional information, configuration or data that might be necessary
+to reproduce the issue.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,7 @@ in the template.
 If making a feature request, delete the following template and describe, in detail,
 the feature and why it is needed.
 
-For general technical details. check out our documentation:
+For general technical details check out our documentation:
 https://pennylane.readthedocs.io
 
 -------------------------------------------------------------------------------------------------------------

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,34 +1,32 @@
-### General guidelines
-
-* Do not make a pull request for minor typos/cosmetic code changes - make an issue instead.
-
 ### Before submitting
 
-Before submitting a pull request, please make sure the following is done:
+Please complete the following checklist when submitting a PR:
 
-* All new features must include a unit test.
-  If you've fixed a bug or added code that should be tested, add a test to the test directory!
+- [ ] All new features must include a unit test.
+      If you've fixed a bug or added code that should be tested, add a test to the
+      test directory!
 
-* All new functions and code must be clearly commented and documented.
-  Have a look through the source code at some of the existing function docstrings - the easiest
-  approach is to simply copy an existing docstring and modify it as appropriate.
-  If you do make documentation changes, make sure that the docs build and render correctly by running `make docs`.
+- [ ] All new functions and code must be clearly commented and documented.
+      If you do make documentation changes, make sure that the docs build and
+      render correctly by running `make docs`.
 
-* Ensure that the test suite passes, by running `make test`.
+- [ ] Ensure that the test suite passes, by running `make test`.
 
-* Make sure the modified code in the pull request conforms to the PEP8 coding standard.
-  The PennyLane source code conforms to PEP8 standards (https://www.python.org/dev/peps/pep-0008/).
-  We check all of our code against Pylint (https://www.pylint.org/). To lint modified files, simply
-  `pip install pylint`, and then from the source code directory, run `pylint pennylane/path/to/file.py`.
+- [ ] Add a new entry to the `.github/CHANGELOG.md` file, summarizing the
+      change, and including a link back to the PR.
 
-### Pull request template
+- [ ] The PennyLane source code conforms to
+      [PEP8 standards](https://www.python.org/dev/peps/pep-0008/).
+      We check all of our code against [Pylint](https://www.pylint.org/).
+      To lint modified files, simply `pip install pylint`, and then
+      run `pylint pennylane/path/to/file.py`.
 
-When ready to submit, delete everything above the dashed line and fill in the pull request template.
-
-Please include as much detail as possible regarding the changes made/new features
-added/performance improvements. If including any bug fixes, mention the issue numbers associated with the bugs.
+When all the above are checked, delete everything above the dashed
+line and fill in the pull request template.
 
 ------------------------------------------------------------------------------------------------------------
+
+**Context:**
 
 **Description of the Change:**
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install tensorflow==1.13.1 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
+- pip install tensorflow==1.14 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install tensorflow==1.14 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
+- pip install tensorflow==1.13.1 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/pennylane/about.py
+++ b/pennylane/about.py
@@ -56,8 +56,8 @@ def about():
     """
     plugin_devices = iter_entry_points("pennylane.plugins")
     _internal.main(["show", "pennylane"])
+    print("Platform info:           {}".format(platform.platform(aliased=True)))
     print("Python version:          {0}.{1}.{2}".format(*sys.version_info[0:3]))
-    print("Platform info:           {}{}".format(platform.system(), platform.machine()))
     print("Numpy version:           {}".format(numpy.__version__))
     print("Scipy version:           {}".format(scipy.__version__))
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from setuptools import setup
-# from sphinx.setup_command import BuildDoc
 
 with open("pennylane/_version.py") as f:
 	version = f.readlines()[-1].split()[-1].strip("\"'")
@@ -37,7 +36,7 @@ info = {
     'version': version,
     'maintainer': 'Xanadu Inc.',
     'maintainer_email': 'nathan@xanadu.ai',
-    'url': 'http://xanadu.ai',
+    'url': 'https://github.com/XanaduAI/pennylane',
     'license': 'Apache License 2.0',
     'packages': [
                     'pennylane',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def qubit_device_1_wire():
 @pytest.fixture(scope="function")
 def qubit_device_2_wires():
     return qml.device('default.qubit', wires=2)
-    
+
 
 @pytest.fixture(scope="function")
 def qubit_device_3_wires():
@@ -127,4 +127,3 @@ def tf_support():
 def seed(request):
     """Different seeds."""
     return request.param
-


### PR DESCRIPTION
**Description of the Change:**

* Updates the changelog

* Updates the PyPI project web address to point to the GitHub repository, so that GitHub dependency tracking works properly.

* ~Updates the CI to use the latest version of TF in the tests (1.13.1 -> 1.14.0)~ See https://github.com/XanaduAI/pennylane/pull/284#issuecomment-517597208.

* Simplifies the issue and PR template, making them clearer and more concise.

* Adds a line to the PR template, reminding users to add an entry to the changelog.

**Benefits:** all the above

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
