### PR TITLE
Adding delimiter for when the Variable index is built into the quantu…

### DIFF
--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -128,8 +128,8 @@ class CircuitGraph:
             string: serialized quantum circuit graph
         """
         serialization_string = ""
-
         delimiter = "!"
+        variable_delimiter = "V"
 
         for op in self.operations_in_order:
             serialization_string += op.name
@@ -137,6 +137,7 @@ class CircuitGraph:
             for param in op.params:
                 if isinstance(param, Variable):
                     serialization_string += delimiter
+                    serialization_string += variable_delimiter
                     serialization_string += str(param.idx)
                     serialization_string += delimiter
 

--- a/tests/circuit_graph/test_circuit_graph_hash.py
+++ b/tests/circuit_graph/test_circuit_graph_hash.py
@@ -58,7 +58,7 @@ class TestCircuitGraphHash:
     symbolic_queue = [
                         ([qml.RX(variable, wires=[0])],
                          [],
-                        'RX!1![0]|||'
+                        'RX!V1![0]|||'
                         ),
 
                     ]
@@ -83,7 +83,7 @@ class TestCircuitGraphHash:
                             qml.RX(variable, wires=[2])
                         ],
                          [],
-                        'RX!1![0]RX!0.3![1]RX!1![2]|||'
+                        'RX!V1![0]RX!0.3![1]RX!V1![2]|||'
                         ),
 
                         ]
@@ -107,8 +107,8 @@ class TestCircuitGraphHash:
                             qml.RX(variable, wires=[1])
                             ],
                          [],
-                        'RX!1![0]' +
-                        'RX!1![1]' +
+                        'RX!V1![0]' +
+                        'RX!V1![1]' +
                         '|||'
                         ),
 
@@ -133,8 +133,8 @@ class TestCircuitGraphHash:
                             qml.RX(variable2, wires=[1])
                             ],
                          [],
-                        'RX!1![0]' +
-                        'RX!2![1]' +
+                        'RX!V1![0]' +
+                        'RX!V2![1]' +
                         '|||'
                         ),
                         ]


### PR DESCRIPTION
**Context:**
Currently, certain symbolic circuits might produce a ``QNode.hash`` that corresponds to a numeric counterpart.

For example, having ``qml.RX(Variable(1), wires=[0])`` in a circuit would be serialized to a string just the same way as ``qml.RX(1, wires=[0])``.

**Description of the Change:**
Adding delimiter for symbolic parameters (when the ``Variable.idx`` is built into the quantum circuit string); this helps in cases when there would be an ambiguity between the index of the ``Variable`` and the argument of the operation (e.g. both would correspond to being 1).

**Benefits:**
In the related cases, a numeric circuit is not going to be mistaken as being symbolic.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A