### PR TITLE
Update Travis to test against PyTorch 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,19 @@ matrix:
   include:
   - python: 3.7
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp37-cp37m-linux_x86_64.whl
   - python: 3.6
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
   - python: 3.5
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp35-cp35m-linux_x86_64.whl
 env:
   global:
   - COVERALLS_PARALLEL=true
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install tensorflow==1.13.1 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
+- pip install wheel pytest pytest-cov codecov --upgrade
+- pip install tensorflow==1.13.1
+- pip install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:


### PR DESCRIPTION
**Context:** PyTorch 1.2 was released a couple of days ago

**Description of the Change:** Updates the Travis configuration to test PennyLane against PyTorch 1.2

**Benefits:** Bugs arising from new PyTorch breaking changes/bugs will be found

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
