### PR TITLE
Setting shots when instantiating Device

### DIFF
--- a/doc/introduction/chemistry.rst
+++ b/doc/introduction/chemistry.rst
@@ -7,7 +7,7 @@ electronic Hamiltonian of molecules, and uses PennyLane to implement the Variati
 Eigensolver (VQE) algorithm.
 
 .. figure:: ../_static/sketch_pennylane_qchem.png
-    :width: 30%
+    :width: 80%
     :align: center
 
 .. note::

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -45,7 +45,7 @@ class Device(abc.ABC):
 
     def __init__(self, wires=1, shots=1000):
         self.num_wires = wires
-        self._shots = shots
+        self.shots = shots
 
         self._op_queue = None
         self._obs_queue = None

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -343,6 +343,10 @@ class TestInternalFunctions:
                 format(mock_device_supporting_paulis.short_name)):
             mock_device_supporting_paulis.check_validity([], [qml.PauliZ(0).inv()])
 
+    def test_args(self, mock_device):
+        """Test that the device requires correct arguments"""
+        with pytest.raises(qml.DeviceError, match="specified number of shots needs to be at least 1"):
+            Device(mock_device, shots=0)
 
 class TestClassmethods:
     """Test the classmethods of Device"""


### PR DESCRIPTION
**Context:**
There is currently no check for instantiating the ``Device`` class with ``shots<1``.

**Description of the Change:**
Use the setter of the ``shots`` property instead of setting the ``_shots`` attribute in the ``__init__`` method of ``Device``. This setter includes checks.

**Benefits:**
Subclasses of ``Device`` cannot be instantiated with ``shots<1`` and an error is raised (e.g. devices from the Qiskit plugin).

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
Related integration test fails in the Qiskit plugin.