### PR TITLE
Changing deprecated abstract property definitions in _device.py

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Improvements
 
 * Removed deprecated `@abstractproperty` decorators
-  in _device.py.
+  in `_device.py`.
   [#374](https://github.com/XanaduAI/pennylane/pull/374)
 
 ### Documentation

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Improvements
 
+* Changing deprecated abstract property definitions
+  in _device.py.
+  [#374](https://github.com/XanaduAI/pennylane/pull/374)
+
 ### Documentation
 
 ### Bug fixes
@@ -13,6 +17,8 @@
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+Antal Száva
 
 ---
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Improvements
 
-* Changing deprecated abstract property definitions
+* Removed deprecated `@abstractproperty` decorators
   in _device.py.
   [#374](https://github.com/XanaduAI/pennylane/pull/374)
 

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -334,7 +334,6 @@ class Device(abc.ABC):
                 if o.name not in self.observables:
                     raise DeviceError("Observable {} not supported on device {}".format(o.name, self.short_name))
 
-    @property
     @abc.abstractmethod
     def apply(self, operation, wires, par):
         """Apply a quantum operation.
@@ -347,7 +346,6 @@ class Device(abc.ABC):
             par (tuple): parameters for the operation
         """
 
-    @property
     @abc.abstractmethod
     def expval(self, observable, wires, par):
         r"""Returns the expectation value of observable on specified wires.
@@ -409,7 +407,6 @@ class Device(abc.ABC):
         """
         raise NotImplementedError("Returning probability not currently supported by {}".format(self.short_name))
 
-    @property
     @abc.abstractmethod
     def reset(self):
         """Reset the backend state.

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -60,48 +60,48 @@ class Device(abc.ABC):
         """Verbose string representation."""
         return "{}\nName: \nAPI version: \nPlugin version: \nAuthor: ".format(self.name, self.pennylane_requires, self.version, self.author)
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
         """The full name of the device."""
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def short_name(self):
         """Returns the string used to load the device."""
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def pennylane_requires(self):
         """The current API version that the device plugin was made for."""
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def version(self):
         """The current version of the plugin."""
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def author(self):
         """The author(s) of the plugin."""
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def operations(self):
         """Get the supported set of operations.
 
         Returns:
             set[str]: the set of PennyLane operation names the device supports
         """
-        raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def observables(self):
         """Get the supported set of observables.
 
         Returns:
             set[str]: the set of PennyLane observable names the device supports
         """
-        raise NotImplementedError
 
     @property
     def shots(self):
@@ -313,7 +313,6 @@ class Device(abc.ABC):
 
         raise ValueError("The given operation must either be a pennylane.Observable class or a string.")
 
-
     def check_validity(self, queue, observables):
         """Checks whether the operations and observables in queue are all supported by the device.
 
@@ -340,6 +339,7 @@ class Device(abc.ABC):
                 if o.name not in self.observables:
                     raise DeviceError("Observable {} not supported on device {}".format(o.name, self.short_name))
 
+    @property
     @abc.abstractmethod
     def apply(self, operation, wires, par):
         """Apply a quantum operation.
@@ -351,8 +351,8 @@ class Device(abc.ABC):
             wires (Sequence[int]): subsystems the operation is applied on
             par (tuple): parameters for the operation
         """
-        raise NotImplementedError
 
+    @property
     @abc.abstractmethod
     def expval(self, observable, wires, par):
         r"""Returns the expectation value of observable on specified wires.
@@ -368,7 +368,6 @@ class Device(abc.ABC):
         Returns:
             float: expectation value :math:`\expect{A} = \bra{\psi}A\ket{\psi}`
         """
-        raise NotImplementedError
 
     def var(self, observable, wires, par):
         r"""Returns the variance of observable on specified wires.
@@ -415,6 +414,7 @@ class Device(abc.ABC):
         """
         raise NotImplementedError("Returning probability not currently supported by {}".format(self.short_name))
 
+    @property
     @abc.abstractmethod
     def reset(self):
         """Reset the backend state.
@@ -422,4 +422,3 @@ class Device(abc.ABC):
         After the reset the backend should be as if it was just constructed.
         Most importantly the quantum state is reset to its initial value.
         """
-        raise NotImplementedError

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -27,7 +27,6 @@ class DeviceError(Exception):
     """Exception raised by a :class:`~.pennylane._device.Device` when it encounters an illegal
     operation in the quantum circuit.
     """
-    pass
 
 
 class Device(abc.ABC):
@@ -248,19 +247,15 @@ class Device(abc.ABC):
 
     def pre_apply(self):
         """Called during :meth:`execute` before the individual operations are executed."""
-        pass
 
     def post_apply(self):
         """Called during :meth:`execute` after the individual operations have been executed."""
-        pass
 
     def pre_measure(self):
         """Called during :meth:`execute` before the individual observables are measured."""
-        pass
 
     def post_measure(self):
         """Called during :meth:`execute` after the individual observables have been measured."""
-        pass
 
     def execution_context(self):
         """The device execution context used during calls to :meth:`execute`.


### PR DESCRIPTION
**Context:**
In the ``_device.py`` file there are currently deprecated ways of referring to abstract properties.

**Description of the Change:**
Using the current ``@abstractmethod decorator`` as [described here](https://docs.python.org/3/library/abc.html#abc.abstractmethod).

**Benefits:**
Removing the deprecated function calls to abstract properties in the ``_device.py`` file.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A