### PR TITLE
Add missing tensornetwork requirement to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
     "numpy",
     "scipy",
     "networkx",
+    "tensornetwork",
     "autograd",
     "toml",
     "appdirs",


### PR DESCRIPTION
**Context:**
The ``tensornetwork`` library is not listed as a requirement in the ``setup.py`` file, although it is in the ``requirements.txt``.

**Description of the Change:**
Add ``tensornetwork`` to the requirements in the ``setup.py`` file.

**Benefits:**
The ``tensornetwork`` package will be installed when ``pennylane`` is installed. Otherwise messages such as ``.expt.tensornet device requires TensorNetwork>=0.2`` are outputted.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A