### PR TITLE
Adds a print_applied method to QNodes

### DIFF
--- a/pennylane/decorator.py
+++ b/pennylane/decorator.py
@@ -66,6 +66,7 @@ def qnode(device, interface='numpy', cache=False):
         # bind the jacobian method to the wrapped function
         wrapper.jacobian = qnode.jacobian
         wrapper.metric_tensor = qnode.metric_tensor
+        wrapper.print_applied = qnode.print_applied
 
         # bind the qnode attributes to the wrapped function
         wrapper.__dict__.update(qnode.__dict__)

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -53,6 +53,10 @@ def TFQNode(qnode):
             """REPL representation"""
             return self.__str__()
 
+        print_applied = qnode.print_applied
+        jacobian = qnode.jacobian
+        metric_tensor = qnode.metric_tensor
+
     @qnode_str
     @tf.custom_gradient
     def _TFQNode(*input_, **input_kwargs):

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -181,6 +181,10 @@ def TorchQNode(qnode):
             """REPL representation"""
             return self.__str__()
 
+        print_applied = qnode.print_applied
+        jacobian = qnode.jacobian
+        metric_tensor = qnode.metric_tensor
+
     @qnode_str
     def custom_apply(*args, **kwargs):
         """Custom apply wrapper, to allow passing kwargs to the TorchQNode"""

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -131,6 +131,36 @@ class QNode:
                 raise QuantumFunctionError('State preparations and gates must precede measured observables.')
             self.queue.append(op)
 
+    def print_applied(self):
+        """Prints the most recently applied operations from the QNode."""
+        if not self.ops:
+            print("QNode has not yet been executed.")
+            return
+
+        print("Operations")
+        print("==========")
+        for op in self.queue:
+            if op.parameters:
+                params = ", ".join([str(p) for p in op.parameters])
+                print("{}({}, wires={})".format(op.name, params, op.wires))
+            else:
+                print("{}(wires={})".format(op.name, op.wires))
+
+        return_map = {
+            qml.operation.Expectation: "expval",
+            qml.operation.Variance: "var",
+            qml.operation.Sample: "sample"
+        }
+
+        print("\nObservables")
+        print("===========")
+        for op in self.ev:
+            return_type = return_map[op.return_type]
+            if op.parameters:
+                params = "".join([str(p) for p in op.parameters])
+                print("{}({}({}, wires={}))".format(return_type, op.name, params, op.wires))
+            else:
+                print("{}({}(wires={}))".format(return_type, op.name, op.wires))
 
     def construct(self, args, kwargs=None):
         """Constructs a representation of the quantum circuit.


### PR DESCRIPTION
**Context:** Currently, it is hard to debug QNodes to ensure that they are executing the correct quantum circuit, for instance, if they include classical branching/logic within the QNode.

**Description of the Change:** Adds a `print_applied` method to QNodes, that prints the operation and observable queue as last constructed.

Example:

```python
import pennylane as qml
from pennylane.templates.embeddings import AngleEmbedding
from pennylane.templates.layers import StronglyEntanglingLayers
from pennylane.init import strong_ent_layer_uniform

dev = qml.device('default.qubit', wires=2)

@qml.qnode(dev, interface="torch")
def circuit(weights, x=None):
    AngleEmbedding(x, [0,1])
    StronglyEntanglingLayers(weights=weights, wires=[0,1])
    return qml.expval(qml.PauliZ(0))

init_weights = strong_ent_layer_uniform(n_wires=2)

circuit(init_weights, x=[1., 2.])
circuit.print_applied()
```

Output:

```
Operations
==========
RX(1.0, wires=[0])
RX(2.0, wires=[1])
Rot(5.2934758701132685, 2.6339939891643005, 6.268309774410444, wires=[0])
Rot(2.599559228882876, 2.0359675113467888, 0.7480448828174393, wires=[1])
CNOT(wires=[0, 1])
CNOT(wires=[1, 0])

Observables
===========
expval(PauliZ(wires=[0]))
```

**Benefits:** Easier to debug complicated QNodes.

**Possible Drawbacks:** Since the queue is not constructed until evaluation, using `print_applied()` will prior to first evaluation will emit a warning message and no information.

**Related GitHub Issues:** n/a (was mentioned on the discussion forum).
