### PR TITLE
Pin scipy to version 1.3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,12 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install wheel pytest pytest-cov absl-py==0.8.1 --upgrade
+- pip install wheel pytest pytest-cov absl-py --upgrade
 - if [ "$TF" = "2" ]; then pip install tensorflow==2.0; fi
 - if [ "$TF" = "1" ]; then pip install tensorflow==1.13.2; fi
 - pip install torch==1.3.0+cpu torchvision==0.4.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
-- pip freeze
 script:
 - make coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
 - pip install torch==1.3.0+cpu torchvision==0.4.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
+- pip freeze
 script:
 - make coverage
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - LOGGING=info
 install:
 - pip install -r requirements.txt
-- pip install wheel pytest pytest-cov absl-py --upgrade
+- pip install wheel pytest pytest-cov absl-py==0.8.1 --upgrade
 - if [ "$TF" = "2" ]; then pip install tensorflow==2.0; fi
 - if [ "$TF" = "1" ]; then pip install tensorflow==1.13.2; fi
 - pip install torch==1.3.0+cpu torchvision==0.4.1+cpu -f https://download.pytorch.org/whl/torch_stable.html

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,12 +1,11 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 pip==19.3.1
-absl-py==0.8.1
 appdirs
 autograd
 numpy
 pygments-github-lexers
 semantic_version==2.6
-scipy
+scipy==1.3.2
 sphinx==2.2.2
 sphinx-automodapi
 sphinx-copybutton

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,6 @@
 --find-links https://download.pytorch.org/whl/torch_stable.html
 pip==19.3.1
+absl-py==0.8.1
 appdirs
 autograd
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+absl-py==0.8.1
 numpy
 scipy
 networkx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-absl-py==0.8.1
 numpy
-scipy
+scipy==1.3.2
 networkx
 tensornetwork
 autograd

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane/_version.py") as f:
 
 requirements = [
     "numpy",
-    "scipy",
+    "scipy==1.3.2",
     "networkx",
     "autograd",
     "toml",


### PR DESCRIPTION
**Context:** The latest release of SciPy, v1.4.0, uses a version of pybind11 that clashes with the version used for PyTorch. Attempting to import pytorch _after_ SciPy will lead to a segmentation fault.

**Description of the Change:** Pins scipy to v1.3.2 for now, to temporarily fix the issue.

**Benefits:** CI and docs will build again

**Possible Drawbacks:** Will need to remember to unpin once 1.4.1 is released.

**Related GitHub Issues:** https://github.com/scipy/scipy/issues/11237
