### PR TITLE
Rename expt.tensornet device to default.tensor

### DIFF
--- a/pennylane/beta/plugins/__init__.py
+++ b/pennylane/beta/plugins/__init__.py
@@ -16,5 +16,5 @@ This package contains experimental plugin devices for PennyLane.
 
 .. currentmodule:: pennylane.beta.plugins
 """
-from .expt_tensornet import TensorNetwork
-from .expt_tensornet_tf import TensorNetworkTF
+from .default_tensor import DefaultTensor
+from .default_tensor_tf import DefaultTensorTF

--- a/pennylane/beta/plugins/default_tensor.py
+++ b/pennylane/beta/plugins/default_tensor.py
@@ -24,7 +24,7 @@ from numpy.linalg import eigh
 try:
     import tensornetwork as tn
 except ImportError as e:
-    raise ImportError("expt.tensornet device requires TensorNetwork>=0.2")
+    raise ImportError("default.tensor device requires TensorNetwork>=0.2")
 
 from pennylane._device import Device
 
@@ -250,7 +250,7 @@ def identity(*_):
 # ========================================================
 
 
-class TensorNetwork(Device):
+class DefaultTensor(Device):
     """Experimental Tensor Network simulator device for PennyLane.
 
     Args:
@@ -258,7 +258,7 @@ class TensorNetwork(Device):
     """
 
     name = "PennyLane TensorNetwork simulator plugin"
-    short_name = "expt.tensornet"
+    short_name = "default.tensor"
     pennylane_requires = "0.8"
     version = "0.8.0"
     author = "Xanadu Inc."
@@ -389,7 +389,7 @@ class TensorNetwork(Device):
                 raise ValueError("State vector must be of length 2**wires.")
             if wires is not None and wires != [] and list(wires) != list(range(self.num_wires)):
                 raise ValueError(
-                    "The expt.tensornet plugin can apply QubitStateVector only to all of the {} wires.".format(
+                    "The default.tensor plugin can apply QubitStateVector only to all of the {} wires.".format(
                         self.num_wires
                     )
                 )
@@ -404,7 +404,7 @@ class TensorNetwork(Device):
                 )
             if wires is not None and wires != [] and list(wires) != list(range(self.num_wires)):
                 raise ValueError(
-                    "The expt.tensornet plugin can apply BasisState only to all of the {} wires.".format(
+                    "The default.tensor plugin can apply BasisState only to all of the {} wires.".format(
                         self.num_wires
                     )
                 )

--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -23,14 +23,14 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        raise ImportError("expt.tensornet.tf device requires TensorFlow>=2.0")
+        raise ImportError("default.tensor.tf device requires TensorFlow>=2.0")
 
 except ImportError as e:
-    raise ImportError("expt.tensornet.tf device requires TensorFlow>=2.0")
+    raise ImportError("default.tensor.tf device requires TensorFlow>=2.0")
 
 from pennylane.variable import Variable
 
-from pennylane.beta.plugins.expt_tensornet import TensorNetwork, I, X, Y, Z
+from pennylane.beta.plugins.default_tensor import DefaultTensor, I, X, Y, Z
 
 
 # tolerance for numerical errors
@@ -184,10 +184,10 @@ def CRot3(a, b, c):
     return CRotz(c) @ (CRoty(b) @ CRotz(a))
 
 
-class TensorNetworkTF(TensorNetwork):
+class DefaultTensorTF(DefaultTensor):
     """Experimental TensorFlow Tensor Network simulator device for PennyLane.
 
-    **Short name:** ``expt.tensornet.tf``
+    **Short name:** ``default.tensor.tf``
 
     This experimental device extends ``expt.tensornet`` by making use of
     the TensorFlow backend of TensorNetwork. As a result, it supports
@@ -203,7 +203,7 @@ class TensorNetworkTF(TensorNetwork):
 
     **Example:**
 
-    >>> dev = qml.device("expt.tensornet.tf", wires=1)
+    >>> dev = qml.device("default.tensor.tf", wires=1)
     >>> @qml.qnode(dev, interface="autograd", diff_method="best")
     >>> def circuit(x):
     ...     qml.RX(x[1], wires=0)
@@ -217,7 +217,7 @@ class TensorNetworkTF(TensorNetwork):
 
         TensorFlow is used as the device backend, and is independent
         of the chosen QNode interface. In the example above, we combine
-        ``expt.tensornet.tf`` with the ``autograd`` interface.
+        ``default.tensor.tf`` with the ``autograd`` interface.
         It can also be used with the ``torch`` and the ``tf`` interface.
 
     Args:
@@ -227,10 +227,10 @@ class TensorNetworkTF(TensorNetwork):
 
     # pylint: disable=too-many-instance-attributes
     name = "PennyLane TensorNetwork (TensorFlow) simulator plugin"
-    short_name = "expt.tensornet.tf"
+    short_name = "default.tensor.tf"
     _capabilities = {"model": "qubit", "tensor_observables": True, "provides_jacobian": True}
 
-    _operation_map = copy.copy(TensorNetwork._operation_map)
+    _operation_map = copy.copy(DefaultTensor._operation_map)
     _operation_map.update(
         {
             "PhaseShift": Rphi,
@@ -348,7 +348,7 @@ class TensorNetworkTF(TensorNetwork):
 
     def execute(self, queue, observables, parameters=None):
         # pylint: disable=bad-super-call
-        results = super(TensorNetwork, self).execute(queue, observables, parameters=parameters)
+        results = super(DefaultTensor, self).execute(queue, observables, parameters=parameters)
 
         with self.tape:
             # convert the results list into a single tensor

--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -189,7 +189,7 @@ class DefaultTensorTF(DefaultTensor):
 
     **Short name:** ``default.tensor.tf``
 
-    This experimental device extends ``expt.tensornet`` by making use of
+    This experimental device extends ``default.tensor`` by making use of
     the TensorFlow backend of TensorNetwork. As a result, it supports
     classical backpropagation as a means to compute the Jacobian. This can
     be faster than the parameter-shift rule for analytic quantum gradients

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ info = {
         'pennylane.plugins': [
             'default.qubit = pennylane.plugins:DefaultQubit',
             'default.gaussian = pennylane.plugins:DefaultGaussian',
-            'expt.tensornet = pennylane.beta.plugins.expt_tensornet:TensorNetwork',
-            'expt.tensornet.tf = pennylane.beta.plugins.expt_tensornet_tf:TensorNetworkTF'
+            'default.tensor = pennylane.beta.plugins.default_tensor:DefaultTensor',
+            'default.tensor.tf = pennylane.beta.plugins.default_tensor_tf:DefaultTensorTF'
             ],
         },
     'description': 'PennyLane is a Python quantum machine learning library by Xanadu Inc.',

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -26,7 +26,7 @@ tensorflow = pytest.importorskip("tensorflow", minversion="2.0")
 
 import pennylane as qml
 from pennylane import numpy as np, QuantumFunctionError
-from pennylane.beta.plugins.expt_tensornet import (
+from pennylane.beta.plugins.default_tensor import (
     CNOT,
     CSWAP,
     CZ,
@@ -331,18 +331,18 @@ class TestStateFunctions:
             hermitian(H2)
  
 
-class TestTensornetIntegration:
-    """Integration tests for expt.tensornet. This test ensures it integrates
+class TestDefaultTensorIntegration:
+    """Integration tests for default.tensor. This test ensures it integrates
     properly with the PennyLane interface, in particular QNode."""
 
     def test_load_tensornet_device(self):
         """Test that the tensor network plugin loads correctly"""
 
-        dev = qml.device("expt.tensornet", wires=2)
+        dev = qml.device("default.tensor", wires=2)
         assert dev.num_wires == 2
         assert dev.shots == 1000
         assert dev.analytic
-        assert dev.short_name == "expt.tensornet"
+        assert dev.short_name == "default.tensor"
 
     def test_args(self):
         """Test that the plugin requires correct arguments"""
@@ -350,7 +350,7 @@ class TestTensornetIntegration:
         with pytest.raises(
             TypeError, match="missing 1 required positional argument: 'wires'"
         ):
-            qml.device("expt.tensornet")
+            qml.device("default.tensor")
 
     @pytest.mark.parametrize("gate", set(qml.ops.cv.ops))
     def test_unsupported_gate_error(self, tensornet_device_3_wires, gate):
@@ -371,7 +371,7 @@ class TestTensornetIntegration:
             return qml.expval(qml.X(0))
 
         with pytest.raises(
-            QuantumFunctionError, match="Device expt.tensornet is a qubit device; CV operations are not allowed."
+            QuantumFunctionError, match="Device default.tensor is a qubit device; CV operations are not allowed."
         ):
             x = np.random.random([op.num_params])
             circuit(*x)
@@ -394,7 +394,7 @@ class TestTensornetIntegration:
             return qml.expval(op(*x, wires=wires))
 
         with pytest.raises(
-            QuantumFunctionError, match="Device expt.tensornet is a qubit device; CV operations are not allowed."
+            QuantumFunctionError, match="Device default.tensor is a qubit device; CV operations are not allowed."
         ):
             x = np.random.random([op.num_params])
             circuit(*x)
@@ -652,7 +652,7 @@ class TestTensornetIntegration:
     def test_expval_warnings(self):
         """Tests that expval raises a warning if the given observable is complex."""
 
-        dev = qml.device("expt.tensornet", wires=1)
+        dev = qml.device("default.tensor", wires=1)
 
         A = np.array([[2j, 1j], [-3j, 1j]])
         obs_node = dev._add_node(A, wires=[0])
@@ -698,7 +698,7 @@ class TestTensorExpval:
 
     def test_paulix_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
 
         dev.apply("RX", wires=[0], par=[theta])
@@ -714,7 +714,7 @@ class TestTensorExpval:
 
     def test_pauliz_identity(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and Identity works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -729,7 +729,7 @@ class TestTensorExpval:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -744,7 +744,7 @@ class TestTensorExpval:
 
     def test_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -773,7 +773,7 @@ class TestTensorExpval:
 
     def test_hermitian_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving two Hermitian matrices works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -814,7 +814,7 @@ class TestTensorExpval:
 
     def test_hermitian_identity_expectation(self, theta, phi, varphi, tol):
         """Test that a tensor product involving an Hermitian matrix and the identity works correctly"""
-        dev = qml.device("expt.tensornet", wires=2)
+        dev = qml.device("default.tensor", wires=2)
         dev.reset()
         dev.apply("RY", wires=[0], par=[theta])
         dev.apply("RY", wires=[1], par=[phi])
@@ -838,7 +838,7 @@ class TestTensorVar:
 
     def test_paulix_pauliy(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -861,7 +861,7 @@ class TestTensorVar:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -882,7 +882,7 @@ class TestTensorVar:
 
     def test_hermitian(self, theta, phi, varphi, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -988,7 +988,7 @@ class TestTensorSample:
 
     def test_paulix_pauliy(self, theta, phi, varphi, monkeypatch, tol):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
-        dev = qml.device("expt.tensornet", wires=3, shots=10000)
+        dev = qml.device("default.tensor", wires=3, shots=10000)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -1020,7 +1020,7 @@ class TestTensorSample:
 
     def test_pauliz_hadamard(self, theta, phi, varphi, monkeypatch, tol):
         """Test that a tensor product involving PauliZ and PauliY and hadamard works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])
@@ -1050,7 +1050,7 @@ class TestTensorSample:
 
     def test_hermitian(self, theta, phi, varphi, monkeypatch, tol):
         """Test that a tensor product involving qml.Hermitian works correctly"""
-        dev = qml.device("expt.tensornet", wires=3)
+        dev = qml.device("default.tensor", wires=3)
         dev.reset()
         dev.apply("RX", wires=[0], par=[theta])
         dev.apply("RX", wires=[1], par=[phi])

--- a/tests/beta/test_default_tensor_tf.py
+++ b/tests/beta/test_default_tensor_tf.py
@@ -23,7 +23,7 @@ tensornetwork = pytest.importorskip("tensornetwork", minversion="0.1")
 tensorflow = pytest.importorskip("tensorflow", minversion="2.0")
 
 import pennylane as qml
-from pennylane.beta.plugins.expt_tensornet_tf import TensorNetworkTF
+from pennylane.beta.plugins.default_tensor_tf import DefaultTensorTF
 from gate_data import I, X, Y, Z, H, CNOT, SWAP, CNOT, Toffoli, CSWAP
 from pennylane.qnodes import qnode, QNode
 from pennylane.qnodes.decorator import ALLOWED_INTERFACES, ALLOWED_DIFF_METHODS
@@ -102,7 +102,7 @@ class TestApply:
 
     def test_basis_state(self, tol):
         """Test basis state initialization"""
-        dev = TensorNetworkTF(wires=4)
+        dev = DefaultTensorTF(wires=4)
         state = np.array([0, 0, 1, 0])
 
         dev.execute([qml.BasisState(state, wires=[0, 1, 2, 3])], [], {})
@@ -115,7 +115,7 @@ class TestApply:
 
     def test_qubit_state_vector(self, init_state, tol):
         """Test qubit state vector application"""
-        dev = TensorNetworkTF(wires=1)
+        dev = DefaultTensorTF(wires=1)
         state = init_state(1)
 
         dev.execute([qml.QubitStateVector(state, wires=[0])], [], {})
@@ -127,7 +127,7 @@ class TestApply:
     def test_invalid_qubit_state_vector(self):
         """Test that an exception is raised if the state
         vector is the wrong size"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         state = np.array([0, 123.432])
 
         with pytest.raises(ValueError, match=r"State vector must be of length 2\*\*wires"):
@@ -136,7 +136,7 @@ class TestApply:
     @pytest.mark.parametrize("op,mat", single_qubit)
     def test_single_qubit_no_parameters(self, init_state, op, mat, tol):
         """Test non-parametrized single qubit operations"""
-        dev = TensorNetworkTF(wires=1)
+        dev = DefaultTensorTF(wires=1)
         state = init_state(1)
 
         queue = [qml.QubitStateVector(state, wires=[0])]
@@ -151,7 +151,7 @@ class TestApply:
     @pytest.mark.parametrize("op,func", single_qubit_param)
     def test_single_qubit_parameters(self, init_state, op, func, theta, tol):
         """Test parametrized single qubit operations"""
-        dev = TensorNetworkTF(wires=1)
+        dev = DefaultTensorTF(wires=1)
         state = init_state(1)
 
         queue = [qml.QubitStateVector(state, wires=[0])]
@@ -164,7 +164,7 @@ class TestApply:
 
     def test_rotation(self, init_state, tol):
         """Test three axis rotation gate"""
-        dev = TensorNetworkTF(wires=1)
+        dev = DefaultTensorTF(wires=1)
         state = init_state(1)
 
         a = 0.542
@@ -182,7 +182,7 @@ class TestApply:
     @pytest.mark.parametrize("op,mat", two_qubit)
     def test_two_qubit_no_parameters(self, init_state, op, mat, tol):
         """Test non-parametrized two qubit operations"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         state = init_state(2)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1])]
@@ -197,7 +197,7 @@ class TestApply:
     def test_qubit_unitary(self, init_state, mat, tol):
         """Test application of arbitrary qubit unitaries"""
         N = int(np.log2(len(mat)))
-        dev = TensorNetworkTF(wires=N)
+        dev = DefaultTensorTF(wires=N)
         state = init_state(N)
 
         queue = [qml.QubitStateVector(state, wires=range(N))]
@@ -211,7 +211,7 @@ class TestApply:
     @pytest.mark.parametrize("op, mat", three_qubit)
     def test_three_qubit_no_parameters(self, init_state, op, mat, tol):
         """Test non-parametrized three qubit operations"""
-        dev = TensorNetworkTF(wires=3)
+        dev = DefaultTensorTF(wires=3)
         state = init_state(3)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1, 2])]
@@ -226,7 +226,7 @@ class TestApply:
     @pytest.mark.parametrize("op,func", two_qubit_param)
     def test_two_qubit_parameters(self, init_state, op, func, theta, tol):
         """Test two qubit parametrized operations"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         state = init_state(2)
 
         queue = [qml.QubitStateVector(state, wires=[0, 1])]
@@ -266,7 +266,7 @@ class TestExpval:
     @pytest.mark.parametrize("gate,obs,expected", single_wire_expval_test_data)
     def test_single_wire_expectation(self, gate, obs, expected, theta, phi, tol):
         """Test that identity expectation value (i.e. the trace) is 1"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         queue = [gate(theta, wires=0), gate(phi, wires=1), qml.CNOT(wires=[0, 1])]
         observables = [obs(wires=[i]) for i in range(2)]
 
@@ -278,7 +278,7 @@ class TestExpval:
 
     def test_hermitian_expectation(self, theta, phi, tol):
         """Test that arbitrary Hermitian expectation values are correct"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         queue = [qml.RY(theta, wires=0), qml.RY(phi, wires=1), qml.CNOT(wires=[0, 1])]
         observables = [qml.Hermitian(A, wires=[i]) for i in range(2)]
 
@@ -307,7 +307,7 @@ class TestExpval:
             ]
         )
 
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
         queue = [qml.RY(theta, wires=0), qml.RY(phi, wires=1), qml.CNOT(wires=[0, 1])]
         observables = [qml.Hermitian(A, wires=[0, 1])]
 
@@ -335,7 +335,7 @@ class TestVar:
 
     def test_var(self, theta, phi, tol):
         """Tests for variance calculation"""
-        dev = TensorNetworkTF(wires=1)
+        dev = DefaultTensorTF(wires=1)
         # test correct variance for <Z> of a rotated state
 
         queue = [qml.RX(phi, wires=0), qml.RY(theta, wires=0)]
@@ -350,7 +350,7 @@ class TestVar:
 
     def test_var_hermitian(self, theta, phi, tol):
         """Tests for variance calculation using an arbitrary Hermitian observable"""
-        dev = TensorNetworkTF(wires=2)
+        dev = DefaultTensorTF(wires=2)
 
         # test correct variance for <H> of a rotated state
         H = np.array([[4, -1 + 6j], [-1 - 6j, 2]])
@@ -377,16 +377,16 @@ class TestVar:
 
 
 class TestQNodeIntegration:
-    """Integration tests for expt.tensornet.tf. This test ensures it integrates
+    """Integration tests for default.tensor.tf. This test ensures it integrates
     properly with the PennyLane UI, in particular the new QNode."""
 
     def test_load_tensornet_tf_device(self):
         """Test that the tensor network plugin loads correctly"""
-        dev = qml.device("expt.tensornet.tf", wires=2)
+        dev = qml.device("default.tensor.tf", wires=2)
         assert dev.num_wires == 2
         assert dev.shots == 1000
         assert dev.analytic
-        assert dev.short_name == "expt.tensornet.tf"
+        assert dev.short_name == "default.tensor.tf"
         assert dev.capabilities()["provides_jacobian"]
 
     @pytest.mark.parametrize("decorator", [qml.qnode, qnode])
@@ -396,7 +396,7 @@ class TestQNodeIntegration:
         This test is parametrized for both the new and old QNode decorator."""
         p = 0.543
 
-        dev = qml.device("expt.tensornet.tf", wires=1)
+        dev = qml.device("default.tensor.tf", wires=1)
 
         @decorator(dev)
         def circuit(x):
@@ -409,7 +409,7 @@ class TestQNodeIntegration:
 
     def test_cannot_overwrite_state(self):
         """Tests that _state is a property and cannot be overwritten."""
-        dev = qml.device("expt.tensornet.tf", wires=2)
+        dev = qml.device("default.tensor.tf", wires=2)
 
         with pytest.raises(AttributeError, match="can't set attribute"):
             dev._state = np.array([[1, 0], [0, 0]])
@@ -418,7 +418,7 @@ class TestQNodeIntegration:
         """Test that the device state is correct after applying a
         quantum function on the device"""
 
-        dev = qml.device("expt.tensornet.tf", wires=2)
+        dev = qml.device("default.tensor.tf", wires=2)
 
         state = dev._state
 
@@ -447,7 +447,7 @@ class TestJacobianIntegration:
         y = 0.2162158
         z = 0.75110998
 
-        dev = qml.device("expt.tensornet.tf", wires=1)
+        dev = qml.device("default.tensor.tf", wires=1)
 
         @qnode(dev)
         def circuit(p):
@@ -478,7 +478,7 @@ class TestJacobianIntegration:
         y = 0.2162158
         z = 0.75110998
         p = np.array([x, y, z])
-        dev = qml.device("expt.tensornet.tf", wires=1)
+        dev = qml.device("default.tensor.tf", wires=1)
 
         @qnode(dev)
         def circuit(x):
@@ -510,7 +510,7 @@ class TestJacobianIntegration:
                 qml.CNOT(wires=[i, i + 1])
             return qml.expval(qml.PauliZ(0)), qml.var(qml.PauliZ(1))
 
-        dev1 = qml.device("expt.tensornet.tf", wires=3)
+        dev1 = qml.device("default.tensor.tf", wires=3)
         dev2 = qml.device("default.qubit", wires=3)
 
         circuit1 = QNode(circuit, dev1, diff_method=diff_method)
@@ -521,7 +521,7 @@ class TestJacobianIntegration:
 
 
 class TestInterfaceIntegration:
-    """Integration tests for expt.tensornet.tf. This test class ensures it integrates
+    """Integration tests for default.tensor.tf. This test class ensures it integrates
     properly with the PennyLane UI, in particular the classical machine learning
     interfaces."""
 
@@ -543,7 +543,7 @@ class TestInterfaceIntegration:
         if interface == "torch" and not torch_support:
             pytest.skip("Skipped, no torch support")
 
-        dev = qml.device("expt.tensornet.tf", wires=2)
+        dev = qml.device("default.tensor.tf", wires=2)
 
         @qnode(dev, diff_method="best", interface=interface)
         def circuit_fn(a, b):
@@ -599,7 +599,7 @@ class TestInterfaceIntegration:
 
 
 class TestHybridInterfaceIntegration:
-    """Integration tests for expt.tensornet.tf. This test class ensures it integrates
+    """Integration tests for default.tensor.tf. This test class ensures it integrates
     properly with the PennyLane UI, in particular the classical machine learning
     interfaces in the case of hybrid-classical computation."""
 
@@ -627,7 +627,7 @@ class TestHybridInterfaceIntegration:
     @pytest.fixture
     def cost(self, interface, torch_support):
         """Fixture to create cost function for the test class"""
-        dev = qml.device("expt.tensornet.tf", wires=1)
+        dev = qml.device("default.tensor.tf", wires=1)
 
         if interface == "torch" and not torch_support:
             pytest.skip("Skipped, no torch support")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,22 +76,22 @@ def qubit_device_3_wires():
 
 @pytest.fixture(scope="session")
 def tensornet_device(n_subsystems):
-    return qml.device('expt.tensornet', wires=n_subsystems)
+    return qml.device('default.tensor', wires=n_subsystems)
 
 
 @pytest.fixture(scope="function")
 def tensornet_device_1_wire():
-    return qml.device('expt.tensornet', wires=1)
+    return qml.device('default.tensor', wires=1)
 
 
 @pytest.fixture(scope="function")
 def tensornet_device_2_wires():
-    return qml.device('expt.tensornet', wires=2)
+    return qml.device('default.tensor', wires=2)
 
 
 @pytest.fixture(scope="function")
 def tensornet_device_3_wires():
-    return qml.device('expt.tensornet', wires=3)
+    return qml.device('default.tensor', wires=3)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
**Context:** The experimental TensorNetwork simulator had a short name that did not fit the PennyLane convention for device shortnames.

**Description of the Change:**

* `expt.tensornet` has become `default.tensor`

* `expt.tensornet.tf` has become `default.tensor.tf`

**Benefits:**

* The `expt` prefix has been replaced by `default`, to bring it inline with existing PennyLane simulators.

* `tensornet` has been shortened to `tensor`

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
