### PR TITLE
Documentation: Fix 2 typos in CV operations

### DIFF
--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -667,7 +667,7 @@ class DisplacedSqueezedState(CVOperation):
     **Details:**
 
     * Number of wires: 1
-    * Number of parameters: 3
+    * Number of parameters: 4
     * Gradient recipe: None (uses finite difference)
 
     Args:
@@ -710,7 +710,7 @@ class GaussianState(CVOperation):
     **Details:**
 
     * Number of wires: Any
-    * Number of parameters: 1
+    * Number of parameters: 2
     * Gradient recipe: None
 
     Args:


### PR DESCRIPTION
Fixes 2 typos in CV operations page

The stated number of parameters for these two functions have a typo:

![typo1](https://user-images.githubusercontent.com/44415402/66007927-508fe600-e482-11e9-9cf7-aa6786736076.png)

![typo2](https://user-images.githubusercontent.com/44415402/66007932-52f24000-e482-11e9-9c1b-492a5c9e4be9.png)
