### PR TITLE
Remove duplicate definition

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -500,18 +500,3 @@ class DefaultQubit(QubitDevice):
             p[idx] = self.ev(Pi, wires)
 
         return np.random.choice(a, self.shots, p=p)
-
-    def ev(self, A, wires):
-        r"""Expectation value of observable on specified wires.
-         Args:
-            A (array[float]): the observable matrix as array
-            wires (Sequence[int]): target subsystems
-         Returns:
-            float: expectation value :math:`\expect{A} = \bra{\psi}A\ket{\psi}`
-        """
-        As = self.mat_vec_product(A, self._state, np.hstack(wires).tolist())
-        expectation = np.vdot(self._state, As)
-
-        if np.abs(expectation.imag) > tolerance:
-            warnings.warn('Nonvanishing imaginary part {} in expectation value.'.format(expectation.imag), RuntimeWarning)
-        return expectation.real


### PR DESCRIPTION
**Context:**
The definition of the ``ev`` method was duplicated in the recent version of ``DefaultQubit``.

**Description of the Change:**
Remove the duplicated method.

**Benefits:**
No duplicate function definitions.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A