### PR TITLE
Replace pinv with np.linalg.solve in the QNG optimizer

### DIFF
--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -99,8 +99,6 @@ class QNGOptimizer(GradientDescentOptimizer):
             time taken per optimization step.
         lam (float): metric tensor regularization :math:`G_{ij}+\lambda I`
             to be applied at each optimization step
-        tol (float): tolerance used when finding the inverse of the
-            quantum gradient tensor
     """
     def __init__(self, stepsize=0.01, diag_approx=False, lam=0):
         super().__init__(stepsize)

--- a/pennylane/optimize/qng.py
+++ b/pennylane/optimize/qng.py
@@ -15,7 +15,6 @@
 #pylint: disable=too-many-branches
 
 import numpy as np
-from scipy import linalg
 
 from pennylane.utils import _flatten, unflatten
 from .gradient_descent import GradientDescentOptimizer

--- a/tests/test_optimize_qng.py
+++ b/tests/test_optimize_qng.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for the QNG optimizer"""
 import pytest
+import scipy as sp
 
 import pennylane as qml
 from pennylane import numpy as np
@@ -77,12 +78,12 @@ class TestOptimize:
             theta_new = opt.step(circuit, theta)
 
             # check metric tensor
-            res = opt.metric_tensor_inv
-            exp = np.diag([4, 4 / (np.cos(theta[0]) ** 2)])
+            res = opt.metric_tensor
+            exp = np.diag([0.25, (np.cos(theta[0]) ** 2)/4])
             assert np.allclose(res, exp, atol=tol, rtol=0)
 
             # check parameter update
-            dtheta = eta * exp @ gradient(theta)
+            dtheta = eta * sp.linalg.pinvh(exp) @ gradient(theta)
             assert np.allclose(dtheta, theta - theta_new, atol=tol, rtol=0)
 
             theta = theta_new


### PR DESCRIPTION
**Context:** The explicit pseudo-inverse, as used by the QNG optimizer, can be numerically unstable.

**Description of the Change:** Replaces the use of `sp.linalg.pinvh(metric_tensor) @ grad` with `np.linalg.solve(metric_tensor, grad)`.

**Benefits:** Should be much more stable and have better accuracy.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
