### PR TITLE
Wrong description in gaussian_state

### DIFF
--- a/pennylane/plugins/default_gaussian.py
+++ b/pennylane/plugins/default_gaussian.py
@@ -515,7 +515,7 @@ def gaussian_state(mu, cov, hbar=2.):
             relation :math:`[\x,\p]=i\hbar`
 
     Returns:
-        array: the thermal state
+        tuple: the mean and covariance matrix of the Gaussian state
     """
     # pylint: disable=unused-argument
     return mu, cov


### PR DESCRIPTION
Fixes the docstring of the returned value in gaussian_state

**Context:**
Wrong docstring in gaussian_state
**Description of the Change:**
Fixes a broken docstring
**Benefits:**
Correct docstring
**Possible Drawbacks:**

**Related GitHub Issues:**
