### PR TITLE
Update examples/pennylane_run_variational_classifier.py.

### DIFF
--- a/examples/pennylane_run_variational_classifier.py
+++ b/examples/pennylane_run_variational_classifier.py
@@ -257,8 +257,8 @@ dev = qml.device("default.qubit", wires=2)
 
 def get_angles(x):
 
-    beta0 = 2 * np.arcsin(np.sqrt(x[1]) ** 2 / np.sqrt(x[0] ** 2 + x[1] ** 2 + 1e-12))
-    beta1 = 2 * np.arcsin(np.sqrt(x[3]) ** 2 / np.sqrt(x[2] ** 2 + x[3] ** 2 + 1e-12))
+    beta0 = 2 * np.arcsin(np.sqrt(x[1] ** 2) / np.sqrt(x[0] ** 2 + x[1] ** 2 + 1e-12))
+    beta1 = 2 * np.arcsin(np.sqrt(x[3] ** 2) / np.sqrt(x[2] ** 2 + x[3] ** 2 + 1e-12))
     beta2 = 2 * np.arcsin(
         np.sqrt(x[2] ** 2 + x[3] ** 2) / np.sqrt(x[0] ** 2 + x[1] ** 2 + x[2] ** 2 + x[3] ** 2)
     )


### PR DESCRIPTION
**Context:**
In this particular case the modification is mathematically irrelevant but necessary to be in accordance with that shown in equation (8) of the reference `Möttönen, et al. (2004) <https://arxiv.org/abs/quant-ph/0407010> `.

**Description of the Change:**
The square is positioned within the square root.

**Benefits:**
Avoid confusion in future cases where this detail is mathematically relevant (when there are more summation terms).

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.