### PR TITLE
Adding 'Raises' sections to docstrings throughout PL

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -113,12 +113,12 @@ class Device(abc.ABC):
     def shots(self, shots):
         """Changes the number of shots.
 
-        Raises:
-            DeviceError: if number of shots is less than 1
-
         Args:
             shots (int): number of circuit evaluations/random samples used to estimate
                 expectation values of observables
+
+        Raises:
+            DeviceError: if number of shots is less than 1
         """
         if shots < 1:
             raise DeviceError("The specified number of shots needs to be at least 1. Got {}.".format(shots))

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -118,7 +118,7 @@ class Device(abc.ABC):
                 expectation values of observables
 
         Raises:
-            DeviceError: if number of shots is less than 1
+            DeviceError: if number of `shots` is less than 1
         """
         if shots < 1:
             raise DeviceError("The specified number of shots needs to be at least 1. Got {}.".format(shots))
@@ -150,7 +150,7 @@ class Device(abc.ABC):
                 :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
 
         Raises:
-            QuantumFunctionError: if the return type of the observable is not supported
+            QuantumFunctionError: if the return type of one of the `observables` is not supported
 
         Returns:
             array[float]: measured value(s)

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -118,7 +118,7 @@ class Device(abc.ABC):
                 expectation values of observables
 
         Raises:
-            DeviceError: if number of `shots` is less than 1
+            DeviceError: if number of shots is less than 1
         """
         if shots < 1:
             raise DeviceError("The specified number of shots needs to be at least 1. Got {}.".format(shots))

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -150,7 +150,7 @@ class Device(abc.ABC):
                 :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
 
         Raises:
-            QuantumFunctionError: if the return type of one of the `observables` is not supported
+            QuantumFunctionError: if the value of :attr:`~.Observable.return_type` is not supported
 
         Returns:
             array[float]: measured value(s)

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -113,6 +113,9 @@ class Device(abc.ABC):
     def shots(self, shots):
         """Changes the number of shots.
 
+        Raises:
+            DeviceError: if number of shots is less than 1
+
         Args:
             shots (int): number of circuit evaluations/random samples used to estimate
                 expectation values of observables
@@ -145,6 +148,9 @@ class Device(abc.ABC):
             observables (Iterable[~.operation.Observable]): observables to measure and return
             parameters (dict[int->list[ParameterDependency]]): Mapping from free parameter index to the list of
                 :class:`Operations <pennylane.operation.Operation>` (in the queue) that depend on it.
+
+        Raises:
+            QuantumFunctionError: if the return type of the observable is not supported
 
         Returns:
             array[float]: measured value(s)
@@ -202,6 +208,9 @@ class Device(abc.ABC):
         Note that this property can only be accessed within the execution context
         of :meth:`~.execute`.
 
+        Raises:
+            ValueError: if outside of the execution context
+
         Returns:
             list[~.operation.Operation]
         """
@@ -216,6 +225,9 @@ class Device(abc.ABC):
 
         Note that this property can only be accessed within the execution context
         of :meth:`~.execute`.
+
+        Raises:
+            ValueError: if outside of the execution context
 
         Returns:
             list[~.operation.Observable]
@@ -232,6 +244,9 @@ class Device(abc.ABC):
 
         Note that this property can only be accessed within the execution context
         of :meth:`~.execute`.
+
+        Raises:
+            ValueError: if outside of the execution context
 
         Returns:
             dict[int->list[ParameterDependency]]: the mapping
@@ -369,6 +384,9 @@ class Device(abc.ABC):
             wires (List[int] or List[List[int]]): subsystems the observable(s) is to be measured on
             par (tuple or list[tuple]]): parameters for the observable(s)
 
+        Raises:
+            NotImplementedError: if the device does not support variance computation
+
         Returns:
             float: variance :math:`\mathrm{var}(A) = \bra{\psi}A^2\ket{\psi} - \bra{\psi}A\ket{\psi}^2`
         """
@@ -388,6 +406,9 @@ class Device(abc.ABC):
             wires (List[int] or List[List[int]]): subsystems the observable(s) is to be measured on
             par (tuple or list[tuple]]): parameters for the observable(s)
 
+        Raises:
+            NotImplementedError: if the device does not support sampling
+
         Returns:
             array[float]: samples in an array of dimension ``(n, num_wires)``
         """
@@ -395,6 +416,9 @@ class Device(abc.ABC):
 
     def probability(self):
         """Return the full state probability of each computational basis state from the last run of the device.
+
+        Raises:
+            NotImplementedError: if the device does not support returning probabilities
 
         Returns:
             OrderedDict[tuple, float]: Dictionary mapping a tuple representing the state
@@ -407,6 +431,6 @@ class Device(abc.ABC):
     def reset(self):
         """Reset the backend state.
 
-        After the reset the backend should be as if it was just constructed.
+        After the reset, the backend should be as if it was just constructed.
         Most importantly the quantum state is reset to its initial value.
         """

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -277,6 +277,9 @@ class CircuitGraph:
     def update_node(self, old, new):
         """Replaces the given circuit graph node with a new one.
 
+        Raises:
+            ValueError: if the new Operator does not act on the same wires as the old one
+
         Args:
             old (Operator): node to replace
             new (Operator): replacement

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -282,7 +282,7 @@ class CircuitGraph:
             new (Operator): replacement
 
         Raises:
-            ValueError: if the new Operator does not act on the same wires as the old one
+            ValueError: if the new :class:`~.Operator` does not act on the same wires as the old one
         """
         # NOTE Does not alter the graph edges in any way. variable_deps is not changed, _grid is not changed. Dangerous!
         if new.wires != old.wires:

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -277,12 +277,12 @@ class CircuitGraph:
     def update_node(self, old, new):
         """Replaces the given circuit graph node with a new one.
 
-        Raises:
-            ValueError: if the new Operator does not act on the same wires as the old one
-
         Args:
             old (Operator): node to replace
             new (Operator): replacement
+
+        Raises:
+            ValueError: if the new Operator does not act on the same wires as the old one
         """
         # NOTE Does not alter the graph edges in any way. variable_deps is not changed, _grid is not changed. Dangerous!
         if new.wires != old.wires:

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -32,6 +32,9 @@ def expval(op):
 
     Args:
         op (Observable): a quantum observable object
+
+    Raises:
+        QuantumFunctionError: the operator defined is not an observable
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(
@@ -61,6 +64,9 @@ def var(op):
 
     Args:
         op (Observable): a quantum observable object
+
+    Raises:
+        QuantumFunctionError: the operator defined is not an observable
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(
@@ -91,6 +97,9 @@ def sample(op):
 
     Args:
         op (Observable): a quantum observable object
+
+    Raises:
+        QuantumFunctionError: the operator defined is not an observable
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(

--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -34,7 +34,7 @@ def expval(op):
         op (Observable): a quantum observable object
 
     Raises:
-        QuantumFunctionError: the operator defined is not an observable
+        QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(
@@ -66,7 +66,7 @@ def var(op):
         op (Observable): a quantum observable object
 
     Raises:
-        QuantumFunctionError: the operator defined is not an observable
+        QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(
@@ -99,7 +99,7 @@ def sample(op):
         op (Observable): a quantum observable object
 
     Raises:
-        QuantumFunctionError: the operator defined is not an observable
+        QuantumFunctionError: `op` is not an instance of :class:`~.Observable`
     """
     if not isinstance(op, Observable):
         raise QuantumFunctionError(

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -672,8 +672,7 @@ class CV:
             num_wires (int): total number of wires in the quantum circuit. If zero, return ``U`` as is.
 
         Raises:
-            ValueError: if the size of the input matrix is invalid or an incorrect number of wires were
-                specified
+            ValueError: if the size of the input matrix is invalid or `num_wires` is incorrect
 
         Returns:
             array[float]: expanded array, dimension ``1+2*num_wires``
@@ -828,7 +827,7 @@ class CVOperation(CV, Operation):
             inverse  (bool): if True, return the inverse transformation instead
 
         Raises:
-            RuntimeError: if the specified operation is not Gaussian or is missing the _heisenberg_rep method
+            RuntimeError: if the specified operation is not Gaussian or is missing the `_heisenberg_rep` method
 
         Returns:
             array[float]: :math:`\tilde{U}`, the Heisenberg picture representation of the linear transformation

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -314,6 +314,7 @@ class Operator(abc.ABC):
                 sequence (affects the handling of 'A' parameters)
         Raises:
             TypeError: parameter is not an element of the expected domain
+            ValueError: parameter is an element of an unknown domain
         Returns:
             Number, array, Variable: p
         """
@@ -669,6 +670,11 @@ class CV:
         Args:
             U (array[float]): array to expand (expected to be of the dimension ``1+2*self.num_wires``)
             num_wires (int): total number of wires in the quantum circuit. If zero, return ``U`` as is.
+
+        Raises:
+            ValueError: if the size of the input matrix is invalid or an incorrect number of wires were
+                specified
+
         Returns:
             array[float]: expanded array, dimension ``1+2*num_wires``
         """
@@ -820,6 +826,9 @@ class CVOperation(CV, Operation):
         Args:
             num_wires (int): total number of wires in the quantum circuit
             inverse  (bool): if True, return the inverse transformation instead
+
+        Raises:
+            RuntimeError: if the specified operation is not Gaussian or is missing the _heisenberg_rep method
 
         Returns:
             array[float]: :math:`\tilde{U}`, the Heisenberg picture representation of the linear transformation

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -197,6 +197,9 @@ def unitary(*args):
     Args:
         args (array): square unitary matrix
 
+    Raises:
+        ValueError: if the matrix is not unitary or square
+
     Returns:
         array: square unitary matrix
     """
@@ -216,6 +219,9 @@ def hermitian(*args):
 
     Args:
         args (array): square hermitian matrix
+
+    Raises:
+        ValueError: if the matrix is not Hermitian or square
 
     Returns:
         array: square hermitian matrix

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -119,12 +119,12 @@ class QNode:
     def _append_op(self, op):
         """Appends a quantum operation into the circuit queue.
 
+        Args:
+            op (:class:`~.operation.Operation`): quantum operation to be added to the circuit
+
         Raises:
             ValueError: if the operation does not act on all wires
             QuantumFunctionError: if state preparations and gates do not precede measured observables
-
-        Args:
-            op (:class:`~.operation.Operation`): quantum operation to be added to the circuit
         """
         if op.num_wires == qml.operation.Wires.All:
             if set(op.wires) != set(range(self.num_wires)):
@@ -182,11 +182,6 @@ class QNode:
         stores the resulting sequence of :class:`~.operation.Operation` instances,
         and creates the variable mapping.
 
-        Raises:
-            QuantumFunctionError: if the QNode's _current_context is attempted to be modified
-                inside of this method, the quantum function returns incorrect values or if
-                both continuous and discrete operations are specified in the same quantum circuit
-
         Args:
             args (tuple): Represent the free parameters passed to the circuit.
                 Here we are not concerned with their values, but with their structure.
@@ -195,6 +190,11 @@ class QNode:
                 however PennyLane does not support differentiating with respect to keyword arguments.
                 Instead, keyword arguments are useful for providing data or 'placeholders'
                 to the quantum circuit function.
+
+        Raises:
+            QuantumFunctionError: if the QNode's _current_context is attempted to be modified
+                inside of this method, the quantum function returns incorrect values or if
+                both continuous and discrete operations are specified in the same quantum circuit
         """
         # pylint: disable=too-many-branches,too-many-statements
         self.queue = []

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -123,7 +123,7 @@ class QNode:
             op (:class:`~.operation.Operation`): quantum operation to be added to the circuit
 
         Raises:
-            ValueError: if the operation does not act on all wires
+            ValueError: if `op` does not act on all wires
             QuantumFunctionError: if state preparations and gates do not precede measured observables
         """
         if op.num_wires == qml.operation.Wires.All:
@@ -192,7 +192,7 @@ class QNode:
                 to the quantum circuit function.
 
         Raises:
-            QuantumFunctionError: if the QNode's _current_context is attempted to be modified
+            QuantumFunctionError: if the :class:`pennylane.QNode`'s _current_context is attempted to be modified
                 inside of this method, the quantum function returns incorrect values or if
                 both continuous and discrete operations are specified in the same quantum circuit
         """
@@ -338,7 +338,7 @@ class QNode:
                 approximation. Default is ``False``.
 
         Raises:
-            QuantumFunctionError: if a metric tensor cannot be generated
+            QuantumFunctionError: if a metric tensor cannot be generated because no generator was defined
 
         .. note::
 
@@ -784,8 +784,8 @@ class QNode:
 
         Raises:
             QuantumFunctionError: if sampling is specified
-            ValueError: if incorrect parameters were defined, the differentiation is not possible or if
-                the gradient method is unknown
+            ValueError: if `params` is incorrect, the differentiation is not possible or if `method`
+                is unknown
 
         Returns:
             array[float]: Jacobian matrix, with shape ``(n_out, len(which))``, where ``len(which)`` is the
@@ -1143,7 +1143,7 @@ class QNode:
         """Convert the standard PennyLane QNode into a :func:`~.TorchQNode`.
 
         Raises:
-            QuantumFunctionError: if PyTorch is not installed
+            QuantumFunctionError: if ``PyTorch`` is not installed
         """
         # Placing slow imports here, in case the user does not use the Torch interface
         try: # pragma: no cover
@@ -1158,7 +1158,7 @@ class QNode:
         """Convert the standard PennyLane QNode into a :func:`~.TFQNode`.
 
         Raises:
-            QuantumFunctionError: if TensorFlow is not installed
+            QuantumFunctionError: if ``TensorFlow`` is not installed
         """
         # Placing slow imports here, in case the user does not use the TF interface
         try: # pragma: no cover

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -784,7 +784,7 @@ class QNode:
 
         Raises:
             QuantumFunctionError: if sampling is specified
-            ValueError: if `params` is incorrect, the differentiation is not possible or if `method`
+            ValueError: if `params` is incorrect, the differentiation is not possible, or if `method`
                 is unknown
 
         Returns:

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -784,7 +784,7 @@ class QNode:
 
         Raises:
             QuantumFunctionError: if sampling is specified
-            ValueError: if `params` is incorrect, the differentiation is not possible, or if `method`
+            ValueError: if `params` is incorrect, differentiation is not possible, or if `method`
                 is unknown
 
         Returns:
@@ -1143,7 +1143,7 @@ class QNode:
         """Convert the standard PennyLane QNode into a :func:`~.TorchQNode`.
 
         Raises:
-            QuantumFunctionError: if ``PyTorch`` is not installed
+            QuantumFunctionError: if PyTorch is not installed
         """
         # Placing slow imports here, in case the user does not use the Torch interface
         try: # pragma: no cover
@@ -1158,7 +1158,7 @@ class QNode:
         """Convert the standard PennyLane QNode into a :func:`~.TFQNode`.
 
         Raises:
-            QuantumFunctionError: if ``TensorFlow`` is not installed
+            QuantumFunctionError: if TensorFlow >= 1.12 is not installed
         """
         # Placing slow imports here, in case the user does not use the TF interface
         try: # pragma: no cover

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -119,6 +119,10 @@ class QNode:
     def _append_op(self, op):
         """Appends a quantum operation into the circuit queue.
 
+        Raises:
+            ValueError: if the operation does not act on all wires
+            QuantumFunctionError: if state preparations and gates do not precede measured observables
+
         Args:
             op (:class:`~.operation.Operation`): quantum operation to be added to the circuit
         """
@@ -177,6 +181,11 @@ class QNode:
         or :meth:`QNode.jacobian` is called. It executes the quantum function,
         stores the resulting sequence of :class:`~.operation.Operation` instances,
         and creates the variable mapping.
+
+        Raises:
+            QuantumFunctionError: if the QNode's _current_context is attempted to be modified
+                inside of this method, the quantum function returns incorrect values or if
+                both continuous and discrete operations are specified in the same quantum circuit
 
         Args:
             args (tuple): Represent the free parameters passed to the circuit.
@@ -327,6 +336,9 @@ class QNode:
         Keyword Args:
             diag_approx (bool): If ``True``, forces the diagonal
                 approximation. Default is ``False``.
+
+        Raises:
+            QuantumFunctionError: if a metric tensor cannot be generated
 
         .. note::
 
@@ -552,6 +564,9 @@ class QNode:
         Args:
             args (tuple): input parameters to the quantum function
 
+        Raises:
+            QuantumFunctionError: if there is an error while measuring
+
         Returns:
             float, array[float]: output measured value(s)
         """
@@ -767,6 +782,11 @@ class QNode:
             shots (int): How many times the circuit should be evaluated (or sampled) to estimate
                 the expectation values.
 
+        Raises:
+            QuantumFunctionError: if sampling is specified
+            ValueError: if incorrect parameters were defined, the differentiation is not possible or if
+                the gradient method is unknown
+
         Returns:
             array[float]: Jacobian matrix, with shape ``(n_out, len(which))``, where ``len(which)`` is the
             number of free parameters, and ``n_out`` is the number of expectation values returned
@@ -866,6 +886,9 @@ class QNode:
             order (int): finite difference method order, 1 or 2
             y0 (float): Value of the circuit at params. Should only be computed once.
 
+        Raises:
+            ValueError: if the order specified is not equal to 1 or 2
+
         Returns:
             float: partial derivative of the node.
         """
@@ -897,6 +920,10 @@ class QNode:
             ob_successors (list[Observable]): list of observable successors to current operation
             w (int): number of wires
             Z (array[float]): the Heisenberg picture representation of the linear transformation
+
+        Raises:
+            QuantumFunctionError: if there is a mismatch between polynomial order of observable
+                and heisenberg representation
 
         Returns:
             float: expectation value
@@ -1114,6 +1141,9 @@ class QNode:
 
     def to_torch(self):
         """Convert the standard PennyLane QNode into a :func:`~.TorchQNode`.
+
+        Raises:
+            QuantumFunctionError: if PyTorch is not installed
         """
         # Placing slow imports here, in case the user does not use the Torch interface
         try: # pragma: no cover
@@ -1126,6 +1156,9 @@ class QNode:
 
     def to_tf(self):
         """Convert the standard PennyLane QNode into a :func:`~.TFQNode`.
+
+        Raises:
+            QuantumFunctionError: if TensorFlow is not installed
         """
         # Placing slow imports here, in case the user does not use the TF interface
         try: # pragma: no cover

--- a/pennylane/qnode_new/qnode.py
+++ b/pennylane/qnode_new/qnode.py
@@ -270,7 +270,11 @@ class QNode:
         """Append a quantum operation into the circuit queue.
 
         Args:
-            op (~.operation.Operator): quantum operation to be added to the circuit
+            op (:class:`~.operation.Operation`): quantum operation to be added to the circuit
+
+        Raises:
+            ValueError: if `op` does not act on all wires
+            QuantumFunctionError: if state preparations and gates do not precede measured observables
         """
         if op.num_wires == Wires.All:
             if set(op.wires) != set(range(self.num_wires)):
@@ -316,6 +320,11 @@ class QNode:
                 the nesting structure.
                 Each positional argument is replaced with a :class:`~.variable.Variable` instance.
             kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
+
+        Raises:
+            QuantumFunctionError: if the :class:`pennylane.QNode`'s _current_context is attempted to be modified
+                inside of this method, the quantum function returns incorrect values or if
+                both continuous and discrete operations are specified in the same quantum circuit
         """
         # pylint: disable=protected-access  # remove when QNode_old is gone
         # pylint: disable=attribute-defined-outside-init, too-many-branches
@@ -465,6 +474,9 @@ class QNode:
         Args:
             kwargs (dict[str, Any]): auxiliary arguments (given using the keyword syntax)
 
+        Raises:
+            QuantumFunctionError: if the parameter to the quantum function was invalid
+
         Returns:
             dict[str, Any]: all auxiliary arguments (with defaults)
         """
@@ -559,6 +571,11 @@ class QNode:
 
         Args:
             diag_approx (bool): iff True, use the diagonal approximation
+
+        Raises:
+            QuantumFunctionError: if a metric tensor cannot be generated because no generator
+                was defined
+
         """
         # pylint: disable=too-many-statements, too-many-branches
 

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -192,7 +192,7 @@ def SqueezingEmbedding(features, wires, method='amplitude', c=0.1):
             amplitude of all squeezing gates if ``execution='phase'``
 
     Raises:
-        ValueError: if `features` or `wires` is invalid
+        ValueError: if ``features`` or ``wires`` is invalid
     """
 
     if not isinstance(wires, Iterable):

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -154,7 +154,7 @@ def BasisEmbedding(features, wires):
         wires (Sequence[int]): sequence of qubit indices that the template acts on
 
     Raises:
-        ValueError: if `features` or `wires` is invalid
+        ValueError: if ``features`` or ``wires`` is invalid
     """
     if not isinstance(wires, Iterable):
         raise ValueError("Wires needs to be a list of wires that the embedding uses; got {}.".format(wires))

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -236,7 +236,7 @@ def DisplacementEmbedding(features, wires, method='amplitude', c=0.1):
             the amplitude of all displacement gates if ``execution='phase'``
 
     Raises:
-        ValueError: if `features` or `wires` is invalid or if `method` is unknown
+        ValueError: if ``features`` or ``wires`` is invalid or if ``method`` is unknown
    """
 
     if not isinstance(wires, Iterable):

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -48,6 +48,9 @@ def AngleEmbedding(features, wires, rotation='X'):
 
     Keyword Args:
         rotation (str): Type of rotations used
+
+    Raises:
+        ValueError: if the wrong wires or features were defined
     """
 
     if not isinstance(wires, Iterable):
@@ -92,6 +95,9 @@ def AmplitudeEmbedding(features, wires, pad=False, normalize=False):
         wires (Sequence[int]): sequence of qubit indices that the template acts on
         pad (Boolean): controls the activation of the padding option
         normalize (Boolean): controls the activation of automatic normalization
+
+    Raises:
+        ValueError: if the feature vector specified is invalid
     """
 
     if isinstance(wires, int):
@@ -146,6 +152,9 @@ def BasisEmbedding(features, wires):
     Args:
         features (array): Binary input array of shape ``(n, )``
         wires (Sequence[int]): sequence of qubit indices that the template acts on
+
+    Raises:
+        ValueError: if the wrong wires or features were defined
     """
     if not isinstance(wires, Iterable):
         raise ValueError("Wires needs to be a list of wires that the embedding uses; got {}.".format(wires))
@@ -181,6 +190,9 @@ def SqueezingEmbedding(features, wires, method='amplitude', c=0.1):
             ``'amplitude'`` uses the amplitude
         c (float): value of the phase of all squeezing gates if ``execution='amplitude'``, or the
             amplitude of all squeezing gates if ``execution='phase'``
+
+    Raises:
+        ValueError: if the wrong wires or features were defined
     """
 
     if not isinstance(wires, Iterable):
@@ -222,6 +234,10 @@ def DisplacementEmbedding(features, wires, method='amplitude', c=0.1):
             ``'amplitude'`` uses the amplitude
         c (float): value of the phase of all displacement gates if ``execution='amplitude'``, or
             the amplitude of all displacement gates if ``execution='phase'``
+
+    Raises:
+        ValueError: if the wrong wires or features were defined or if an unknown execution method was
+            specified
    """
 
     if not isinstance(wires, Iterable):

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -97,7 +97,7 @@ def AmplitudeEmbedding(features, wires, pad=False, normalize=False):
         normalize (Boolean): controls the activation of automatic normalization
 
     Raises:
-        ValueError: if `features` or `wires` is invalid
+        ValueError: if ``features`` or ``wires`` is invalid
     """
 
     if isinstance(wires, int):

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -50,7 +50,7 @@ def AngleEmbedding(features, wires, rotation='X'):
         rotation (str): Type of rotations used
 
     Raises:
-        ValueError: if `features` or `wires` is invalid
+        ValueError: if ``features`` or ``wires`` is invalid
     """
 
     if not isinstance(wires, Iterable):

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -50,7 +50,7 @@ def AngleEmbedding(features, wires, rotation='X'):
         rotation (str): Type of rotations used
 
     Raises:
-        ValueError: if the wrong wires or features were defined
+        ValueError: if `features` or `wires` is invalid
     """
 
     if not isinstance(wires, Iterable):
@@ -97,7 +97,7 @@ def AmplitudeEmbedding(features, wires, pad=False, normalize=False):
         normalize (Boolean): controls the activation of automatic normalization
 
     Raises:
-        ValueError: if the feature vector specified is invalid
+        ValueError: if `features` or `wires` is invalid
     """
 
     if isinstance(wires, int):
@@ -154,7 +154,7 @@ def BasisEmbedding(features, wires):
         wires (Sequence[int]): sequence of qubit indices that the template acts on
 
     Raises:
-        ValueError: if the wrong wires or features were defined
+        ValueError: if `features` or `wires` is invalid
     """
     if not isinstance(wires, Iterable):
         raise ValueError("Wires needs to be a list of wires that the embedding uses; got {}.".format(wires))
@@ -192,7 +192,7 @@ def SqueezingEmbedding(features, wires, method='amplitude', c=0.1):
             amplitude of all squeezing gates if ``execution='phase'``
 
     Raises:
-        ValueError: if the wrong wires or features were defined
+        ValueError: if `features` or `wires` is invalid
     """
 
     if not isinstance(wires, Iterable):
@@ -236,8 +236,7 @@ def DisplacementEmbedding(features, wires, method='amplitude', c=0.1):
             the amplitude of all displacement gates if ``execution='phase'``
 
     Raises:
-        ValueError: if the wrong wires or features were defined or if an unknown execution method was
-            specified
+        ValueError: if `features` or `wires` is invalid or if `method` is unknown
    """
 
     if not isinstance(wires, Iterable):

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -75,6 +75,9 @@ def StronglyEntanglingLayer(weights, wires, r=1, imprimitive=CNOT):
     Keyword Args:
         r (int): range of the imprimitive gates of this layer, defaults to 1
         imprimitive (pennylane.ops.Operation): two-qubit gate to use, defaults to :class:`~pennylane.ops.CNOT`
+
+    Raises:
+        ValueError: if less than 2 wires were specified
     """
     if len(wires) < 2:
         raise ValueError("StronglyEntanglingLayer requires at least two wires or subsystems to apply "
@@ -152,6 +155,9 @@ def RandomLayer(weights, wires, ratio_imprim=0.3, imprimitive=CNOT, rotations=No
             determines how often a particular rotation type is used. Defaults to the use of all three
             rotations with equal frequency.
         seed (int): seed to generate random architecture
+
+    Raises:
+        ValueError: if less than 2 wires were specified
     """
 
     if len(wires) < 2:
@@ -346,6 +352,10 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
         beamsplitter (str): if ``clements``, the beamsplitter convention from
           Clements et al. 2016 (https://dx.doi.org/10.1364/OPTICA.3.001460) is used; if ``pennylane``, the
           beamsplitter is implemented via PennyLane's ``Beamsplitter`` operation.
+
+    Raises:
+        QuantumFunctionError: if the beamsplitter or the mesh is defined as a
+            :class:`~pennylane.variable.Variable`
     """
     if isinstance(beamsplitter, Variable):
         raise QuantumFunctionError("The beamsplitter parameter influences the "

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -354,7 +354,7 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
           beamsplitter is implemented via PennyLane's ``Beamsplitter`` operation.
 
     Raises:
-        QuantumFunctionError: if `beamsplitter` or `mesh` is an instance of
+        QuantumFunctionError: if ``beamsplitter`` or ``mesh`` is an instance of
             :class:`~pennylane.variable.Variable`
     """
     if isinstance(beamsplitter, Variable):

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -354,7 +354,7 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
           beamsplitter is implemented via PennyLane's ``Beamsplitter`` operation.
 
     Raises:
-        QuantumFunctionError: if the beamsplitter or the mesh is defined as a
+        QuantumFunctionError: if `beamsplitter` or `mesh` is an instance of
             :class:`~pennylane.variable.Variable`
     """
     if isinstance(beamsplitter, Variable):

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -58,7 +58,7 @@ def _unflatten(flat, model):
         model (array, Iterable, Number): model nested structure
 
     Raises:
-        TypeError: if `model` contains an object of unsupported type
+        TypeError: if ``model`` contains an object of unsupported type
 
     Returns:
         (other, array): first elements of flat arranged into the nested

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -58,7 +58,7 @@ def _unflatten(flat, model):
         model (array, Iterable, Number): model nested structure
 
     Raises:
-        TypeError: if the model contains unsupported type
+        TypeError: if `model` contains an object of unsupported type
 
     Returns:
         (other, array): first elements of flat arranged into the nested
@@ -88,7 +88,7 @@ def unflatten(flat, model):
         model (array, Iterable, Number): model nested structure
 
     Raises:
-        ValueError: if the flattened iterable has more elements than the model
+        ValueError: if 'flat' has more elements than `model`
     """
     # pylint:disable=len-as-condition
     res, tail = _unflatten(np.asarray(flat), model)

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -57,6 +57,9 @@ def _unflatten(flat, model):
         flat (array): 1D array of items
         model (array, Iterable, Number): model nested structure
 
+    Raises:
+        TypeError: if the model contains unsupported type
+
     Returns:
         (other, array): first elements of flat arranged into the nested
         structure of model, unused elements of flat
@@ -79,6 +82,13 @@ def _unflatten(flat, model):
 
 def unflatten(flat, model):
     """Wrapper for :func:`_unflatten`.
+
+    Args:
+        flat (array): 1D array of items
+        model (array, Iterable, Number): model nested structure
+
+    Raises:
+        ValueError: if the flattened iterable has more elements than the model
     """
     # pylint:disable=len-as-condition
     res, tail = _unflatten(np.asarray(flat), model)
@@ -129,6 +139,10 @@ def expand(U, wires, num_wires):
         U (array): :math:`2^n \times 2^n` matrix where n = len(wires).
         wires (Sequence[int]): Target subsystems (order matters! the
             left-most Hilbert space is at index 0).
+
+    Raises:
+        ValueError: if wrong wires of the system were targeted or
+            the size of the unitary is incorrect
 
     Returns:
         array: :math:`2^N\times 2^N` matrix. The full system operator.

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -88,7 +88,7 @@ def unflatten(flat, model):
         model (array, Iterable, Number): model nested structure
 
     Raises:
-        ValueError: if 'flat' has more elements than `model`
+        ValueError: if ``flat`` has more elements than ``model``
     """
     # pylint:disable=len-as-condition
     res, tail = _unflatten(np.asarray(flat), model)

--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -125,6 +125,9 @@ class Variable:
     def val(self):
         """Current numerical value of the Variable.
 
+        Raises:
+            TypeError: if the keyword arguments were not mapped to arrays
+
         Returns:
             float: current value of the Variable
         """


### PR DESCRIPTION
**Context:**
The ``Raises`` section is often missing from docstrings in PennyLane. Docstrings modifiend in the upcoming PR  #377 were left intact.

**Description of the Change:**
Adds the ``Raises`` section with a related message.

**Benefits:**
Information about exceptions appears in the documentation online.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A