### PR TITLE
Fix scrolling behaviour on API links

### DIFF
--- a/doc/xanadu_theme/layout.html
+++ b/doc/xanadu_theme/layout.html
@@ -243,6 +243,19 @@
 
 <script type="text/javascript" src="{{ pathto('_static/js/nanoscroller.min.js', 1) }}"></script>
 <script type="text/javascript">
+    $('a.reference.internal').each(function(){
+      var link = $(this).attr("href");
+
+      if (link.includes("api")) {
+        var hash = link.split('#')[1];
+        var page = link.split('#')[0].split('/').slice(-1)[0].replace(".html", "");
+
+        if (hash == page) {
+          $(this).attr('href', link.split('#')[0]);
+        }
+      }
+    });
+
     $(".document > .section").removeClass("section");
     $(".comment-container .nano-content").css("height", $("#content").height());
     $(".comment-container").css("height", $("#content").height());
@@ -271,6 +284,12 @@
         $(".css-transitions-only-after-page-load").each(function (index, element) {
             setTimeout(function () { $(element).removeClass("css-transitions-only-after-page-load") }, 10);
         });
+        if (window.location.hash) {
+          var hash = window.location.hash.replace(/\./g, "\\.");
+          o =  $(hash).offset().top;
+          var sT = o - $(".navbar").outerHeight(true) - 25;
+          $('html, body').animate({scrollTop: sT}, 1);
+        }
     });
 </script>
 <script type="text/javascript">


### PR DESCRIPTION
**Context:**

Sphinx does not 'know' about the new top navigation bar, and does not take it into account when scrolling to page sections. In addition, code domains automatically link to the signature, as opposed to the top of the page, which would make more sense now that we have individual pages per code object.

**Description of the Change:**

This PR introduces two changes:

1. Javascript function that scans all internal links on a page. If they are API links, and the reference matches the page name, the reference is stripped from the link. This will cause the page to load at the top, rather than scrolling to the signature.

2. If the URL loaded _does_ contain a reference hash, the JQuery `scrollTop` function is used to ensure the navbar height offset is taken into account.

**Benefits:** n/a

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
