### PR TITLE
Check Python 3.8 compatibility

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 <h3>Improvements</h3>
 
+* Beginning of support for Python 3.8, with the test suite
+  now being run in a Python 3.8 environment.
+  [(#501)](https://github.com/XanaduAI/pennylane/pull/501)
+
 <h3>Documentation</h3>
 
 <h3>Bug fixes</h3>

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 cache: pip
 matrix:
   include:
+  - python: 3.8
+    dist: xenial
+    env: TF=0
   - python: 3.7
     dist: xenial
     env: TF=2

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ classifiers = [
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3 :: Only',
     "Topic :: Scientific/Engineering :: Physics"
 ]


### PR DESCRIPTION
**Context:** Python 3.8 has been out for a couple of months now, and a lot of dependencies are adding support for it.

**Description of the Change:** Adds continuous integration against Python 3.8

**Benefits:** n/a

**Possible Drawbacks:** Currently, wheels are not available for TensorFlow on Python 3.8.

**Related GitHub Issues:** n/a
