### PR TITLE
[WIP] tensornetwork torch backend

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -199,7 +199,7 @@ class Device(abc.ABC):
             if any(obs.return_type is Sample for obs in observables):
                 return np.asarray(results, dtype="object")
 
-            return np.asarray(results)
+            return results #np.asarray(results)
 
     @property
     def op_queue(self):

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -65,7 +65,7 @@ def args_to_numpy(args):
 
     # if NumPy array is scalar, convert to a Python float
     res = [i.tolist() if (isinstance(i, np.ndarray) and not i.shape) else i for i in res]
-
+    res = list(args)
     return res
 
 
@@ -119,8 +119,12 @@ def TorchQNode(qnode):
             res = qnode(*ctx.args, **ctx.kwargs)
 
             if not isinstance(res, np.ndarray):
-                # scalar result, cast to NumPy scalar
-                res = np.array(res)
+                if isinstance(res, list):
+                    if isinstance(res[0], torch.Tensor):
+                        res = res[0]
+                    else:
+                        # scalar result, cast to NumPy scalar
+                        res = np.array(res)
 
             # if any input tensor uses the GPU, the output should as well
             for i in input_:
@@ -129,7 +133,7 @@ def TorchQNode(qnode):
                         cuda_device = i.get_device()
                         return torch.as_tensor(torch.from_numpy(res), device=cuda_device)
 
-            return torch.from_numpy(res)
+            return res #torch.from_numpy(res)
 
         @staticmethod
         def backward(ctx, grad_output): #pragma: no cover

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -105,6 +105,7 @@ import numbers
 from collections.abc import Sequence
 
 import numpy as np
+import torch
 
 from .qnode import QNode
 from .utils import _flatten, _unflatten
@@ -332,6 +333,8 @@ class Operator(abc.ABC):
                 if not isinstance(p, np.ndarray):
                     raise TypeError('{}: Array parameter expected, got {}.'.format(self.name, type(p)))
         elif self.par_domain in ('R', 'N'):
+            if isinstance(p, torch.Tensor):
+                return p
             if not isinstance(p, numbers.Real):
                 raise TypeError('{}: Real scalar parameter expected, got {}.'.format(self.name, type(p)))
 

--- a/pennylane/qnode.py
+++ b/pennylane/qnode.py
@@ -230,7 +230,7 @@ class QNode:
                 temp = [Variable(idx, name=key) for idx, _ in enumerate(_flatten(val))]
                 kwarg_variables[key] = unflatten(temp, val)
 
-        Variable.free_param_values = np.array(list(_flatten(args)))
+        Variable.free_param_values = list(_flatten(args)) #np.array(list(_flatten(args)))
         Variable.kwarg_values = {k: np.array(list(_flatten(v))) for k, v in keyword_values.items()}
 
         # set up the context for Operation entry
@@ -610,7 +610,7 @@ class QNode:
         # keyword_values.update(kwargs_as_position)
 
         # temporarily store the free parameter values in the Variable class
-        Variable.free_param_values = np.array(list(_flatten(args)))
+        Variable.free_param_values = list(_flatten(args)) #np.array(list(_flatten(args)))
         Variable.kwarg_values = keyword_values
 
         self.device.reset()
@@ -632,7 +632,7 @@ class QNode:
             check_op(op)
 
         ret = self.device.execute(self.circuit.operations, self.circuit.observables, self.variable_deps)
-        return self.output_conversion(ret)
+        return ret #self.output_conversion(ret)
 
     def metric_tensor(self, *args, **kwargs):
         """Evaluate the value of the metric tensor.

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -23,6 +23,7 @@ import inspect
 import itertools
 
 import numpy as np
+import torch
 
 import pennylane as qml
 from pennylane.variable import Variable
@@ -41,6 +42,8 @@ def _flatten(x):
     """
     if isinstance(x, np.ndarray):
         yield from _flatten(x.flat)  # should we allow object arrays? or just "yield from x.flat"?
+    elif isinstance(x, torch.Tensor):
+        yield from x
     elif isinstance(x, Iterable) and not isinstance(x, (str, bytes)):
         for item in x:
             yield from _flatten(item)
@@ -68,6 +71,10 @@ def _unflatten(flat, model):
         return flat[0], flat[1:]
     elif isinstance(model, np.ndarray):
         idx = model.size
+        res = np.array(flat)[:idx].reshape(model.shape)
+        return res, flat[idx:]
+    elif isinstance(model, torch.Tensor):
+        idx = model.size().numel()
         res = np.array(flat)[:idx].reshape(model.shape)
         return res, flat[idx:]
     elif isinstance(model, Iterable):


### PR DESCRIPTION
**Context:** Adding support for the tensornetwork backend to directly execute the entire computation in pytorch

**Description of the Change:** This is a WIP. So far I have just hacked the pipeline to see where we need to change things. Some things are simple fixes (checking for torch tensor types), others are bigger blockers (torch does not support complex number tensors).

**Benefits:** we need to do this if we want to enable backpropagation for gradient computations (can be much faster than parameter-shift rule)

**Possible Drawbacks:** Right now, the biggest blocker seems to be lack of complex number support, as well as potentially needing to make pytorch an explicit dependency (since there are several spots along the pipeline where we need to check if something is a ``torch.Tensor``)

**Related GitHub Issues:** N/A

===================================================

Steps needed to ensure the whole pipeline worked:

- ``args_to_numpy`` not really needed (only to convert tuple->list)
- ``_flatten`` and ``unflatten`` functions need to be made compatible with ``torch.Tensor``s
- ``Variable.free_param_values = list(_flatten(args))`` casts to numpy array (lose torch.Tensors). This happens twice in qnode.py. Probably ok for kwargs?
- ``self.output_conversion = float`` needs to keep Tensors as Tensors
- ``if not isinstance(p, numbers.Real)`` in operation.py does not recognize a real-valued torch.Tensors
- will need to manually code up backend-specific (or dispatched) versions of all matrix-creating functions for tensornetwork
- pytorch doesn't like complex tensors :(
- need to declare backend when creating tn.Node (it doesn't infer from data)
- torch doesn't seem to like tensordot when the arguments contain both numpy arrays and tensors
- need to convert observables to tensors before making them into nodes
- pytorch tensordot complains if the two tensors have different numeric dtypes (float/double)
- ``expval.imag`` and ``expval.real`` in tensornetwork ``ev`` method fail for pytorch tensors
- ``execute`` has a final line ``return np.asarray(results)``, which kills the tensor
- ``self.output_conversion(ret)`` in qnode.py does not work because it references the function `float`
- ``forward`` attempts to convert the result of the qnode to a numpy array
- ``return torch.from_numpy(res)`` in `_TorchQNode` attempts to create a torch object from numpy (but if the object is already a torch tensor, it fails)

Other notes:

- There still seems to be a lot of autograd stuff hanging around (i.e., a torch qnode is still wrapped by autograd as an ``ae.primative``). Perhaps this will be fixed by ``JacobianQNode`` PR
- we do a lot of flattening/unflattening multiple times. Might it make sense to just do this once at start/finish

