### PR TITLE
Correct typo in configuration file

### DIFF
--- a/doc/introduction/configuration.rst
+++ b/doc/introduction/configuration.rst
@@ -44,7 +44,7 @@ and has the following format:
     # Global PennyLane options.
     # Affects every loaded plugin if applicable.
     shots = 1000
-    analytic = True
+    analytic = true
 
     [strawberryfields.global]
     # Options for the Strawberry Fields plugin


### PR DESCRIPTION
Fix the typo in the example for the configuration file