### PR TITLE
Adding the Identity option for returning the eigenvalues of a Tensor …

### DIFF
--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -757,6 +757,10 @@ class Tensor(Observable):
                             herm_eigs = qml.Hermitian.eigvals(np.array(operator))
                             self._eigvals = np.kron(self._eigvals, herm_eigs)
 
+                        elif ns_obs[0].name == "Identity":
+                            # Identity observable has eigenvalues (1, 1)
+                            self._eigvals = np.kron(self._eigvals, np.array([1, 1]))
+
         return self._eigvals
 
 #=============================================================================

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -727,6 +727,15 @@ class TestTensor:
         t = t.eigvals
         assert np.allclose(t, d, atol=tol, rtol = 0)
 
+    def test_eigvals_identity(self, tol):
+        """Test that the correct eigenvalues are returned for the Tensor"""
+        X = qml.PauliX(0)
+        Iden = qml.Identity(1)
+        t = Tensor(X, Iden)
+        d = np.kron(np.array([1., -1.]), np.array([1.,  1.]))
+        t = t.eigvals
+        assert np.allclose(t, d, atol=tol, rtol = 0)
+
 
 class TestDecomposition:
     """Test for operation decomposition"""


### PR DESCRIPTION
**Context:**
The ``qml.Identity`` class is currently a subclass of ``CVObservable``. However, it can be used in the qubit case as well, as there is a separate check for it in ``pennylane/qnodes/base.py``.

**Description of the Change:**
Include ``qml.Identity`` when returning the eigenvalues of a ``Tensor`` object.

**Benefits:**
The ``qml.Identity`` can be defined as part of a ``Tensor`` object.

**Possible Drawbacks:**
Slight ambiguity around the type of ``qml.Identity`` in the UI.

**Related GitHub Issues:**
N/A