### PR TITLE
Refactor getting the operator matrix into separate method

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -386,8 +386,8 @@ class DefaultQubit(Device):
         """
         if isinstance(observable, list):
             return self._get_tensor_operator_matrix(observable, par)
-        else:
-            return self._get_operator_matrix(observable, par)
+
+        return self._get_operator_matrix(observable, par)
 
     def expval(self, observable, wires, par):
         if self.analytic:

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -375,13 +375,24 @@ class DefaultQubit(Device):
         state_multi_index = np.transpose(tdot, inv_perm)
         return np.reshape(state_multi_index, 2 ** self.num_wires)
 
+    def get_operator_matrix_for_measurement(self, observable, par):
+        """Get the operator matrix for a given observable before measurement.
+
+        Args:
+          observable (str or list[str]): name of the operation/observable
+          par (tuple[float] or list[list[Any]]): parameter values
+        Returns:
+          array: matrix representation.
+        """
+        if isinstance(observable, list):
+            return self._get_tensor_operator_matrix(observable, par)
+        else:
+            return self._get_operator_matrix(observable, par)
+
     def expval(self, observable, wires, par):
         if self.analytic:
             # exact expectation value
-            if isinstance(observable, list):
-                A = self._get_tensor_operator_matrix(observable, par)
-            else:
-                A = self._get_operator_matrix(observable, par)
+            A = self.get_operator_matrix_for_measurement(observable, par)
 
             ev = self.ev(A, wires)
         else:
@@ -393,10 +404,7 @@ class DefaultQubit(Device):
     def var(self, observable, wires, par):
         if self.analytic:
             # exact variance value
-            if isinstance(observable, list):
-                A = self._get_tensor_operator_matrix(observable, par)
-            else:
-                A = self._get_operator_matrix(observable, par)
+            A = self.get_operator_matrix_for_measurement(observable, par)
 
             var = self.ev(A@A, wires) - self.ev(A, wires)**2
         else:
@@ -406,10 +414,7 @@ class DefaultQubit(Device):
         return var
 
     def sample(self, observable, wires, par):
-        if isinstance(observable, list):
-            A = self._get_tensor_operator_matrix(observable, par)
-        else:
-            A = self._get_operator_matrix(observable, par)
+        A = self.get_operator_matrix_for_measurement(observable, par)
 
         a, P = spectral_decomposition(A)
 


### PR DESCRIPTION
**Context:**
Currently, the ``expval``, ``var`` and ``sample`` methods of ``default_qubit`` all include a minor check for getting the operator matrix of an observable. This is done so that not just a single, but multiple observables are accepted.

**Description of the Change:**
Organizes the check into the new separate method ``get_operator_matrix_for_measurement`` in ``default_qubit``.

**Benefits:**
Removes code duplication and makes the code cleaner.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A