### PR TITLE
Update utils.py

### DIFF
--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -283,7 +283,7 @@ class CircuitGraph:
         """
         return self._graph
 
-    def get_wire(self, wire):
+    def get_op_indices(self, wire):
         """The operation indices on the given wire.
 
         Args:


### PR DESCRIPTION
**Context:** `CircuitGraph.utils.get_wire()` returns the operation indices on a given wire. The method name didn't make semantic sense.

**Description of the Change:** new name is `CircuitGraph.utils.get_op_indices()`

**Benefits:** makes more sense

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
