### PR TITLE
Revert "Pin scipy to version 1.3.2"

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,7 +5,7 @@ autograd
 numpy
 pygments-github-lexers
 semantic_version==2.6
-scipy==1.3.2
+scipy
 sphinx==2.2.2
 sphinx-automodapi
 sphinx-copybutton

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-scipy==1.3.2
+scipy
 networkx
 tensornetwork
 autograd

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open("pennylane/_version.py") as f:
 
 requirements = [
     "numpy",
-    "scipy==1.3.2",
+    "scipy",
     "networkx",
     "autograd",
     "toml",


### PR DESCRIPTION
Reverts XanaduAI/pennylane#447

Now that Scipy 1.4.1 is out, this PR can be reverted