### PR TITLE
Add generators to the controlled rotation gates

### DIFF
--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -393,7 +393,7 @@ class CRX(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
-    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]]), -1/2]
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]), -1/2]
 
 
 class CRY(Operation):

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -393,6 +393,7 @@ class CRX(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 1], [0, 0, 0, 1]]), -1/2]
 
 
 class CRY(Operation):
@@ -423,6 +424,7 @@ class CRY(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, -1j], [0, 0, 1j, 0]]), -1/2]
 
 
 class CRZ(Operation):
@@ -453,6 +455,7 @@ class CRZ(Operation):
     num_wires = 2
     par_domain = "R"
     grad_method = "A"
+    generator = [np.array([[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 1, 0], [0, 0, 0, -1]]), -1/2]
 
 
 class CRot(Operation):


### PR DESCRIPTION
**Context:**

Operations have the class property `generator`, which provides PennyLane with information of the Hamiltonian used to generate the operation. To use parametrized operations with the `QNGOptimizer`, this generator must be defined. It is currently only defined for the `RX`, `RY`, `RZ`, and `PhaseShift` gates.

**Description of the Change:**

Adds `generator` definitions to the `CRX`, `CRY`, and `CRZ` operations, allowing them to be used in circuits optimized by `QNGOptimizer`.

**Benefits:**

Increases the number of parametrized gates that can be optimized by the `QNGOptimizer`.

**Possible Drawbacks:** 

Currently, the 'generator' property only makes sense for parametrized gates with at most one parameter. To enable `qml.Rot(theta, phi, varphi)` to be used with the `QNGOptimizer`, support for decomposing them into `qml.RY` and `qml.RZ` gates in the `CircuitGraph` will need to be included.

**Related GitHub Issues:** n/a
