### PR TITLE
Adding the copy button in sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,6 +44,7 @@ extensions = [
     # 'sphinx_gallery.gen_gallery',
     "sphinx.ext.intersphinx",
     "sphinx_automodapi.automodapi",
+    'sphinx_copybutton',
 ]
 
 autosummary_generate = True

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,6 +7,7 @@ semantic_version==2.6
 scipy
 sphinx==1.8.5
 sphinx-automodapi
+sphinx-copybutton
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.0
 tensornetwork==0.2


### PR DESCRIPTION
**Context:**
There are many copy snippets on the PL documentation websites and it would be nice to make them copiable.

**Description of the Change:**
Adds the ``sphinx-copybutton`` extension and the requirement for the extension.

**Benefits:**
Every code snippet becomes copiable.

**Possible Drawbacks:**
This copy button does not hide prompts such as ``>>>`` in the beginning of the line or result lines. This is currently an open issue: https://github.com/choldgraf/sphinx-copybutton/issues/30

Another approach could be using a [solution that hides prompts](http://z4r.github.io/python/2011/12/02/hides-the-prompts-and-output/). This would then, not have the copying functionality.

**Related GitHub Issues:**
N/A