### PR TITLE
Refactor function names

### DIFF
--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -134,7 +134,7 @@ and map it to a linear combination of Pauli operators via the `Jordan-Wigner
 
 .. code-block:: python
 
-    qubit_hamiltonian = qchem.decompose_hamiltonian(
+    qubit_hamiltonian = qml.qchem.decompose_hamiltonian(
         'water',
         hf_data,
         mapping='jordan_wigner',

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -545,12 +545,10 @@ def generate_hamiltonian(
         mol_name, hf_data, n_active_electrons, n_active_orbitals
     )
 
-    h_of, nr_qubits = (
+    return (
         decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices, active_indices),
         2 * len(active_indices),
     )
-
-    return convert_hamiltonian(h_of), nr_qubits
 
 
 __all__ = [

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -547,7 +547,7 @@ def generate_hamiltonian(
 
     return (
         decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices, active_indices),
-        2 * len(active_indices),
+        2 * len(active_indices)
     )
 
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -547,7 +547,7 @@ def generate_hamiltonian(
 
     return (
         decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices, active_indices),
-        2 * len(active_indices)
+        2 * len(active_indices),
     )
 
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -20,8 +20,7 @@ from shutil import copyfile
 import numpy as np
 from openfermion.hamiltonians import MolecularData
 from openfermion.ops._qubit_operator import QubitOperator
-from openfermion.transforms import (bravyi_kitaev, get_fermion_operator,
-                                    jordan_wigner)
+from openfermion.transforms import bravyi_kitaev, get_fermion_operator, jordan_wigner
 from openfermionpsi4 import run_psi4
 from openfermionpyscf import run_pyscf
 
@@ -109,8 +108,9 @@ def read_structure(filepath, outpath="."):
         if not _exec_exists("obabel"):
             raise TypeError(obabel_error_message)
         try:
-            subprocess.run(["obabel", "-i" + extension, file_in, "-oxyz", "-O", file_out],
-                           check=True)
+            subprocess.run(
+                ["obabel", "-i" + extension, file_in, "-oxyz", "-O", file_out], check=True
+            )
         except subprocess.CalledProcessError as e:
             raise RuntimeError(
                 "Open Babel error. See the following Open Babel "
@@ -127,9 +127,9 @@ def read_structure(filepath, outpath="."):
     return geometry
 
 
-def gen_meanfield_data(
-        mol_name, geometry, charge, multiplicity, basis, qc_package="pyscf", outpath="."
-        ):  # pylint: disable=too-many-arguments
+def meanfield_data(
+    mol_name, geometry, charge, multiplicity, basis, qc_package="pyscf", outpath="."
+):  # pylint: disable=too-many-arguments
     r"""Launches the meanfield (Hartree-Fock) electronic structure calculation.
 
     Also builds the path to the directory containing the input data file for quantum simulations.
@@ -138,7 +138,7 @@ def gen_meanfield_data(
     **Example usage:**
 
     >>> geometry = read_structure('h2_ref.xyz')
-    >>> gen_meanfield_data('h2', geometry, 0, 1, 'sto-3g', qc_package='pyscf')
+    >>> meanfield_data('h2', geometry, 0, 1, 'sto-3g', qc_package='pyscf')
     ./pyscf/sto-3g
 
     Args:
@@ -193,12 +193,12 @@ def gen_meanfield_data(
     return path_to_hf_data
 
 
-def gen_active_space(mol_name, hf_data, n_active_electrons=None, n_active_orbitals=None):
+def active_space(mol_name, hf_data, n_active_electrons=None, n_active_orbitals=None):
     r"""Builds the active space by partitioning the set of Hartree-Fock molecular orbitals.
 
     **Example usage:**
 
-    >>> d_occ_orbitals, active_orbitals = gen_active_space('lih', './pyscf/sto-3g',
+    >>> d_occ_orbitals, active_orbitals = active_space('lih', './pyscf/sto-3g',
     n_active_electrons=2, n_active_orbitals=2)
     >>> d_occ_indices  # doubly-occupied molecular orbitals
     [0]
@@ -302,15 +302,15 @@ def gen_active_space(mol_name, hf_data, n_active_electrons=None, n_active_orbita
     return docc_indices, active_indices
 
 
-def gen_hamiltonian_pauli_basis(
-        mol_name, hf_data, mapping="jordan_wigner", docc_mo_indices=None, active_mo_indices=None
-        ):
+def decompose_hamiltonian(
+    mol_name, hf_data, mapping="jordan_wigner", docc_mo_indices=None, active_mo_indices=None
+):
     r"""Decomposes the electronic Hamiltonian into a linear combination of Pauli operators using
     OpenFermion tools.
 
     **Example usage:**
 
-    >>> gen_hamiltonian_pauli_basis('h2', './pyscf/sto-3g/', mapping='bravyi_kitaev')
+    >>> decompose_hamiltonian('h2', './pyscf/sto-3g/', mapping='bravyi_kitaev')
     (-0.04207897696293986+0j) [] + (0.04475014401986122+0j) [X0 Z1 X2] +
     (0.04475014401986122+0j) [X0 Z1 X2 Z3] +(0.04475014401986122+0j) [Y0 Z1 Y2] +
     (0.04475014401986122+0j) [Y0 Z1 Y2 Z3] +(0.17771287459806262+0j) [Z0] +
@@ -458,13 +458,13 @@ def _qubit_operators_equivalent(openfermion_qubit_operator, pennylane_qubit_oper
     return openfermion_qubit_operator == _terms_to_qubit_operator(coeffs, ops)
 
 
-def load_hamiltonian(qubit_hamiltonian):
+def convert_hamiltonian(qubit_hamiltonian):
     r"""Converts OpenFermion `QubitOperator` Hamiltonian to Pennylane VQE Hamiltonian
 
     **Example usage**
 
-    >>> h_of = gen_hamiltonian_pauli_basis('h2', './pyscf/sto-3g/')
-    >>> h_pl = load_hamiltonian(h_of)
+    >>> h_of = decompose_hamiltonian('h2', './pyscf/sto-3g/')
+    >>> h_pl = convert_hamiltonian(h_of)
     >>> h_pl.coeffs
     [-0.04207898+0.j  0.17771287+0.j  0.17771287+0.j -0.2427428 +0.j -0.2427428 +0.j  0.17059738+0.j
     0.04475014+0.j  0.04475014+0.j  0.04475014+0.j  0.04475014+0.j  0.12293305+0.j  0.16768319+0.j
@@ -484,18 +484,18 @@ def load_hamiltonian(qubit_hamiltonian):
     return Hamiltonian(*_qubit_operator_to_terms(qubit_hamiltonian))
 
 
-def generate_mol_hamiltonian(
-        mol_name,
-        mol_geo_file,
-        mol_charge,
-        multiplicity,
-        basis_set,
-        qc_package="pyscf",
-        n_active_electrons=None,
-        n_active_orbitals=None,
-        mapping="jordan_wigner",
-        outpath=".",
-        ):  # pylint:disable=too-many-arguments
+def generate_hamiltonian(
+    mol_name,
+    mol_geo_file,
+    mol_charge,
+    multiplicity,
+    basis_set,
+    qc_package="pyscf",
+    n_active_electrons=None,
+    n_active_orbitals=None,
+    mapping="jordan_wigner",
+    outpath=".",
+):  # pylint:disable=too-many-arguments
     r"""Generates the qubit Hamiltonian based on geometry and mean field electronic structure.
 
     An active space can be defined, otherwise the Hamiltonian is expanded in the full basis of
@@ -503,7 +503,7 @@ def generate_mol_hamiltonian(
 
     **Example usage:**
 
-    >>> generate_mol_hamiltonian('h2', 'h2_ref.xyz', 0, 1, 'sto-3g')
+    >>> generate_hamiltonian('h2', 'h2_ref.xyz', 0, 1, 'sto-3g')
     (-0.04207897696293986+0j) [] +(-0.04475014401986122+0j) [X0 X1 Y2 Y3] +
     (0.04475014401986122+0j) [X0 Y1 Y2 X3] +(0.04475014401986122+0j) [Y0 X1 X2 Y3] +
     (-0.04475014401986122+0j) [Y0 Y1 X2 X3] +(0.17771287459806262+0j) [Z0] +
@@ -531,34 +531,36 @@ def generate_mol_hamiltonian(
                 map the second-quantized electronic Hamiltonian to the qubit Hamiltonian
         outpath (str): path to the directory containing output files
     Returns:
-        tuple(QubitOperator, int): the fermionic-to-qubit transformed Hamiltonian
-            and the total number of qubits
+        tuple(pennylane.beta.vqe.Hamiltonian, int): the fermionic-to-qubit transformed
+        Hamiltonian and the number of qubits
      """
 
     geometry = read_structure(mol_geo_file, outpath)
 
-    hf_data = gen_meanfield_data(
+    hf_data = meanfield_data(
         mol_name, geometry, mol_charge, multiplicity, basis_set, qc_package, outpath
     )
 
-    docc_indices, active_indices = gen_active_space(
+    docc_indices, active_indices = active_space(
         mol_name, hf_data, n_active_electrons, n_active_orbitals
     )
 
-    return (
-        gen_hamiltonian_pauli_basis(mol_name, hf_data, mapping, docc_indices, active_indices),
+    h_of, nr_qubits = (
+        decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices, active_indices),
         2 * len(active_indices),
     )
+
+    return convert_hamiltonian(h_of), nr_qubits
 
 
 __all__ = [
     "read_structure",
-    "gen_meanfield_data",
-    "gen_active_space",
-    "gen_hamiltonian_pauli_basis",
+    "meanfield_data",
+    "active_space",
+    "decompose_hamiltonian",
     "_qubit_operator_to_terms",
     "_terms_to_qubit_operator",
     "_qubit_operators_equivalent",
-    "load_hamiltonian",
-    "generate_mol_hamiltonian",
+    "convert_hamiltonian",
+    "generate_hamiltonian",
 ]

--- a/qchem/tests/test_active_space.py
+++ b/qchem/tests/test_active_space.py
@@ -25,7 +25,7 @@ def test_active_spaces(
 
     r"""Test the correctness of the generated active spaces"""
 
-    docc_indices, active_indices = qchem.gen_active_space(
+    docc_indices, active_indices = qchem.active_space(
         mol_name, ref_dir, n_act_electrons, n_act_orbitals
     )
 
@@ -53,4 +53,4 @@ def test_inconsistent_active_spaces(mol_name, n_act_electrons, n_act_orbitals, m
     r"""Test that an error is raised if an inconsistent active space is generated"""
 
     with pytest.raises(ValueError, match=message_match):
-        qchem.gen_active_space(mol_name, ref_dir, n_act_electrons, n_act_orbitals)
+        qchem.active_space(mol_name, ref_dir, n_act_electrons, n_act_orbitals)

--- a/qchem/tests/test_convert_hamiltonian.py
+++ b/qchem/tests/test_convert_hamiltonian.py
@@ -299,7 +299,7 @@ def test_load_hamiltonian(mol_name, terms_ref, monkeypatch):
     if terms_ref is not None:
         monkeypatch.setattr(qOp, "terms", terms_ref)
 
-    vqe_hamiltonian = qchem.load_hamiltonian(qOp)
+    vqe_hamiltonian = qchem.convert_hamiltonian(qOp)
 
     assert qchem._qubit_operators_equivalent(qOp, vqe_hamiltonian)
 
@@ -348,12 +348,12 @@ def test_not_xyz_terms_to_qubit_operator():
     ],
 )
 def test_integration_hamiltonian_to_vqe_cost(monkeypatch, mol_name, terms_ref, expected_cost, tol):
-    r"""Test if `load_hamiltonian()` in qchem integrates with `vqe.cost()` in pennylane"""
+    r"""Test if `convert_hamiltonian()` in qchem integrates with `vqe.cost()` in pennylane"""
 
     qOp = QubitOperator()
     if terms_ref is not None:
         monkeypatch.setattr(qOp, "terms", terms_ref)
-    vqe_hamiltonian = qchem.load_hamiltonian(qOp)
+    vqe_hamiltonian = qchem.convert_hamiltonian(qOp)
 
     # maybe make num_qubits a @property of the Hamiltonian class?
     num_qubits = max(1, len(set([w for op in vqe_hamiltonian.ops for ws in op.wires for w in ws])))
@@ -387,11 +387,11 @@ def test_integration_hamiltonian_to_vqe_cost(monkeypatch, mol_name, terms_ref, e
 def test_integration_mol_file_to_vqe_cost(
     hf_filename, docc_mo, act_mo, type_of_transformation, expected_cost, tol
 ):
-    r"""Test if the output of `gen_hamiltonian_pauli_basis()` works with `load_hamiltonian()`
+    r"""Test if the output of `decompose_hamiltonian()` works with `convert_hamiltonian()`
     to generate `vqe.cost()`"""
     ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 
-    transformed_hamiltonian = qchem.gen_hamiltonian_pauli_basis(
+    transformed_hamiltonian = qchem.decompose_hamiltonian(
         hf_filename,
         ref_dir,
         mapping=type_of_transformation,
@@ -399,7 +399,7 @@ def test_integration_mol_file_to_vqe_cost(
         active_mo_indices=act_mo,
     )
 
-    vqe_hamiltonian = qchem.load_hamiltonian(transformed_hamiltonian)
+    vqe_hamiltonian = qchem.convert_hamiltonian(transformed_hamiltonian)
     assert len(vqe_hamiltonian.ops) > 1  # just to check if this runs
 
     num_qubits = max(1, len(set([w for op in vqe_hamiltonian.ops for ws in op.wires for w in ws])))

--- a/qchem/tests/test_decompose_hamiltonian.py
+++ b/qchem/tests/test_decompose_hamiltonian.py
@@ -517,7 +517,7 @@ def test_transformation(
     of the electronic Hamiltonian of different molecules (:math: `H_2, H_2O, LiH`) represented
     in different active spaces."""
 
-    transformed_hamiltonian = qchem.gen_hamiltonian_pauli_basis(
+    transformed_hamiltonian = qchem.decompose_hamiltonian(
         hf_filename,
         ref_dir,
         mapping=type_of_transformation,
@@ -538,7 +538,7 @@ def test_not_available_transformation():
     is neither 'jordan_wigner' nor 'bravyi_kitaev'."""
 
     with pytest.raises(TypeError, match="transformation is not available"):
-        qchem.gen_hamiltonian_pauli_basis(
+        qchem.decompose_hamiltonian(
             "lih",
             ref_dir,
             mapping="not_available_transformation",

--- a/qchem/tests/test_generate_hamiltonian.py
+++ b/qchem/tests/test_generate_hamiltonian.py
@@ -62,7 +62,7 @@ def test_building_hamiltonian(
 
     geo_file = os.path.join(ref_dir, geo_file)
 
-    built_hamiltonian, n_qubits = qchem.generate_mol_hamiltonian(
+    built_hamiltonian, n_qubits = qchem.generate_hamiltonian(
         mol_name,
         geo_file,
         charge,

--- a/qchem/tests/test_meanfield_data.py
+++ b/qchem/tests/test_meanfield_data.py
@@ -23,7 +23,7 @@ def test_path_to_hf_data(names, tmpdir, psi4_support):
 
     path_to_hf_data_ref = os.path.join(tmpdir.strpath, names.lower(), basis.strip())
 
-    path_to_hf_data = qchem.gen_meanfield_data(
+    path_to_hf_data = qchem.meanfield_data(
         mol_name, geometry, charge, multiplicity, basis, qc_package=names, outpath=tmpdir.strpath
     )
 
@@ -60,7 +60,7 @@ def test_hf_calculations(names, tmpdir, psi4_support, tol):
         ]
     )
 
-    path_to_hf_data = qchem.gen_meanfield_data(
+    path_to_hf_data = qchem.meanfield_data(
         mol_name, geometry, charge, multiplicity, basis, qc_package=names, outpath=tmpdir.strpath
     )
 
@@ -80,7 +80,7 @@ def test_not_available_qc_package(names, tmpdir):
     r"""Test that an error is raised if the chosen quantum chemistry package is neither Psi4 nor PySCF"""
 
     with pytest.raises(TypeError, match="Integration with quantum chemistry package"):
-        qchem.gen_meanfield_data(
+        qchem.meanfield_data(
             mol_name,
             geometry,
             charge,


### PR DESCRIPTION
Function names in PL-Qchem were previously long and repetitive. This PR changes function names to shorten then and make them more intuitive. Note that file names for tests have also been changed