### PR TITLE
 Fix#304 - Add sample to explicit members in automodule 

### DIFF
--- a/doc/code/measure.rst
+++ b/doc/code/measure.rst
@@ -1,2 +1,2 @@
 .. automodule:: pennylane.measure
-   :members: expval, var
+   :members: expval, var, sample

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ networkx
 autograd
 toml
 appdirs
-semantic_version
+semantic_version==2.6

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     "autograd",
     "toml",
     "appdirs",
-    "semantic_version"
+    "semantic_version==2.6"
 ]
 
 extra_requirements = {


### PR DESCRIPTION
This PR addresses Issue #304.

It adds the "sample" function to the explicit list of functions generated by the automodule directive for pennylane.measure.
 
