### PR TITLE
Version bump to v0.6.0

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Release 0.6.0-dev
+# Release 0.6.0
 
 ### New features since last release
 
@@ -47,12 +47,17 @@
 * Remainder of the unittest-style tests were ported to pytest.
   [#310](https://github.com/XanaduAI/pennylane/pull/310)
 
+* The `do_queue` argument for operations now only takes effect
+  within QNodes. Outside of QNodes, operations can now be instantiated
+  without error.
+  [#359](https://github.com/XanaduAI/pennylane/pull/359)
+
 ### Documentation
 
 * The docs are rewritten and restructured to contain a code introduction section as well as an API section.
   [#314](https://github.com/XanaduAI/pennylane/pull/275)
 
-* Added Ising model example to the tutorials 
+* Added Ising model example to the tutorials
   [#319] (https://github.com/XanaduAI/pennylane/pull/319)
 
 * Added tutorial for QAOA on MaxCut problem
@@ -80,7 +85,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Shahnawaz Ahmed, Ville Bergholm, Aroosa Ijaz, Josh Izaac, Angus Lowe,
+Shahnawaz Ahmed, Ville Bergholm, Aroosa Ijaz, Josh Izaac, Nathan Killoran, Angus Lowe,
 Johannes Jakob Meyer, Maria Schuld, Antal Száva, Roeland Wiersema.
 
 ---

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 * The `do_queue` argument for operations now only takes effect
   within QNodes. Outside of QNodes, operations can now be instantiated
-  without error.
+  without needing to specify `do_queue`.
   [#359](https://github.com/XanaduAI/pennylane/pull/359)
 
 ### Documentation

--- a/pennylane/_version.py
+++ b/pennylane/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = '0.6.0-dev'
+__version__ = '0.6.0'


### PR DESCRIPTION
**Description of the Change:**

* Bumps the version number to v0.6.0 to ready for release.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
