### PR TITLE
Reordering and adding pennylane.qnodes to setup.py's packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,15 @@ info = {
     'license': 'Apache License 2.0',
     'packages': [
                     'pennylane',
-                    'pennylane.ops',
-                    'pennylane.templates',
-                    'pennylane.plugins',
-                    'pennylane.optimize',
-                    'pennylane.interfaces',
                     'pennylane.beta',
                     'pennylane.beta.plugins',
                     'pennylane.beta.vqe',
+                    'pennylane.interfaces',
+                    'pennylane.ops',
+                    'pennylane.optimize',
+                    'pennylane.plugins',
+                    'pennylane.qnodes',
+                    'pennylane.templates',
                 ],
     'entry_points': {
         'pennylane.plugins': [


### PR DESCRIPTION
**Context:**
When installing PennyLane through
``pip install git+https://github.com/XanaduAI/pennylane.git#egg=pennylane``, the following traceback follows upon ``import pennylane``:

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/lib/python3.7/site-packages/pennylane/__init__.py", line 35, in <module>
    from ._device import Device, DeviceError
  File "/lib/python3.7/site-packages/pennylane/_device.py", line 23, in <module>
    from pennylane.qnodes import QuantumFunctionError
ModuleNotFoundError: No module named 'pennylane.qnodes'
```

**Description of the Change:**
Adding ``pennylane.qnodes`` to the ``packages`` list in ``setup.py`` and ordering the other packages in alphabetical order.

**Benefits:**
The packaging is corrected and ``pip install git+https://github.com/XanaduAI/pennylane.git#egg=pennylane`` will work just fine.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A