### PR TITLE
Fix formatting in measurement type error message

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -51,7 +51,7 @@
 ### Bug fixes
 
 * Fixed typo in measurement type error message in qnode.py
-  []()
+  [#341](https://github.com/XanaduAI/pennylane/pull/341)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -50,6 +50,9 @@
 
 ### Bug fixes
 
+* Fixed typo in measurement type error message in qnode.py
+  []()
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -339,7 +339,7 @@ class QNode:
         for x in res:
             if x.return_type is None:
                 raise QuantumFunctionError("Observable '{}' does not have the measurement "
-                                           "type specified.")
+                                           "type specified.".format(x.name))
 
         # check that all ev's are returned, in the correct order
         if res != tuple(self.ev):


### PR DESCRIPTION
**Context:** Returning an Observable without specifying a Measurement currently raises an error with a message that has not been properly formatted.  

**Description of the Change:** Fix formatting on the error message to include the name of the Observable being referred to instead of parentheses {}.

**Benefits:** Fixes error message formatting.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
