### PR TITLE
Updated samples in Barren Plateau tutorial for better figure

### DIFF
--- a/examples/pennylane_run_barren_plateaus.py
+++ b/examples/pennylane_run_barren_plateaus.py
@@ -113,7 +113,7 @@ grad = qml.grad(qcircuit, argnum=0)
  ################################################# 
 # We take a small number of samples to allow the code to run
 # in a reasonable amount of time.
-num_samples = 10
+num_samples = 200
 grad_vals = []
 
 for i in range(num_samples):
@@ -143,11 +143,11 @@ def generate_random_circuit(num_qubits):
     return qcircuit, random_gate_sequence
 
 
-qubits = [2, 3, 4, 5, 6, 7, 8]
+qubits = [2, 3, 4, 5, 6]
 variances = []
 
 # We can increase the sample size for better results.
-num_samples = 25
+num_samples = 200
 
 
 for num_qubits in qubits:


### PR DESCRIPTION
The barren plateau tutorial (just merged) is dependent on how many samples one considers for a random circuit. I was using a very low number for simulations which got decent results but its not reliable as we saw in the rendered tutorial:

https://pennylane.readthedocs.io/en/latest/tutorials/pennylane_run_barren_plateaus.html#barren-plateaus

This PR reduces the number of qubits and increases the number of samples to 200 which sort of reproduces the straight line plot in the original paper. 

Please have a look @josh146 since the plot looks quite ugly right now and statisticians would scoff at sample size 25 :p 
@co9olguy 