### PR TITLE
Make QNodes context managers for qfuncs.

### DIFF
--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -200,6 +200,20 @@ class BaseQNode:
         detail = "<QNode: device='{}', func={}, wires={}>"
         return detail.format(self.device.short_name, self.func.__name__, self.num_wires)
 
+    def __enter__(self):
+        """Make this node the current execution context for quantum functions.
+        """
+        if qml._current_context is None:
+            qml._current_context = self
+        else:
+            raise QuantumFunctionError("qml._current_context must not be modified outside this method.")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Reset the quantum function execution context to None.
+        """
+        qml._current_context = None
+
     def print_applied(self):
         """Prints the most recently applied operations from the QNode.
         """
@@ -482,29 +496,21 @@ class BaseQNode:
         self.obs_queue = []  #: list[Observable]: applied observables
 
         # set up the context for Operator entry
-        if qml._current_context is None:
-            qml._current_context = self
-        else:
-            raise QuantumFunctionError(
-                "qml._current_context must not be modified outside this method."
-            )
-        try:
-            # generate the program queue by executing the quantum circuit function
-            if self.mutable:
-                # it's ok to directly pass auxiliary arguments since the circuit is re-constructed each time
-                # (positional args must be replaced because parameter-shift differentiation requires VariableRefs)
-                res = self.func(*self.arg_vars, **kwargs)
-            else:
-                # TODO: Maybe we should only convert the kwarg_vars that were actually given
-                res = self.func(*self.arg_vars, **self.kwarg_vars)
-        except:
-            # The qfunc call may have failed because the user supplied bad parameters, which is why we must wipe the created VariableRefs.
-            self.arg_vars = None
-            self.kwarg_vars = None
-
-            raise
-        finally:
-            qml._current_context = None
+        with self:
+            try:
+                # generate the program queue by executing the quantum circuit function
+                if self.mutable:
+                    # it's ok to directly pass auxiliary arguments since the circuit is re-constructed each time
+                    # (positional args must be replaced because parameter-shift differentiation requires VariableRefs)
+                    res = self.func(*self.arg_vars, **kwargs)
+                else:
+                    # TODO: Maybe we should only convert the kwarg_vars that were actually given
+                    res = self.func(*self.arg_vars, **self.kwarg_vars)
+            except:
+                # The qfunc call may have failed because the user supplied bad parameters, which is why we must wipe the created VariableRefs.
+                self.arg_vars = None
+                self.kwarg_vars = None
+                raise
 
         # check the validity of the circuit
         self._check_circuit(res)


### PR DESCRIPTION
**Context:**

Quantum functions need a QNode as a context to capture their contents when they are executed. The context is currently set using a global variable that the nodes set in their `_construct` method, and then released immediately afterwards.

**Description of the Change:**

* `BaseQNode` is given `__enter__` and `__exit__` methods, turning it into a context manager for qfuncs.

**Benefits:**

* The context is set using a `with` statement in the `_construct` methods of `BaseQNode` subclasses. All the code that involves the global variable is now in one place, and releasing the context happens automatically even if there's an exception in the qfunc.

