### PR TITLE
Updates measurements page

### DIFF
--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -9,7 +9,7 @@ Measurements
 .. currentmodule:: pennylane.measure
 
 PennyLane can extract different types of measurement results: the expectation of an observable
-over multiple measurements, its variance, or samples of a single measurement.
+its variance, or samples of a single measurement.
 
 For example, the quantum function shown in the previous section
 used the :func:`~pennylane.expval` measurement:

--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -12,7 +12,7 @@ PennyLane can extract different types of measurement results from quantum
 devices: the expectation of an observable, its variance, or
 samples of a single measurement.
 
-For example, a QNode that returns the expectation value of the
+For example, the following circuit returns the expectation value of the
 :class:`~pennylane.PauliZ` observable on wire 1:
 
 .. code-block:: python
@@ -82,7 +82,7 @@ the ``@`` notation. For example, to measure the expectation value of
         qml.CNOT(wires=[0, 2])
         return qml.expval(qml.PauliZ(0) @ qml.PauliX(2))
 
-Note that we don't need to declare the identity term on wire 1; this is
+Note that we don't need to declare the identity observable on wire 1; this is
 implicitly assumed.
 
 The tensor observable notation can be used inside all measurement functions,

--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -8,11 +8,12 @@ Measurements
 
 .. currentmodule:: pennylane.measure
 
-PennyLane can extract different types of measurement results: the expectation of an observable
-its variance, or samples of a single measurement.
+PennyLane can extract different types of measurement results from quantum
+devices: the expectation of an observable, its variance, or
+samples of a single measurement.
 
-For example, the quantum function shown in the previous section
-used the :func:`~pennylane.expval` measurement:
+For example, a QNode that returns the expectation value of the
+:class:`~pennylane.PauliZ` observable on wire 1:
 
 .. code-block:: python
 
@@ -22,7 +23,7 @@ used the :func:`~pennylane.expval` measurement:
         qml.RY(y, wires=1)
         return qml.expval(qml.PauliZ(1))
 
-For more details on the available measurement functions:
+The available measurement functions are
 
 :html:`<div class="summary-table">`
 
@@ -81,7 +82,12 @@ the ``@`` notation. For example, to measure the expectation value of
         qml.CNOT(wires=[0, 2])
         return qml.expval(qml.PauliZ(0) @ qml.PauliX(2))
 
-The tensor observable notation can be used inside all measurement functions.
+Note that we don't need to declare the identity term on wire 1; this is
+implicitly assumed.
+
+The tensor observable notation can be used inside all measurement functions,
+including :func:`~.pennylane.expval`, :func:`~.pennylane.var`,
+and :func:`~.pennylane.sample`.
 
 Changing the number of shots
 ----------------------------

--- a/doc/introduction/measurements.rst
+++ b/doc/introduction/measurements.rst
@@ -8,23 +8,21 @@ Measurements
 
 .. currentmodule:: pennylane.measure
 
-PennyLane can extract different types of measurement results: The expectation of an observable
-over multiple measurements, its variance, or a sample of a single measurement.
+PennyLane can extract different types of measurement results: the expectation of an observable
+over multiple measurements, its variance, or samples of a single measurement.
 
 For example, the quantum function shown in the previous section
-used the :func:`expval <pennylane.expval>` measurement:
+used the :func:`~pennylane.expval` measurement:
 
 .. code-block:: python
 
-    import pennylane as qml
-
     def my_quantum_function(x, y):
         qml.RZ(x, wires=0)
-        qml.CNOT(wires=[0,1])
+        qml.CNOT(wires=[0, 1])
         qml.RY(y, wires=1)
         return qml.expval(qml.PauliZ(1))
 
-The three measurement functions can be found here:
+For more details on the available measurement functions:
 
 :html:`<div class="summary-table">`
 
@@ -37,3 +35,76 @@ The three measurement functions can be found here:
 
 :html:`</div>`
 
+.. note::
+
+    Both :func:`~.pennylane.expval` and :func:`~.pennylane.var` support analytic
+    differentiation. :func:`~.pennylane.sample`, however, returns *stochastic*
+    results, and does not support differentiation.
+
+Multiple measurements
+---------------------
+
+Quantum functions can also return multiple measurements, as long as each wire
+is not measured more than once:
+
+.. code-block:: python
+
+    def my_quantum_function(x, y):
+        qml.RZ(x, wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.RY(y, wires=1)
+        return qml.expval(qml.PauliZ(1)), qml.var(qml.PauliX(0))
+
+You can also use list comprehensions, and other common Python patterns:
+
+.. code-block:: python
+
+    def my_quantum_function(x, y):
+        qml.RZ(x, wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.RY(y, wires=1)
+        return [qml.expval(qml.PauliZ(i)) for i in range(2)]
+
+Tensor observables
+------------------
+
+PennyLane supports measuring the tensor product of observables, by using
+the ``@`` notation. For example, to measure the expectation value of
+:math:`Z\otimes I \otimes X`:
+
+.. code-block:: python3
+
+    def my_quantum_function(x, y):
+        qml.RZ(x, wires=0)
+        qml.CNOT(wires=[0, 1])
+        qml.RY(y, wires=1)
+        qml.CNOT(wires=[0, 2])
+        return qml.expval(qml.PauliZ(0) @ qml.PauliX(2))
+
+The tensor observable notation can be used inside all measurement functions.
+
+Changing the number of shots
+----------------------------
+
+For hardware devices where the number of shots determines the accuracy
+of the expectation value and variance, as well as the number of samples returned,
+it can sometimes be convenient to execute the same QNode with differing
+number of shots. This can be done by modifying the value of :attr:`.Device.shots`:
+
+
+.. code-block:: python
+
+    dev = qml.device("default.qubit", wires=1, shots=10, analytic=False)
+
+    @qml.qnode(dev)
+    def circuit(x, y):
+        qml.RX(x, wires=0)
+        qml.RY(y, wires=0)
+        return qml.expval(qml.PauliZ(0))
+
+    # execute the QNode using 10 shots
+    result = circuit(0.54, 0.1)
+
+    # execute the QNode again, now using 1 shot
+    dev.shots = 1
+    result = circuit(0.54, 0.1)


### PR DESCRIPTION
**Description of the Change:**

Updates the Using PennyLane/Measurement page with some features and common patterns that aren't mentioned anywhere else in the documentation:

1. Adds a short example of multiple measurements

2. Shows how to specify tensor observables

3. Shows how to execute a QNode with differing number of shots (I put this here because it generally is used with the `sample()` function, maybe there is a better place for it?)

**Benefits:** Briefly introduces tensor observables, multiple measurements, changing shots.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
