### PR TITLE
Implemented Pauli matrix exponentiation without expm

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -53,6 +53,10 @@
   class information arguments (`dev.supports_observable(qml.PauliX)`).
   [#276](https://github.com/XanaduAI/pennylane/pull/276)
 
+* The one-qubit rotations in `pennylane.plugins.default_qubit` no longer depend on Scipy's `expm`. Instead 
+  they are calculated with Euler's formula.
+  [#292](https://github.com/XanaduAI/pennylane/pull/292)
+
 ### Bug fixes
 
 * Fixed a bug where a `PolyXP` observable would fail if applied to subsets

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Aroosa Ijaz, Josh Izaac, Johannes Jakob Meyer.
+Aroosa Ijaz, Josh Izaac, Johannes Jakob Meyer, Roeland Wiersema.
 
 ---
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,19 @@ matrix:
   include:
   - python: 3.7
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp37-cp37m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp37-cp37m-linux_x86_64.whl
   - python: 3.6
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp36-cp36m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp36-cp36m-linux_x86_64.whl
   - python: 3.5
     dist: xenial
-    env:
-      - PYTORCH=https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl
-      - TORCHVISION=https://download.pytorch.org/whl/cpu/torchvision-0.3.0-cp35-cp35m-linux_x86_64.whl
 env:
   global:
   - COVERALLS_PARALLEL=true
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install tensorflow==1.13.1 $PYTORCH $TORCHVISION wheel pytest pytest-cov codecov --upgrade
+- pip install wheel pytest pytest-cov codecov --upgrade
+- pip install tensorflow==1.13.1
+- pip install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -80,7 +80,7 @@ Code details
 import warnings
 
 import numpy as np
-from scipy.linalg import expm, eigh
+from scipy.linalg import eigh
 
 from pennylane import Device
 
@@ -151,7 +151,7 @@ def Rotx(theta):
     Returns:
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_x \theta/2}`
     """
-    return expm(-1j * theta/2 * X)
+    return np.cos(theta/2) * I + 1j * np.sin(-theta/2) * X
 
 
 def Roty(theta):
@@ -162,7 +162,7 @@ def Roty(theta):
     Returns:
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_y \theta/2}`
     """
-    return expm(-1j * theta/2 * Y)
+    return np.cos(theta/2) * I + 1j * np.sin(-theta/2) * Y
 
 
 def Rotz(theta):
@@ -173,7 +173,7 @@ def Rotz(theta):
     Returns:
         array: unitary 2x2 rotation matrix :math:`e^{-i \sigma_z \theta/2}`
     """
-    return expm(-1j * theta/2 * Z)
+    return np.cos(theta/2) * I + 1j * np.sin(-theta/2) * Z
 
 
 def Rot3(a, b, c):


### PR DESCRIPTION
**Context:**
`RotX`,  `RotY`  and `RotZ` in `pennylane.plugins.default_qubit` use Scipy's `expm` function to calculate matrix exponentials. This can be implemented more efficiently using Euler's identity formula. See the PennyLane [discussion forum](https://discuss.pennylane.ai/t/using-expm-vs-euler-formula-in-default-qubit-rotations/192) for more info.

**Description of the Change:**
The unitary operations in `default.qubit` are are no longer calculated with `expm` but with Euler's identity instead.

**Benefits:**
A significant speed up for calls to `RotX`,  `RotY`  and `RotZ`.

**Possible Drawbacks:**
None
**Related GitHub Issues:**
None