### PR TITLE
Fix tf templates integration

### DIFF
--- a/doc/code/qml_templates.rst
+++ b/doc/code/qml_templates.rst
@@ -4,4 +4,3 @@ qml.templates
 .. currentmodule:: pennylane.templates
 
 .. automodule:: pennylane.templates
-

--- a/doc/code/qml_templates.rst
+++ b/doc/code/qml_templates.rst
@@ -4,3 +4,4 @@ qml.templates
 .. currentmodule:: pennylane.templates
 
 .. automodule:: pennylane.templates
+

--- a/pennylane/templates/__init__.py
+++ b/pennylane/templates/__init__.py
@@ -20,10 +20,15 @@ evaluate, and train quantum nodes.
 .. autosummary::
     :toctree: api
 
-    embeddings
     layers
+    embeddings
+
 """
+
+from .layers import *
+from .embeddings import *
+
 from .layers import __all__ as _layers__all__
 from .embeddings import __all__ as _embeddings__all__
 
-__all__ = list(_embeddings__all__ | _layers__all__)
+__all__ = _embeddings__all__ + _layers__all__

--- a/pennylane/templates/__init__.py
+++ b/pennylane/templates/__init__.py
@@ -23,3 +23,7 @@ evaluate, and train quantum nodes.
     embeddings
     layers
 """
+from .layers import __all__ as _layers__all__
+from .embeddings import __all__ as _embeddings__all__
+
+__all__ = list(_embeddings__all__ | _layers__all__)

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -253,3 +253,9 @@ def DisplacementEmbedding(features, wires, method='amplitude', c=0.1):
             Displacement(c, f, wires=wires[idx])
         else:
             raise ValueError("Execution method '{}' not known. Has to be 'phase' or 'amplitude'.".format(method))
+
+
+embeddings = {"AngleEmbedding", "AmplitudeEmbedding", "BasisEmbedding", "SqueezingEmbedding", "DisplacementEmbedding"}
+
+
+__all__ = list(embeddings)

--- a/pennylane/templates/embeddings.py
+++ b/pennylane/templates/embeddings.py
@@ -257,5 +257,4 @@ def DisplacementEmbedding(features, wires, method='amplitude', c=0.1):
 
 embeddings = {"AngleEmbedding", "AmplitudeEmbedding", "BasisEmbedding", "SqueezingEmbedding", "DisplacementEmbedding"}
 
-
 __all__ = list(embeddings)

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -12,15 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 r"""
-This module contains templates for trainable 'layers' of quantum gates.
-
-In contrast to other templates such as embeddings, layers
-do typically only take trainable parameters, and get repeated in the circuit -- just like the layers of a
-neural network. This makes the layer 'learnable' within the limits of the architecture.
-
-Most templates in this module have a 'Layer' version that implements a single layer, as well as a 'Layers'
-version which calls the single layer multiple times, possibly using different hyperparameters for the
-sequence in each call.
+This module contains templates for trainable 'layers' of quantum gates, which can be repeatedly
+applied in a quantum circuit.
 """
 #pylint: disable-msg=too-many-branches,too-many-arguments,protected-access
 from collections.abc import Sequence
@@ -183,7 +176,8 @@ def RandomLayer(weights, wires, ratio_imprim=0.3, imprimitive=CNOT, rotations=No
 
 
 def CVNeuralNetLayers(theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_2, a, phi_a, k, wires):
-    r"""A sequence of layers of type :func:`CVNeuralNetLayer()`, as specified in `arXiv:1806.06871 <https://arxiv.org/abs/1806.06871>`_.
+    r"""A sequence of layers of type :func:`CVNeuralNetLayer()`,
+    as specified in `arXiv:1806.06871 <https://arxiv.org/abs/1806.06871>`_.
 
     The number of layers :math:`L` is inferred from the first dimension of the eleven weight parameters. The layers
     act on the :math:`M` modes given in ``wires``, and include interferometers of :math:`K=M(M-1)/2` beamsplitters.
@@ -328,17 +322,19 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
 
     .. note::
 
-        The decomposition as formulated in `Clements et al. <https://dx.doi.org/10.1364/OPTICA.3.001460>`__ uses a different
-        convention for a beamsplitter :math:`T(\theta, \phi)` than PennyLane, namely:
+        The decomposition as formulated in `Clements et al. <https://dx.doi.org/10.1364/OPTICA.3.001460>`__
+        uses a different convention for a beamsplitter :math:`T(\theta, \phi)` than PennyLane, namely:
 
         .. math:: T(\theta, \phi) = BS(\theta, 0) R(\phi)
 
         For the universality of the decomposition, the used convention is irrelevant, but
         for a given set of angles the resulting interferometers will be different.
 
-        If an interferometer consistent with the convention from `Clements et al. <https://dx.doi.org/10.1364/OPTICA.3.001460>`__
+        If an interferometer consistent with the convention from
+        `Clements et al. <https://dx.doi.org/10.1364/OPTICA.3.001460>`__
         is needed, the optional keyword argument ``beamsplitter='clements'`` can be specified. This
-        will result in each :class:`~pennylane.ops.Beamsplitter` being preceded by a :class:`~pennylane.ops.Rotation` and
+        will result in each :class:`~pennylane.ops.Beamsplitter` being preceded by
+        a :class:`~pennylane.ops.Rotation` and
         thus increase the number of elementary operations in the circuit.
 
     Args:
@@ -411,6 +407,5 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
 
 
 layers = {"StronglyEntanglingLayers", "RandomLayers", "CVNeuralNetLayers", "Interferometer"}
-
 
 __all__ = list(layers)

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -42,8 +42,9 @@ def StronglyEntanglingLayers(weights, wires, ranges=None, imprimitive=CNOT):
     if ranges is None:
         ranges = [1]*len(weights)
 
-    for block_weights, block_range in zip(weights, ranges):
-        StronglyEntanglingLayer(block_weights, r=block_range, imprimitive=imprimitive, wires=wires)
+    n_layers = len(weights)
+    for l, block_range in zip(range(n_layers), ranges):
+        StronglyEntanglingLayer(weights[l], r=block_range, imprimitive=imprimitive, wires=wires)
 
 
 def StronglyEntanglingLayer(weights, wires, r=1, imprimitive=CNOT):
@@ -109,8 +110,9 @@ def RandomLayers(weights, wires, ratio_imprim=0.3, imprimitive=CNOT, rotations=N
     if rotations is None:
         rotations = [RX, RY, RZ]
 
-    for layer_weights in weights:
-        RandomLayer(layer_weights, wires=wires, ratio_imprim=ratio_imprim, imprimitive=imprimitive, rotations=rotations,
+    n_layers = len(weights)
+    for l in range(n_layers):
+        RandomLayer(weights[l], wires=wires, ratio_imprim=ratio_imprim, imprimitive=imprimitive, rotations=rotations,
                     seed=seed)
 
 

--- a/pennylane/templates/layers.py
+++ b/pennylane/templates/layers.py
@@ -408,3 +408,9 @@ def Interferometer(theta, phi, varphi, wires, mesh='rectangular', beamsplitter='
     # apply the final local phase shifts to all modes
     for i, p in enumerate(varphi):
         Rotation(p, wires=[w[i]])
+
+
+layers = {"StronglyEntanglingLayers", "RandomLayers", "CVNeuralNetLayers", "Interferometer"}
+
+
+__all__ = list(layers)


### PR DESCRIPTION
**Context:** During the templates re-design process @josh146 noticed that some templates are not compatible with the TensorFlow interface. It turns out the fix is very easy.

**Description of the Change:** In the Layers() templates, replace 

``
for w in weights:
``

with

``
for l in range(len(weights)):
``

**Benefits:** Makes templates TF compatible.

**Possible Drawbacks:** None

