### PR TITLE
Adding tensornetwork to setup.py

### DIFF
--- a/pennylane/plugins/__init__.py
+++ b/pennylane/plugins/__init__.py
@@ -26,4 +26,3 @@ to verify and test quantum gradient computations.
 """
 from .default_qubit import DefaultQubit
 from .default_gaussian import DefaultGaussian
-from .expt_tensornet import TensorNetwork

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 networkx
-tensornetwork<=0.1.1,>=0.0.7
+tensornetwork
 autograd
 toml
 appdirs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 networkx
-tensornetwork
+tensornetwork<=0.1.1,>=0.0.7
 autograd
 toml
 appdirs

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ requirements = [
     "numpy",
     "scipy",
     "networkx",
-    "tensornetwork<=0.1.1,>=0.0.7",
     "autograd",
     "toml",
     "appdirs",
@@ -47,7 +46,7 @@ info = {
         'pennylane.plugins': [
             'default.qubit = pennylane.plugins:DefaultQubit',
             'default.gaussian = pennylane.plugins:DefaultGaussian',
-            'expt.tensornet = pennylane.plugins:TensorNetwork'
+            'expt.tensornet = pennylane.plugins.expt_tensornet:TensorNetwork'
             ],
         },
     'description': 'PennyLane is a Python quantum machine learning library by Xanadu Inc.',

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
     "numpy",
     "scipy",
     "networkx",
+    "tensornetwork",
     "autograd",
     "toml",
     "appdirs",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@
 from setuptools import setup
 
 with open("pennylane/_version.py") as f:
-	version = f.readlines()[-1].split()[-1].strip("\"'")
+    version = f.readlines()[-1].split()[-1].strip("\"'")
 
 requirements = [
     "numpy",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy",
     "scipy",
     "networkx",
-    "tensornetwork==0.1.1",
+    "tensornetwork<=0.1.1,>=0.0.7",
     "autograd",
     "toml",
     "appdirs",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     "numpy",
     "scipy",
     "networkx",
-    "tensornetwork",
+    "tensornetwork==0.1.1",
     "autograd",
     "toml",
     "appdirs",


### PR DESCRIPTION
**Context:**
The Tensornetwork is missing as a requirement in `setup.py` and this causes tests of plugins (e.g. PennyLane-Qiskit) to fail when using a device from PennyLane core.

**Description of the Change:**
Adding the Tensornetwork library as a requirement in `setup.py`

**Benefits:**
Fixing Travis tests for plugins.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A