### PR TITLE
Update qubit.py

### DIFF
--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -537,7 +537,7 @@ class BasisState(Operation):
 
 class QubitStateVector(Operation):
     r"""QubitStateVector(state, wires)
-    Prepare subsystems using the given ket vector in the Fock basis.
+    Prepare subsystems using the given ket vector in the computational basis.
 
     **Details:**
 


### PR DESCRIPTION
Corrects error in the docstring of ```QubitStateVector```. Fock bases only exist for identical particles, not for qubits.

