### PR TITLE
Remove unnecessary print statement

### DIFF
--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -341,7 +341,6 @@ class DefaultQubit(QubitDevice):
 
             else:
                 A = self._get_operator_matrix(operation.name, par)
-                print(A, self._state, wires)
                 self._state = self.mat_vec_product(A, self._state, wires)
 
         # store the pre-rotated state


### PR DESCRIPTION
**Context:**
There are some outputs when using ``default.qubit``.

**Description of the Change:**
Remove the unnecessary print statement from ``default.qubit``.

**Benefits:**
No outputs.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A