### PR TITLE
Fixes the divide-by-zero bug in Operation.get_parameter_shift.

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,17 +19,21 @@
 
 <h3>Documentation</h3>
 
-* Present templates as a gallery of thumbnails showing the 
+* Present templates as a gallery of thumbnails showing the
   basic circuit architecture.
   [(#499)](https://github.com/XanaduAI/pennylane/pull/499)
 
 <h3>Bug fixes</h3>
 
+* Fixed a bug where multiplying a QNode parameter by 0 caused a divide
+  by zero error when calculating the parameter shift formula.
+  [(#512)](https://github.com/XanaduAI/pennylane/pull/512)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Ville Bergholm
+Ville Bergholm, Josh Izaac, Maria Schuld
 
 # Release 0.8.0 (current release)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -516,13 +516,15 @@ class Operation(Operator):
         """
         # get the gradient recipe for this parameter
         recipe = self.grad_recipe[idx]
+        multiplier, shift = (0.5, np.pi / 2) if recipe is None else recipe
+
         # internal multiplier in the VariableRef
         var_mult = self.params[idx].mult
 
-        multiplier = 0.5 if recipe is None else recipe[0]
         multiplier *= var_mult
-        shift = np.pi / 2 if recipe is None else recipe[1]
-        shift /= var_mult
+        if var_mult != 0:
+            # zero multiplier means the shift is unimportant
+            shift /= var_mult
         return multiplier, shift
 
     @property

--- a/tests/qnodes/test_qnode_qubit.py
+++ b/tests/qnodes/test_qnode_qubit.py
@@ -84,6 +84,30 @@ class TestBestMethod:
 class TestExpectationJacobian:
     """Jacobian integration tests for qubit expectations."""
 
+    def test_parameter_multipliers(self, tol):
+        """Test that various types and values of scalar multipliers for differentiable
+        qfunc parameters yield the correct gradients."""
+
+        mults = [1, -2, 1.623, -0.051, 0]  # intergers, floats, zero
+        par = np.zeros_like(mults)
+
+        def circuit(x):
+            for k in range(len(mults)):
+                qml.RY(mults[k] * x[k], wires=[0])
+            return qml.expval(qml.PauliX(0))
+
+        dev = qml.device("default.qubit", wires=1)
+        q = QubitQNode(circuit, dev)
+
+        # gradients
+        exact = (mults * np.cos(mults * par))[np.newaxis, :]
+        grad_F = q.jacobian([par], method="F")
+        grad_A = q.jacobian([par], method="A")
+
+        # different methods must agree
+        assert grad_F == pytest.approx(exact, abs=tol)
+        assert grad_A == pytest.approx(exact, abs=tol)
+
     @pytest.mark.parametrize("reused_p", thetas ** 3 / 19)
     @pytest.mark.parametrize("other_p", thetas ** 2 / 1)
     def test_fanout_multiple_params(self, reused_p, other_p, tol):

--- a/tests/qnodes/test_qnode_qubit.py
+++ b/tests/qnodes/test_qnode_qubit.py
@@ -84,25 +84,24 @@ class TestBestMethod:
 class TestExpectationJacobian:
     """Jacobian integration tests for qubit expectations."""
 
-    def test_parameter_multipliers(self, tol):
+    @pytest.mark.parametrize("mult", [1, -2, 1.623, -0.051, 0])  # intergers, floats, zero
+    def test_parameter_multipliers(self, mult, tol):
         """Test that various types and values of scalar multipliers for differentiable
         qfunc parameters yield the correct gradients."""
 
-        mults = [1, -2, 1.623, -0.051, 0]  # intergers, floats, zero
-        par = np.zeros_like(mults)
-
         def circuit(x):
-            for k in range(len(mults)):
-                qml.RY(mults[k] * x[k], wires=[0])
+            qml.RY(mult * x, wires=[0])
             return qml.expval(qml.PauliX(0))
 
         dev = qml.device("default.qubit", wires=1)
         q = QubitQNode(circuit, dev)
 
+        par = [0.1]
+
         # gradients
-        exact = (mults * np.cos(mults * par))[np.newaxis, :]
-        grad_F = q.jacobian([par], method="F")
-        grad_A = q.jacobian([par], method="A")
+        exact = mult * np.cos(mult * np.array([par]))
+        grad_F = q.jacobian(par, method="F")
+        grad_A = q.jacobian(par, method="A")
 
         # different methods must agree
         assert grad_F == pytest.approx(exact, abs=tol)


### PR DESCRIPTION
**Context:**

If a `VariableRef` has a zero internal multiplier, `Operation.get_parameter_shift` raises a divide-by-zero error.

**Description of the Change:**

* Adds a check for a zero multiplier.
* Adds a test for `VariableRef` multipliers.

**Benefits:**

* The bug is fixed.
