### PR TITLE
Create Tensor prune method for removing Identity instances

### DIFF
--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -111,6 +111,14 @@ class CircuitGraph:
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
         for k, op in enumerate(ops):
+
+            print('before', op)
+            # Extract the non-Identity observables from
+            # the Tensor object
+            if isinstance(op, qml.operation.Tensor):
+                op = op.prune()
+
+            print('after', op)
             op.queue_idx = k  # store the queue index in the Operator
             for w in set(
                 _flatten(op.wires)

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -111,14 +111,6 @@ class CircuitGraph:
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
         for k, op in enumerate(ops):
-
-            print('before', op)
-            # Extract the non-Identity observables from
-            # the Tensor object
-            if isinstance(op, qml.operation.Tensor):
-                op = op.prune()
-
-            print('after', op)
             op.queue_idx = k  # store the queue index in the Operator
             for w in set(
                 _flatten(op.wires)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -900,6 +900,41 @@ class Tensor(Observable):
         # over the defined wires.
         return functools.reduce(np.kron, U_list)
 
+    def prune(self):
+        """Returns a pruned tensor of observables based on the current Tensor.
+
+        If the Tensor only contained one observable, then this observable instance is
+        returned.
+
+        Note that this way this method might return an instance that is not a Tensor
+        instance.
+
+        **Example:**
+
+        1.
+
+        >>> O = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
+        >>> O.prune()
+        <pennylane.operation.Tensor at 0x7fc1642d1590
+        >>>> O.obs
+        [<pennylane.ops.qubit.PauliZ object at 0x7fc1b076afd0>, <pennylane.ops.qubit.PauliZ object at 0x7fc1b075bd90>]
+
+        2.
+        >>> O = qml.PauliZ(0) @ qml.Identity(1)
+        >>> O.prune()
+        <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
+
+        Returns:
+            `~.Observable`: the pruned
+        """
+        non_identity_obs = [obs for obs in self.obs if not isinstance(obs, qml.Identity)]
+
+        print(non_identity_obs)
+        if len(non_identity_obs) == 1:
+            return non_identity_obs[0]
+
+        return Tensor(*non_identity_obs)
+
 #=============================================================================
 # CV Operations and observables
 #=============================================================================

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -768,6 +768,16 @@ class Tensor(Observable):
         """
         return [o.parameters for o in self.obs]
 
+    @property
+    def non_identity_obs(self):
+        """Returns the non-identity observables contained in the Tensor.
+
+        Returns:
+            list[`~.Observable`]: list containing the non-identity observables
+            in the tensor product
+        """
+        return [obs for obs in self.obs if not isinstance(obs, qml.Identity)]
+
     def __matmul__(self, other):
         if isinstance(other, Tensor):
             self.obs.extend(other.obs)
@@ -901,7 +911,8 @@ class Tensor(Observable):
         return functools.reduce(np.kron, U_list)
 
     def prune(self):
-        """Returns a pruned tensor of observables based on the current Tensor.
+        """Returns a pruned tensor of observables by removing Identity instances from
+        the observables building up the Tensor.
 
         If the Tensor only contained one observable, then this observable instance is
         returned.
@@ -925,15 +936,12 @@ class Tensor(Observable):
         <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
 
         Returns:
-            `~.Observable`: the pruned
+            `~.Observable`: the pruned Tensor
         """
-        non_identity_obs = [obs for obs in self.obs if not isinstance(obs, qml.Identity)]
+        if len(self.non_identity_obs) == 1:
+            return self.non_identity_obs[0]
 
-        print(non_identity_obs)
-        if len(non_identity_obs) == 1:
-            return non_identity_obs[0]
-
-        return Tensor(*non_identity_obs)
+        return Tensor(*self.non_identity_obs)
 
 #=============================================================================
 # CV Operations and observables

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -914,7 +914,9 @@ class Tensor(Observable):
         """Returns a pruned tensor product of observables by removing :class:`~.Identity` instances from
         the observables building up the :class:`~.Tensor`.
 
-        If the tensor product only containes one observable, then this observable instance is
+        The return_type attribute is preserved while pruning.
+
+        If the tensor product only contains one observable, then this observable instance is
         returned.
 
         Note that this way this method might return an instance that is not a :class:`.Tensor`
@@ -940,9 +942,12 @@ class Tensor(Observable):
             :class:`~.Observable`: the pruned tensor product of observables
         """
         if len(self.non_identity_obs) == 1:
-            return self.non_identity_obs[0]
+            obs = self.non_identity_obs[0]
+        else:
+            obs = Tensor(*self.non_identity_obs)
 
-        return Tensor(*self.non_identity_obs)
+        obs.return_type = self.return_type
+        return obs
 
 #=============================================================================
 # CV Operations and observables

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -911,7 +911,7 @@ class Tensor(Observable):
         return functools.reduce(np.kron, U_list)
 
     def prune(self):
-        """Returns a pruned tensor of observables by removing Identity instances from
+        """Returns a pruned tensor product of observables by removing Identity instances from
         the observables building up the Tensor.
 
         If the Tensor only contained one observable, then this observable instance is
@@ -936,7 +936,7 @@ class Tensor(Observable):
         <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
 
         Returns:
-            `~.Observable`: the pruned Tensor
+            `~.Observable`: the pruned tensor product of observables
         """
         if len(self.non_identity_obs) == 1:
             return self.non_identity_obs[0]

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -770,10 +770,10 @@ class Tensor(Observable):
 
     @property
     def non_identity_obs(self):
-        """Returns the non-identity observables contained in the Tensor.
+        """Returns the non-identity observables contained in the tensor product.
 
         Returns:
-            list[`~.Observable`]: list containing the non-identity observables
+            list[:class:`~.Observable`]: list containing the non-identity observables
             in the tensor product
         """
         return [obs for obs in self.obs if not isinstance(obs, qml.Identity)]
@@ -911,13 +911,13 @@ class Tensor(Observable):
         return functools.reduce(np.kron, U_list)
 
     def prune(self):
-        """Returns a pruned tensor product of observables by removing Identity instances from
-        the observables building up the Tensor.
+        """Returns a pruned tensor product of observables by removing :class:`~.Identity` instances from
+        the observables building up the :class:`~.Tensor`.
 
-        If the Tensor only contained one observable, then this observable instance is
+        If the tensor product only containes one observable, then this observable instance is
         returned.
 
-        Note that this way this method might return an instance that is not a Tensor
+        Note that this way this method might return an instance that is not a :class:`.Tensor`
         instance.
 
         **Example:**
@@ -925,18 +925,19 @@ class Tensor(Observable):
         1.
 
         >>> O = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
-        >>> O.prune()
+        >>> pruned_obs = O.prune()
         <pennylane.operation.Tensor at 0x7fc1642d1590
-        >>>> O.obs
+        >>> pruned_obs.obs
         [<pennylane.ops.qubit.PauliZ object at 0x7fc1b076afd0>, <pennylane.ops.qubit.PauliZ object at 0x7fc1b075bd90>]
 
         2.
+
         >>> O = qml.PauliZ(0) @ qml.Identity(1)
         >>> O.prune()
         <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
 
         Returns:
-            `~.Observable`: the pruned tensor product of observables
+            :class:`~.Observable`: the pruned tensor product of observables
         """
         if len(self.non_identity_obs) == 1:
             return self.non_identity_obs[0]

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -924,25 +924,26 @@ class Tensor(Observable):
 
         **Example:**
 
-        1.
+        Pruning that returns a :class:`~.Tensor`:
 
         >>> O = qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2)
-        >>> pruned_obs = O.prune()
+        >>> O.prune()
         <pennylane.operation.Tensor at 0x7fc1642d1590
-        >>> pruned_obs.obs
-        [<pennylane.ops.qubit.PauliZ object at 0x7fc1b076afd0>, <pennylane.ops.qubit.PauliZ object at 0x7fc1b075bd90>]
+        >>> [(o.name, o.wires) for o in O.prune().obs]
+        [('PauliZ', [0]), ('PauliZ', [2])]
 
-        2.
+        Pruning that returns a single observable:
 
         >>> O = qml.PauliZ(0) @ qml.Identity(1)
-        >>> O.prune()
-        <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
+        >>> O_pruned = O.prune()
+        >>> (O_pruned.name, O_pruned.wires)
+        ('PauliZ', [0])
 
         Returns:
             ~.Observable: the pruned tensor product of observables
         """
-        # Return one Identity in there in case the tensor only contains Identities
         if len(self.non_identity_obs) == 0:
+            # Return one Identity in there in case the tensor only contains Identities
             obs = qml.Identity(0)
         elif len(self.non_identity_obs) == 1:
             obs = self.non_identity_obs[0]

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -919,7 +919,7 @@ class Tensor(Observable):
         If the tensor product only contains one observable, then this observable instance is
         returned.
 
-        Note that this way this method might return an instance that is not a :class:`.Tensor`
+        Note that this way this method might return an instance that is not a :class:`~.Tensor`
         instance.
 
         **Example:**
@@ -939,9 +939,12 @@ class Tensor(Observable):
         <pennylane.ops.qubit.PauliZ at 0x7fc1642d1850>
 
         Returns:
-            :class:`~.Observable`: the pruned tensor product of observables
+            ~.Observable: the pruned tensor product of observables
         """
-        if len(self.non_identity_obs) == 1:
+        # Return one Identity in there in case the tensor only contains Identities
+        if len(self.non_identity_obs) == 0:
+            obs = qml.Identity(0)
+        elif len(self.non_identity_obs) == 1:
             obs = self.non_identity_obs[0]
         else:
             obs = Tensor(*self.non_identity_obs)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -530,12 +530,11 @@ class BaseQNode:
         finally:
             qml._current_context = None
 
-        # Prune all the Tensor objects that have been used in the circuit
-        res = self._prune_tensors(res)
-        self.obs_queue = self._prune_tensors(self.obs_queue)
-
         # check the validity of the circuit
         self._check_circuit(res)
+
+        # Prune all the Tensor objects that have been used in the circuit
+        self.ops = self._prune_tensors(self.ops)
 
         # map each free variable to the operators which depend on it
         self.variable_deps = {k: [] for k in range(self.num_variables)}

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -565,7 +565,8 @@ class BaseQNode:
                     "The operations {} cannot affect the output of the circuit.".format(invisible)
                 )
 
-    def _prune_tensors(self, res):
+    @staticmethod
+    def _prune_tensors(res):
         """Prune the tensors that have been passed by the quantum function.
 
         .. note:: Check the :meth:`~Tensor.prune()` for further details.
@@ -576,11 +577,10 @@ class BaseQNode:
         Returns:
             res (Sequence[Observable], Observable): pruned output returned by the quantum function
         """
-        if isinstance(res, Observable) and not isinstance(res, qml.operation.Tensor):
-            return res
-        elif isinstance(res, qml.operation.Tensor):
+        if isinstance(res, qml.operation.Tensor):
             return res.prune()
-        elif isinstance(res, Sequence):
+
+        if isinstance(res, Sequence):
             ops = []
             for o in res:
                 if isinstance(o, qml.operation.Tensor):
@@ -588,6 +588,8 @@ class BaseQNode:
                 else:
                     ops.append(o)
             return ops
+
+        return res
 
     def _check_circuit(self, res):
         """Check that the generated Operator queue corresponds to a valid quantum circuit.

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -239,6 +239,28 @@ class TestQNodeOperationQueue:
         assert qnode.ops[2].name == "RZ"
         assert qnode.ops[3].name == "PauliX"
 
+    def test_prune_tensors(self, mock_device):
+        px = qml.PauliX(1)
+        obs = qml.Identity(0) @ px
+
+        def circuit(x):
+            return qml.expval(obs)
+
+        qnode = BaseQNode(circuit, mock_device)
+
+        assert qnode._prune_tensors(obs) == px
+
+    def test_prune_tensors_construct(self, mock_device):
+        """Test that the tensors are pruned in construct."""
+        def circuit(x):
+            return qml.expval(qml.PauliX(0) @ qml.Identity(1))
+
+        qnode = BaseQNode(circuit, mock_device)
+        qnode._construct([1.0], {})
+
+        assert qnode.ops[0].name == "PauliX"
+        assert len(qnode.ops[0].wires) == 1
+        assert qnode.ops[0].wires[0] == 0
 
 class TestQNodeExceptions:
     """Tests that QNode raises proper errors"""

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -240,9 +240,23 @@ class TestQNodeOperationQueue:
         assert qnode.ops[3].name == "PauliX"
 
     def test_prune_tensors(self, mock_device):
-        """Test that the _prune_tensors auxiliary method."""
+        """Test that the _prune_tensors auxiliary method prunes correct for
+        a single Identity in the Tensor."""
         px = qml.PauliX(1)
         obs = qml.Identity(0) @ px
+
+        def circuit(x):
+            return qml.expval(obs)
+
+        qnode = BaseQNode(circuit, mock_device)
+
+        assert qnode._prune_tensors(obs) == px
+
+    def test_prune_tensors_no_pruning_took_place(self, mock_device):
+        """Test that the _prune_tensors auxiliary method returns
+        the original tensor if no observables were pruned."""
+        px = qml.PauliX(1)
+        obs = px
 
         def circuit(x):
             return qml.expval(obs)

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -240,6 +240,7 @@ class TestQNodeOperationQueue:
         assert qnode.ops[3].name == "PauliX"
 
     def test_prune_tensors(self, mock_device):
+        """Test that the _prune_tensors auxiliary method."""
         px = qml.PauliX(1)
         obs = qml.Identity(0) @ px
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -852,6 +852,13 @@ class TestTensor:
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    herm_matrix = np.array([
+                            [1, 0, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 0, 1, 0],
+                            [0, 0, 0, 1]
+                            ])
+
     tensor_obs = [
                     (
                     qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2),
@@ -870,6 +877,14 @@ class TestTensor:
                     (
                     qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2),
                     [qml.PauliX(1)]
+                    ),
+                    (
+                    qml.Identity(0) @ qml.Identity(1),
+                    [qml.Identity(0)]
+                    ),
+                    (
+                    qml.Identity(0) @ qml.Identity(1) @ qml.Hermitian(herm_matrix, wires=[2,3]),
+                    [qml.Hermitian(herm_matrix, wires=[2,3])]
                     )
                 ]
 
@@ -891,7 +906,6 @@ class TestTensor:
                             qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2) @ qml.PauliZ(3) @  qml.PauliZ(4) @ qml.Identity(5),
                             qml.PauliX(1) @ qml.PauliZ(3) @ qml.PauliZ(4)
                             ),
-
                             # Single observable is returned
                             (
                             qml.PauliZ(0) @ qml.Identity(1),
@@ -900,6 +914,18 @@ class TestTensor:
                             (
                             qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2),
                             qml.PauliX(1)
+                            ),
+                            (
+                            qml.Identity(0) @ qml.Identity(1),
+                            qml.Identity(0)
+                            ),
+                            (
+                            qml.Identity(0) @ qml.Identity(1),
+                            qml.Identity(0)
+                            ),
+                            (
+                            qml.Identity(0) @ qml.Identity(1) @ qml.Hermitian(herm_matrix, wires=[2,3]),
+                            qml.Hermitian(herm_matrix, wires=[2,3])
                             )
                          ]
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -852,6 +852,48 @@ class TestTensor:
 
         assert np.allclose(res, expected, atol=tol, rtol=0)
 
+    tensor_obs = [
+                    (
+                    qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2),
+                    qml.PauliZ(0) @ qml.PauliZ(2)
+                    ),
+                    (
+                    qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2) @ qml.PauliZ(3) @  qml.PauliZ(4),
+                    qml.PauliX(1) @ qml.PauliZ(4)
+                    )
+                ]
+
+    @pytest.mark.parametrize("tensor_observable, expected", tensor_obs)
+    def test_prune(self, tensor_observable, expected):
+        """Tests that the prune method returns a Tensor removing any Identities."""
+
+        O = tensor_observable
+        O_pruned = O.prune()
+        for idx, obs in enumerate(O_pruned.obs):
+            assert type(obs) == type(expected.obs[idx])
+            assert obs.wires == expected.obs[idx].wires
+
+    def test_prune_single_observable(self):
+        """Tests that the prune method returns a single observable when there is only one non-Identity in the list of observables for a Tensor."""
+    tensor_obs = [
+                    (
+                    qml.PauliZ(0) @ qml.Identity(1),
+                    qml.PauliZ(0)
+                    ),
+                    (
+                    qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2),
+                    qml.PauliX(1)
+                    )
+                ]
+
+    @pytest.mark.parametrize("tensor_observable, expected", tensor_obs)
+    def test_prune(self, tensor_observable, expected):
+        """Tests that the prune method returns a Tensor removing any Identities."""
+
+        O = tensor_observable
+        O_pruned = O.prune()
+        assert type(O_pruned) == type(expected)
+        assert O_pruned.wires == expected.wires
 
 class TestDecomposition:
     """Test for operation decomposition"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -904,13 +904,16 @@ class TestTensor:
                          ]
 
     @pytest.mark.parametrize("tensor_observable, expected", tensor_obs_pruning)
-    def test_prune(self, tensor_observable, expected):
+    @pytest.mark.parametrize("statistics", [qml.expval, qml.var, qml.sample])
+    def test_prune(self, tensor_observable, expected, statistics):
         """Tests that the prune method returns the expected Tensor or single non-Tensor Observable."""
+        O = statistics(tensor_observable)
+        O_expected = statistics(expected)
 
-        O = tensor_observable
         O_pruned = O.prune()
         assert type(O_pruned) == type(expected)
         assert O_pruned.wires == expected.wires
+        assert O_pruned.return_type == O_expected.return_type
 
 class TestDecomposition:
     """Test for operation decomposition"""

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -855,40 +855,57 @@ class TestTensor:
     tensor_obs = [
                     (
                     qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2),
-                    qml.PauliZ(0) @ qml.PauliZ(2)
+                    [qml.PauliZ(0), qml.PauliZ(2)]
                     ),
                     (
-                    qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2) @ qml.PauliZ(3) @  qml.PauliZ(4),
-                    qml.PauliX(1) @ qml.PauliZ(4)
-                    )
-                ]
+                    qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2) @ qml.PauliZ(3) @  qml.PauliZ(4) @ qml.Identity(5),
+                    [qml.PauliX(1), qml.PauliZ(3), qml.PauliZ(4)]
+                    ),
 
-    @pytest.mark.parametrize("tensor_observable, expected", tensor_obs)
-    def test_prune(self, tensor_observable, expected):
-        """Tests that the prune method returns a Tensor removing any Identities."""
-
-        O = tensor_observable
-        O_pruned = O.prune()
-        for idx, obs in enumerate(O_pruned.obs):
-            assert type(obs) == type(expected.obs[idx])
-            assert obs.wires == expected.obs[idx].wires
-
-    def test_prune_single_observable(self):
-        """Tests that the prune method returns a single observable when there is only one non-Identity in the list of observables for a Tensor."""
-    tensor_obs = [
+                    # List containing single observable is returned
                     (
                     qml.PauliZ(0) @ qml.Identity(1),
-                    qml.PauliZ(0)
+                    [qml.PauliZ(0)]
                     ),
                     (
                     qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2),
-                    qml.PauliX(1)
+                    [qml.PauliX(1)]
                     )
                 ]
 
     @pytest.mark.parametrize("tensor_observable, expected", tensor_obs)
+    def test_non_identity_obs(self, tensor_observable, expected):
+        """Tests that the non_identity_obs property returns a list without any Identities."""
+
+        O = tensor_observable
+        for idx, obs in enumerate(O.non_identity_obs):
+            assert type(obs) == type(expected[idx])
+            assert obs.wires == expected[idx].wires
+
+    tensor_obs_pruning = [
+                            (
+                            qml.PauliZ(0) @ qml.Identity(1) @ qml.PauliZ(2),
+                            qml.PauliZ(0) @ qml.PauliZ(2)
+                            ),
+                            (
+                            qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2) @ qml.PauliZ(3) @  qml.PauliZ(4) @ qml.Identity(5),
+                            qml.PauliX(1) @ qml.PauliZ(3) @ qml.PauliZ(4)
+                            ),
+
+                            # Single observable is returned
+                            (
+                            qml.PauliZ(0) @ qml.Identity(1),
+                            qml.PauliZ(0)
+                            ),
+                            (
+                            qml.Identity(0) @ qml.PauliX(1) @ qml.Identity(2),
+                            qml.PauliX(1)
+                            )
+                         ]
+
+    @pytest.mark.parametrize("tensor_observable, expected", tensor_obs_pruning)
     def test_prune(self, tensor_observable, expected):
-        """Tests that the prune method returns a Tensor removing any Identities."""
+        """Tests that the prune method returns the expected Tensor or single non-Tensor Observable."""
 
         O = tensor_observable
         O_pruned = O.prune()

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -875,7 +875,7 @@ class TestTensor:
 
     @pytest.mark.parametrize("tensor_observable, expected", tensor_obs)
     def test_non_identity_obs(self, tensor_observable, expected):
-        """Tests that the non_identity_obs property returns a list without any Identities."""
+        """Tests that the non_identity_obs property returns a list that contains no Identity instances."""
 
         O = tensor_observable
         for idx, obs in enumerate(O.non_identity_obs):


### PR DESCRIPTION
**Context:**
A `Tensor` instance might contain `Identity` instances in its `obs` attribute. It is oftentimes preferable to:
* not have such identities there
* in case there is only a single observable in `obs`, obtain the single observable instead of a `Tensor`

**Description of the Change:**
Adds the `non_identity_obs` attribute and the `prune` method to the `Tensor` class, where
* The `non_identity_obs` returns the non-identity observables contained in the tensor product.
* The `prune` method returns a pruned tensor product of observables by removing the `Identity` instances from the observables building up the `Tensor`. If the tensor product only contains one observable, then this observable instance is returned.

**Benefits:**
There are functionalities included to remove unnecessary `Identity` instances from a `Tensor` instance.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
This PR will help with the following PennyLane-Forest PR: https://github.com/rigetti/pennylane-forest/pull/41