### PR TITLE
Temporarily rename `VariableRef` back to `Variable`

### DIFF
--- a/doc/code/qml_operation.rst
+++ b/doc/code/qml_operation.rst
@@ -14,4 +14,4 @@ qml.operation
 .. automodapi:: pennylane.operation
     :no-heading:
     :include-all-objects:
-    :skip: Sequence, Enum, IntEnum, VariableRef, ClassPropertyDescriptor, multi_dot, pauli_eigs
+    :skip: Sequence, Enum, IntEnum, Variable, ClassPropertyDescriptor, multi_dot, pauli_eigs

--- a/doc/code/qml_utils.rst
+++ b/doc/code/qml_utils.rst
@@ -12,4 +12,4 @@ qml.utils
     :no-heading:
     :include-all-objects:
     :no-inheritance-diagram:
-    :skip: Iterable, VariableRef, OrderedDict
+    :skip: Iterable, Variable, OrderedDict

--- a/doc/code/qml_variable.rst
+++ b/doc/code/qml_variable.rst
@@ -6,7 +6,7 @@ qml.variable
 .. warning::
 
     Unless you are a PennyLane or plugin developer, you likely do not need
-    to use the ``VariableRef`` class.
+    to use the ``Variable`` class.
 
 .. automodapi:: pennylane.variable
     :no-heading:

--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -28,7 +28,7 @@ try:
 except ImportError as e:
     raise ImportError("default.tensor.tf device requires TensorFlow>=2.0")
 
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 from pennylane.beta.plugins.default_tensor import DefaultTensor, I, X, Y, Z
 
 
@@ -327,7 +327,7 @@ class DefaultTensorTF(DefaultTensor):
         # check that no Variables remain in the op_params dictionary
         values = [item for sublist in self.op_params.values() for item in sublist]
         assert not any(
-            isinstance(v, VariableRef) for v in values
+            isinstance(v, Variable) for v in values
         ), "A pennylane.Variable instance was not correctly converted to a tf.Variable"
 
         # flatten the variables list in case of nesting

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -107,12 +107,12 @@ class RepresentationResolver:
         """Resolve the representation of an Operator's parameter.
 
         Args:
-            par (Union[~.variable.VariableRef, int, float]): The parameter to be rendered
+            par (Union[~.variable.Variable, int, float]): The parameter to be rendered
 
         Returns:
             str: String representation of the parameter
         """
-        if isinstance(par, qml.variable.VariableRef):
+        if isinstance(par, qml.variable.Variable):
             return par.render(self.show_variable_names)
 
         return str(round(par, 3))

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -24,7 +24,7 @@ from pennylane.operation import Sample
 
 from .circuit_drawer import CHARSETS, CircuitDrawer
 from .utils import _flatten
-from .variable import VariableRef
+from .variable import Variable
 
 
 def _by_idx(x):
@@ -184,7 +184,7 @@ class CircuitGraph:
             serialization_string += op.name
 
             for param in op.params:
-                if isinstance(param, VariableRef):
+                if isinstance(param, Variable):
                     serialization_string += delimiter
                     serialization_string += variable_delimiter
                     serialization_string += str(param.idx)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -112,7 +112,7 @@ from numpy.linalg import multi_dot
 import pennylane as qml
 
 from .utils import _flatten, pauli_eigs
-from .variable import VariableRef
+from .variable import Variable
 
 # =============================================================================
 # Wire types
@@ -223,7 +223,7 @@ class Operator(abc.ABC):
     * :attr:`~.Operator.par_domain`
 
     Args:
-        params (tuple[float, int, array, VariableRef]): operator parameters
+        params (tuple[float, int, array, Variable]): operator parameters
 
     Keyword Args:
         wires (Sequence[int]): Subsystems it acts on. If not given, args[-1]
@@ -375,27 +375,27 @@ class Operator(abc.ABC):
     def check_domain(self, p, flattened=False):
         """Check the validity of a parameter.
 
-        :class:`.VariableRef` instances can represent any real scalars (but not arrays).
+        :class:`.Variable` instances can represent any real scalars (but not arrays).
 
         Args:
-            p (Number, array, VariableRef): parameter to check
+            p (Number, array, Variable): parameter to check
             flattened (bool): True means p is an element of a flattened parameter
                 sequence (affects the handling of 'A' parameters)
         Raises:
             TypeError: parameter is not an element of the expected domain
             ValueError: parameter is an element of an unknown domain
         Returns:
-            Number, array, VariableRef: p
+            Number, array, Variable: p
         """
-        if isinstance(p, VariableRef):
+        if isinstance(p, Variable):
             if self.par_domain == "A":
                 raise TypeError(
-                    "{}: Array parameter expected, got a VariableRef,"
+                    "{}: Array parameter expected, got a Variable,"
                     "which can only represent real scalars.".format(self.name)
                 )
             return p
 
-        # p is not a VariableRef
+        # p is not a Variable
         if self.par_domain == "A":
             if flattened:
                 if isinstance(p, np.ndarray):
@@ -442,7 +442,7 @@ class Operator(abc.ABC):
         """Current parameter values.
 
         Fixed parameters are returned as is, free parameters represented by
-        :class:`.VariableRef` instances are replaced by their
+        :class:`.Variable` instances are replaced by their
         current numerical value.
 
         Returns:
@@ -452,12 +452,12 @@ class Operator(abc.ABC):
         def evaluate(p):
             """Evaluate a single parameter."""
             if isinstance(p, np.ndarray):
-                # object arrays may have VariableRefs inside them
+                # object arrays may have Variables inside them
                 if p.dtype == object:
-                    temp = np.array([x.val if isinstance(x, VariableRef) else x for x in p.flat])
+                    temp = np.array([x.val if isinstance(x, Variable) else x for x in p.flat])
                     return temp.reshape(p.shape)
                 return p
-            if isinstance(p, VariableRef):
+            if isinstance(p, Variable):
                 p = self.check_domain(p.val)
             return p
 
@@ -498,7 +498,7 @@ class Operation(Operator):
     * :attr:`~.Operation.generator`
 
     Args:
-        params (tuple[float, int, array, VariableRef]): operation parameters
+        params (tuple[float, int, array, Variable]): operation parameters
 
     Keyword Args:
         wires (Sequence[int]): Subsystems it acts on. If not given, args[-1]
@@ -549,7 +549,7 @@ class Operation(Operator):
         recipe = self.grad_recipe[idx]
         multiplier, shift = (0.5, np.pi / 2) if recipe is None else recipe
 
-        # internal multiplier in the VariableRef
+        # internal multiplier in the Variable
         var_mult = self.params[idx].mult
 
         multiplier *= var_mult
@@ -682,7 +682,7 @@ class Observable(Operator):
     * :attr:`~.Operator.par_domain`
 
     Args:
-        params (tuple[float, int, array, VariableRef]): observable parameters
+        params (tuple[float, int, array, Variable]): observable parameters
 
     Keyword Args:
         wires (Sequence[int]): subsystems it acts on.

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -25,7 +25,7 @@ import pennylane as qml
 from pennylane.operation import Observable, CV, Wires, ObservableReturnTypes
 from pennylane.utils import _flatten, unflatten
 from pennylane.circuit_graph import CircuitGraph, _is_observable
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 ParameterDependency = namedtuple("ParameterDependency", ["op", "par_idx"])
@@ -34,7 +34,7 @@ ParameterDependency = namedtuple("ParameterDependency", ["op", "par_idx"])
 Args:
     op (Operator): operator depending on the positional parameter in question
     par_idx (int): flattened operator parameter index of the corresponding
-        :class:`~.VariableRef` instance
+        :class:`~.Variable` instance
 """
 
 
@@ -275,17 +275,17 @@ class BaseQNode:
         )
 
     def _set_variables(self, args, kwargs):
-        """Store the current values of the quantum function parameters in the VariableRef class
+        """Store the current values of the quantum function parameters in the Variable class
         so the Operators may access them.
 
         Args:
             args (tuple[Any]): positional (differentiable) arguments
             kwargs (dict[str, Any]): auxiliary arguments
         """
-        VariableRef.positional_arg_values = np.array(list(_flatten(args)))
+        Variable.positional_arg_values = np.array(list(_flatten(args)))
         if not self.mutable:
-            # only immutable circuits access auxiliary arguments through VariableRefs
-            VariableRef.kwarg_values = {k: np.array(list(_flatten(v))) for k, v in kwargs.items()}
+            # only immutable circuits access auxiliary arguments through Variables
+            Variable.kwarg_values = {k: np.array(list(_flatten(v))) for k, v in kwargs.items()}
 
     def _op_descendants(self, op, only):
         """Descendants of the given operator in the quantum circuit.
@@ -384,10 +384,10 @@ class BaseQNode:
         return variable_name_string
 
     def _make_variables(self, args, kwargs):
-        """Create the :class:`~.variable.VariableRef` instances representing the QNode's arguments.
+        """Create the :class:`~.variable.Variable` instances representing the QNode's arguments.
 
-        The created :class:`~.variable.VariableRef` instances are given in the same nested structure
-        as the original arguments. The :class:`~.variable.VariableRef` instances are named according
+        The created :class:`~.variable.Variable` instances are given in the same nested structure
+        as the original arguments. The :class:`~.variable.Variable` instances are named according
         to the argument names given in the QNode definition. Consider the following example:
 
         .. code-block:: python3
@@ -401,7 +401,7 @@ class BaseQNode:
 
                 return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        In this example, ``_make_variables`` will return the following :class:`~.variable.VariableRef` instances
+        In this example, ``_make_variables`` will return the following :class:`~.variable.Variable` instances
 
         .. code-block:: python3
 
@@ -410,13 +410,13 @@ class BaseQNode:
             >>> qfunc._make_variables([3.4, [1.2, 3.4, 5.6]], {})
             ["a", ["w[0]", "w[1]", "w[2]"]], {}
 
-        where the VariableRef instances are replaced with their name for readability.
+        where the Variable instances are replaced with their name for readability.
 
         Args:
             args (tuple[Any]): Positional arguments passed to the quantum function.
                 During the construction we are not concerned with the numerical values, but with
                 the nesting structure.
-                Each positional argument is replaced with a :class:`~.variable.VariableRef` instance.
+                Each positional argument is replaced with a :class:`~.variable.Variable` instance.
             kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
         """
         # Get the name of the qfunc's arguments
@@ -440,18 +440,18 @@ class BaseQNode:
                 )
 
         arg_vars = [
-            VariableRef(idx, name) for idx, name in enumerate(_flatten(variable_name_strings))
+            Variable(idx, name) for idx, name in enumerate(_flatten(variable_name_strings))
         ]
         self.num_variables = len(arg_vars)
 
-        # arrange the newly created VariableRefs in the nested structure of args
+        # arrange the newly created Variables in the nested structure of args
         arg_vars = unflatten(arg_vars, args)
 
         # kwargs
-        # if not mutable: must convert auxiliary arguments to named VariableRefs so they can be updated without re-constructing the circuit
+        # if not mutable: must convert auxiliary arguments to named Variables so they can be updated without re-constructing the circuit
         # kwarg_vars = {}
         # for key, val in kwargs.items():
-        #    temp = [VariableRef(idx, name=key) for idx, _ in enumerate(_flatten(val))]
+        #    temp = [Variable(idx, name=key) for idx, _ in enumerate(_flatten(val))]
         #    kwarg_vars[key] = unflatten(temp, val)
 
         variable_name_strings = {}
@@ -471,11 +471,11 @@ class BaseQNode:
                     )
 
                 kwarg_variable = [
-                    VariableRef(idx, name=name, is_kwarg=True)
+                    Variable(idx, name=name, is_kwarg=True)
                     for idx, name in enumerate(_flatten(variable_name_string))
                 ]
             else:
-                kwarg_variable = VariableRef(0, name=variable_name, is_kwarg=True)
+                kwarg_variable = Variable(0, name=variable_name, is_kwarg=True)
 
             kwarg_vars[variable_name] = kwarg_variable
 
@@ -488,17 +488,17 @@ class BaseQNode:
         or :meth:`.JacobianQNode.jacobian` is called, and for mutable nodes *each time*
         they are called. It executes the quantum function,
         stores the resulting sequence of :class:`.Operator` instances,
-        converts it into a circuit graph, and creates the VariableRef mapping.
+        converts it into a circuit graph, and creates the Variable mapping.
 
         .. note::
-           The VariableRefs are only required for analytic differentiation,
+           The Variables are only required for analytic differentiation,
            for evaluation we could simply reconstruct the circuit each time.
 
         Args:
             args (tuple[Any]): Positional arguments passed to the quantum function.
                 During the construction we are not concerned with the numerical values, but with
                 the nesting structure.
-                Each positional argument is replaced with a :class:`~.VariableRef` instance.
+                Each positional argument is replaced with a :class:`~.Variable` instance.
             kwargs (dict[str, Any]): Auxiliary arguments passed to the quantum function.
 
         Raises:
@@ -520,13 +520,13 @@ class BaseQNode:
                 # generate the program queue by executing the quantum circuit function
                 if self.mutable:
                     # it's ok to directly pass auxiliary arguments since the circuit is re-constructed each time
-                    # (positional args must be replaced because parameter-shift differentiation requires VariableRefs)
+                    # (positional args must be replaced because parameter-shift differentiation requires Variables)
                     res = self.func(*self.arg_vars, **kwargs)
                 else:
                     # TODO: Maybe we should only convert the kwarg_vars that were actually given
                     res = self.func(*self.arg_vars, **self.kwarg_vars)
             except:
-                # The qfunc call may have failed because the user supplied bad parameters, which is why we must wipe the created VariableRefs.
+                # The qfunc call may have failed because the user supplied bad parameters, which is why we must wipe the created Variables.
                 self.arg_vars = None
                 self.kwarg_vars = None
                 raise
@@ -543,7 +543,7 @@ class BaseQNode:
         self.variable_deps = {k: [] for k in range(self.num_variables)}
         for k, op in enumerate(self.ops):
             for j, p in enumerate(_flatten(op.params)):
-                if isinstance(p, VariableRef):
+                if isinstance(p, Variable):
                     if not p.is_kwarg:  # ignore auxiliary arguments
                         self.variable_deps[p.idx].append(ParameterDependency(op, j))
 

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -439,9 +439,7 @@ class BaseQNode:
                     self._determine_structured_variable_name(variable_value, variable_name)
                 )
 
-        arg_vars = [
-            Variable(idx, name) for idx, name in enumerate(_flatten(variable_name_strings))
-        ]
+        arg_vars = [Variable(idx, name) for idx, name in enumerate(_flatten(variable_name_strings))]
         self.num_variables = len(arg_vars)
 
         # arrange the newly created Variables in the nested structure of args

--- a/pennylane/qnodes/passthru.py
+++ b/pennylane/qnodes/passthru.py
@@ -33,11 +33,11 @@ Additionally, any array-like ADT needs to be able to handle (1) scalar multiplic
 (2) indexing/slicing, and possibly (3) iteration, as these are the things qfuncs expect of
 array-like parameters.
 
-PassthruQNode does not have a Jacobian method, so it does not HAVE to use VariableRefs or scalar linear indexing of input parameters.
+PassthruQNode does not have a Jacobian method, so it does not HAVE to use Variables or scalar linear indexing of input parameters.
 Two options:
-1. Use VariableRefs anyway, re-use most BaseQNode methods.
-   Problem: after evaluating the VariableRefs, stacking sliced/indexed Tensors in Operation.parameters should somehow result in a Tensor, not an object array.
-2. Do not use VariableRefs, call the qfunc each time :meth:`PassthruQNode.evaluate` is called (always mutable).
+1. Use Variables anyway, re-use most BaseQNode methods.
+   Problem: after evaluating the Variables, stacking sliced/indexed Tensors in Operation.parameters should somehow result in a Tensor, not an object array.
+2. Do not use Variables, call the qfunc each time :meth:`PassthruQNode.evaluate` is called (always mutable).
    Problem: tensornet_tf requires variable_deps?
 
 TODO rethink output_conversion? should require device to return things in a fixed form, but either as arrays or as AD Tensors, do conversion in interface (if necessary...)
@@ -84,13 +84,13 @@ class PassthruQNode(BaseQNode):
         return detail.format(self.device.short_name, self.func.__name__, self.num_wires)
 
     def _set_variables(self, args, kwargs):
-        # do nothing, since we do not use VariableRefs
+        # do nothing, since we do not use Variables
         pass
 
     def _construct(self, args, kwargs):
         """Construct the quantum circuit graph by calling the quantum function.
 
-        Like :class:`.BaseQNode._construct`, but does not use VariableRefs.
+        Like :class:`.BaseQNode._construct`, but does not use Variables.
         """
         # temporary queues for operations and observables
         self.queue = []  #: list[Operation]: applied operations
@@ -114,7 +114,7 @@ class PassthruQNode(BaseQNode):
         # no output conversion
         self.output_conversion = lambda x: x
 
-        # no VariableRefs, self.variable_deps is empty!
+        # no Variables, self.variable_deps is empty!
         # generate the DAG
         self.circuit = pennylane.circuit_graph.CircuitGraph(self.ops, self.variable_deps)
 

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -25,7 +25,7 @@ from pennylane.templates.utils import (
     _check_type,
     _get_shape,
 )
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 # tolerance for normalization
 TOLERANCE = 1e-10
@@ -215,7 +215,7 @@ def AmplitudeEmbedding(features, wires, pad=None, normalize=False):
         )
 
     # normalize
-    if isinstance(features[0], VariableRef):
+    if isinstance(features[0], Variable):
         feature_values = [s.val for s in features]
         norm = np.sum(np.abs(feature_values) ** 2)
     else:

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -22,7 +22,7 @@ import pennylane as qml
 
 from pennylane.templates.decorator import template
 from pennylane.templates.utils import _check_wires, _check_shape, _get_shape
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 # pylint: disable=len-as-condition,arguments-out-of-order
@@ -258,7 +258,7 @@ def MottonenStatePreparation(state_vector, wires):
     )
 
     # check if state_vector is normalized
-    if isinstance(state_vector[0], VariableRef):
+    if isinstance(state_vector[0], Variable):
         state_vector_values = [s.val for s in state_vector]
         norm = np.sum(np.abs(state_vector_values) ** 2)
     else:
@@ -278,7 +278,7 @@ def MottonenStatePreparation(state_vector, wires):
     omega = sparse.dok_matrix(state_vector.shape)
 
     for (i, j), v in state_vector.items():
-        if isinstance(v, VariableRef):
+        if isinstance(v, Variable):
             a[i, j] = np.absolute(v.val)
             omega[i, j] = np.angle(v.val)
         else:

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -18,7 +18,7 @@ Utility functions used in the templates.
 from collections.abc import Iterable
 
 import numpy as np
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 def _check_no_variable(arg, msg):
@@ -32,11 +32,11 @@ def _check_no_variable(arg, msg):
         msg (str): error message to display
     """
 
-    if isinstance(arg, VariableRef):
+    if isinstance(arg, Variable):
         raise ValueError(msg)
 
     if isinstance(arg, Iterable):
-        if any([isinstance(a_, VariableRef) for a_ in arg]):
+        if any([isinstance(a_, Variable) for a_ in arg]):
             raise ValueError(msg)
 
 

--- a/pennylane/utils.py
+++ b/pennylane/utils.py
@@ -27,7 +27,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 def _flatten(x):
@@ -66,7 +66,7 @@ def _unflatten(flat, model):
         Union[array, list, Any], array: first elements of flat arranged into the nested
         structure of model, unused elements of flat
     """
-    if isinstance(model, (numbers.Number, VariableRef, str)):
+    if isinstance(model, (numbers.Number, Variable, str)):
         return flat[0], flat[1:]
 
     if isinstance(model, np.ndarray):

--- a/pennylane/variable.py
+++ b/pennylane/variable.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-This module contains the :class:`VariableRef` class, which is used to track
+This module contains the :class:`Variable` class, which is used to track
 and identify :class:`~pennylane.qnode.QNode` parameters.
 
 Description
@@ -22,10 +22,10 @@ The first time a QNode is evaluated (either by calling :meth:`~.QNode.evaluate`,
 :meth:`~.QNode.__call__`, or :meth:`~.QNode.jacobian`), the :meth:`~.QNode.construct`
 method is called, which performs a 'just-in-time' circuit construction
 on the :mod:`~pennylane._device.Device`. As part of this construction, all arguments
-and keyword arguments are wrapped in a `VariableRef` as follows:
+and keyword arguments are wrapped in a `Variable` as follows:
 
 * All positional arguments in ``*args``, including those with multiple dimensions, are
-  flattened to a single list, and each element wrapped as a VariableRef instance,
+  flattened to a single list, and each element wrapped as a Variable instance,
   indexed by its position in the list.
 
   This allows PennyLane to inspect the shape and type of arguments
@@ -34,11 +34,11 @@ and keyword arguments are wrapped in a `VariableRef` as follows:
 
 
 * The same is done for each keyword argument in ``**kwargs``, the only
-  difference being that the name of each contained VariableRef corresponds
+  difference being that the name of each contained Variable corresponds
   with the keyword name.
 
 As a result, the device stores a list of operations and expectations, with all
-free parameters stored as VariableRef instances.
+free parameters stored as Variable instances.
 
 .. note::
     The QNode can be differentiated with respect to positional arguments,
@@ -50,20 +50,20 @@ free parameters stored as VariableRef instances.
     corresponding variable as a keyword argument, otherwise it won't register.
 
 For each successive QNode execution, the user-provided values for the positional and keyword
-arguments are stored in :attr:`VariableRef.positional_arg_values` and
-:attr:`VariableRef.kwarg_values` respectively; the values are
-then returned by :meth:`VariableRef.val`, using the VariableRef's ``idx`` attribute, and, for
+arguments are stored in :attr:`Variable.positional_arg_values` and
+:attr:`Variable.kwarg_values` respectively; the values are
+then returned by :meth:`Variable.val`, using the Variable's ``idx`` attribute, and, for
 keyword arguments, its ``name``, to return the correct value to the operation.
 
 .. note::
     The :meth:`Operation.parameters() <pennylane.operation.Operation.parameters>`
-    property automates the process of unpacking the VariableRef value.
-    The attribute :meth:`VariableRef.val` should not need to be accessed outside of advanced usage.
+    property automates the process of unpacking the Variable value.
+    The attribute :meth:`Variable.val` should not need to be accessed outside of advanced usage.
 """
 import copy
 
 
-class VariableRef:
+class Variable:
     """A reference to dynamically track and update circuit parameters.
 
     Represents a free quantum circuit parameter (with a non-fixed value),
@@ -71,14 +71,14 @@ class VariableRef:
 
     Each time the circuit is executed, it is given a vector of flattened positional argument values,
     and a dictionary mapping keyword-only argument names to vectors of their flattened values.
-    Each element of these vectors corresponds to a VariableRef instance.
-    Positional arguments are represented by nameless VariableRefs, whereas for keyword-only
-    arguments :attr:`VariableRef.name` contains the argument name.
-    In both cases :attr:`VariableRef.idx` is an index into the argument value vector.
+    Each element of these vectors corresponds to a Variable instance.
+    Positional arguments are represented by nameless Variables, whereas for keyword-only
+    arguments :attr:`Variable.name` contains the argument name.
+    In both cases :attr:`Variable.idx` is an index into the argument value vector.
 
-    The VariableRef has an optional scalar multiplier for the argument it represents.
+    The Variable has an optional scalar multiplier for the argument it represents.
 
-    .. note:: VariableRefs currently do not implement any arithmetic
+    .. note:: Variables currently do not implement any arithmetic
         operations other than scalar multiplication.
 
     Args:
@@ -103,14 +103,14 @@ class VariableRef:
 
     def __repr__(self):
         temp = " * {}".format(self.mult) if self.mult != 1.0 else ""
-        return "<VariableRef({}:{}{})>".format(self.name, self.idx, temp)
+        return "<Variable({}:{}{})>".format(self.name, self.idx, temp)
 
     def __str__(self):
         temp = ", * {}".format(self.mult) if self.mult != 1.0 else ""
-        return "VariableRef: name = {}, idx = {}{}".format(self.name, self.idx, temp)
+        return "Variable: name = {}, idx = {}{}".format(self.name, self.idx, temp)
 
     def __eq__(self, other):
-        if not isinstance(other, VariableRef):
+        if not isinstance(other, Variable):
             return False
 
         return (
@@ -142,37 +142,37 @@ class VariableRef:
 
     @property
     def val(self):
-        """Current numerical value of the VariableRef.
+        """Current numerical value of the Variable.
 
         Returns:
-            float: current value of the VariableRef
+            float: current value of the Variable
         """
         # pylint: disable=unsubscriptable-object
         if not self.is_kwarg:
             # The variable is a placeholder for a positional argument
-            return VariableRef.positional_arg_values[self.idx] * self.mult
+            return Variable.positional_arg_values[self.idx] * self.mult
 
         # The variable is a placeholder for a keyword argument
-        values = VariableRef.kwarg_values[self.name]
+        values = Variable.kwarg_values[self.name]
         return values[self.idx] * self.mult
 
     def render(self, show_name_only=False):
-        """Returns a string representation of the VariableRef.
+        """Returns a string representation of the Variable.
 
         Args:
             show_name_only (bool, optional): Render the name instead of the value.
 
         Returns:
-            str: A string representation of the VariableRef
+            str: A string representation of the Variable
         """
         if not show_name_only:
-            if self.is_kwarg and VariableRef.kwarg_values and self.name in VariableRef.kwarg_values:
+            if self.is_kwarg and Variable.kwarg_values and self.name in Variable.kwarg_values:
                 return str(round(self.val, 3))
 
             if (
                 not self.is_kwarg
-                and VariableRef.positional_arg_values is not None
-                and len(VariableRef.positional_arg_values) > self.idx
+                and Variable.positional_arg_values is not None
+                and len(Variable.positional_arg_values) > self.idx
             ):
                 return str(round(self.val, 3))
 

--- a/tests/circuit_drawer/test_representation_resolver.py
+++ b/tests/circuit_drawer/test_representation_resolver.py
@@ -20,7 +20,7 @@ import numpy as np
 
 import pennylane as qml
 from pennylane.circuit_drawer import RepresentationResolver
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 @pytest.fixture
@@ -43,16 +43,16 @@ def unicode_representation_resolver_varnames():
 
 @pytest.fixture
 def variable(monkeypatch):
-    """A mocked VariableRef instance for a non-keyword variable."""
-    monkeypatch.setattr(VariableRef, "positional_arg_values", [0, 1, 2, 3])
-    yield VariableRef(2, "test")
+    """A mocked Variable instance for a non-keyword variable."""
+    monkeypatch.setattr(Variable, "positional_arg_values", [0, 1, 2, 3])
+    yield Variable(2, "test")
 
 
 @pytest.fixture
 def kwarg_variable(monkeypatch):
-    """A mocked VariableRef instance for a keyword variable."""
-    monkeypatch.setattr(VariableRef, "kwarg_values", {"kwarg_test": [0, 1, 2, 3]})
-    yield VariableRef(1, "kwarg_test", True)
+    """A mocked Variable instance for a keyword variable."""
+    monkeypatch.setattr(Variable, "kwarg_values", {"kwarg_test": [0, 1, 2, 3]})
+    yield Variable(1, "kwarg_test", True)
 
 
 class TestRepresentationResolver:

--- a/tests/circuit_graph/test_circuit_graph_hash.py
+++ b/tests/circuit_graph/test_circuit_graph_hash.py
@@ -21,7 +21,7 @@ import pennylane as qml
 from pennylane.operation import Tensor
 from pennylane.circuit_graph import CircuitGraph
 from pennylane.qnodes import BaseQNode
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 class TestCircuitGraphHash:
     """Test the creation of a hash on a CircuitGraph"""
@@ -53,7 +53,7 @@ class TestCircuitGraphHash:
         assert expected_string == circuit_graph_1.serialize()
 
 
-    variable = VariableRef(1)
+    variable = Variable(1)
 
     symbolic_queue = [
                         ([qml.RX(variable, wires=[0])],
@@ -74,7 +74,7 @@ class TestCircuitGraphHash:
         assert expected_string == circuit_graph_1.serialize()
 
 
-    variable = VariableRef(1)
+    variable = Variable(1)
 
     symbolic_queue = [
                         ([
@@ -99,7 +99,7 @@ class TestCircuitGraphHash:
         assert circuit_graph_1.serialize() == circuit_graph_2.serialize()
         assert expected_string == circuit_graph_1.serialize()
 
-    variable = VariableRef(1)
+    variable = Variable(1)
 
     many_symbolic_queue = [
                         ([
@@ -124,8 +124,8 @@ class TestCircuitGraphHash:
         assert circuit_graph_1.serialize() == circuit_graph_2.serialize()
         assert expected_string == circuit_graph_1.serialize()
 
-    variable1 = VariableRef(1)
-    variable2 = VariableRef(2)
+    variable1 = Variable(1)
+    variable2 = Variable(2)
 
     multiple_symbolic_queue = [
                         ([

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -24,7 +24,7 @@ import numpy as np
 import pennylane as qml
 from pennylane._device import Device
 from pennylane.qnodes.base import BaseQNode, QuantumFunctionError, decompose_queue
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 @pytest.fixture(scope="function")
@@ -541,7 +541,7 @@ class TestQNodeExceptions:
 
         # valid calls
         node(x=0.1, n=0.4)
-        assert circuit.in_args[2:] == (0.3, 0.4)  # first two are VariableRefs
+        assert circuit.in_args[2:] == (0.3, 0.4)  # first two are Variables
         node(0.1, n=0.4)
         assert circuit.in_args[2:] == (0.3, 0.4)
 
@@ -583,7 +583,7 @@ class TestQNodeExceptions:
 
         # valid calls
         node(x=0.1, n=0.4)
-        assert circuit.in_args[2:] == (0.3, 0.4)  # first two are VariableRefs
+        assert circuit.in_args[2:] == (0.3, 0.4)  # first two are Variables
         node(0.1, n=0.4)
         assert circuit.in_args[2:] == (0.3, 0.4)
 
@@ -622,7 +622,7 @@ class TestQNodeExceptions:
 
         # valid calls
         node(0.1)
-        assert circuit.in_args[1:] == (0.2, 0.3)  # first is a VariableRef
+        assert circuit.in_args[1:] == (0.2, 0.3)  # first is a Variable
         node(0.1, y=1.2)
         assert circuit.in_args[1:] == (1.2, 0.3)
         node(0.1, z=1.3, y=1.2)
@@ -1009,10 +1009,10 @@ class TestDecomposition:
 
 
 class TestQNodeVariableMap:
-    """Test the conversion of arguments to VariableRef instances."""
+    """Test the conversion of arguments to Variable instances."""
 
     def test_regular_arguments(self, mock_device):
-        """Test that regular arguments are properly converted to VariableRef instances."""
+        """Test that regular arguments are properly converted to Variable instances."""
         def circuit(a, b, c, d):
             qml.RX(a, wires=[0])
             qml.RY(b, wires=[0])
@@ -1025,10 +1025,10 @@ class TestQNodeVariableMap:
         arg_vars, kwarg_vars = node._make_variables([1.0, 2.0, 3.0, 4.0], {})
 
         expected_arg_vars = [
-            VariableRef(0, "a"),
-            VariableRef(1, "b"),
-            VariableRef(2, "c"),
-            VariableRef(3, "d"),
+            Variable(0, "a"),
+            Variable(1, "b"),
+            Variable(2, "c"),
+            Variable(3, "d"),
         ]
 
         for var, expected in zip(qml.utils._flatten(arg_vars), expected_arg_vars):
@@ -1037,7 +1037,7 @@ class TestQNodeVariableMap:
         assert not kwarg_vars
 
     def test_array_arguments(self, mock_device):
-        """Test that array arguments are properly converted to VariableRef instances."""
+        """Test that array arguments are properly converted to Variable instances."""
         def circuit(weights):
             qml.RX(weights[0, 0], wires=[0])
             qml.RY(weights[0, 1], wires=[0])
@@ -1052,10 +1052,10 @@ class TestQNodeVariableMap:
         arg_vars, kwarg_vars = node._make_variables([weights], {})
 
         expected_arg_vars = [
-            VariableRef(0, "weights[0,0]"),
-            VariableRef(1, "weights[0,1]"),
-            VariableRef(2, "weights[1,0]"),
-            VariableRef(3, "weights[1,1]"),
+            Variable(0, "weights[0,0]"),
+            Variable(1, "weights[0,1]"),
+            Variable(2, "weights[1,0]"),
+            Variable(3, "weights[1,1]"),
         ]
 
         for var, expected in zip(qml.utils._flatten(arg_vars), expected_arg_vars):
@@ -1064,7 +1064,7 @@ class TestQNodeVariableMap:
         assert not kwarg_vars
 
     def test_regular_keyword_arguments(self, mock_device):
-        """Test that regular keyword arguments are properly converted to VariableRef instances."""
+        """Test that regular keyword arguments are properly converted to Variable instances."""
         def circuit(*, a=1, b=2, c=3, d=4):
             qml.RX(a, wires=[0])
             qml.RY(b, wires=[0])
@@ -1077,10 +1077,10 @@ class TestQNodeVariableMap:
         arg_vars, kwarg_vars = node._make_variables([], {"b" : 3})
 
         expected_kwarg_vars = {
-            "a" : [VariableRef(0, "a", is_kwarg=True)],
-            "b" : [VariableRef(0, "b", is_kwarg=True)],
-            "c" : [VariableRef(0, "c", is_kwarg=True)],
-            "d" : [VariableRef(0, "d", is_kwarg=True)],
+            "a" : [Variable(0, "a", is_kwarg=True)],
+            "b" : [Variable(0, "b", is_kwarg=True)],
+            "c" : [Variable(0, "c", is_kwarg=True)],
+            "d" : [Variable(0, "d", is_kwarg=True)],
         }
 
         assert not arg_vars
@@ -1090,7 +1090,7 @@ class TestQNodeVariableMap:
                 assert var == expected
 
     def test_array_keyword_arguments(self, mock_device):
-        """Test that array keyword arguments are properly converted to VariableRef instances."""
+        """Test that array keyword arguments are properly converted to Variable instances."""
         def circuit(*, a=np.array([[1, 0], [0, 1]]), b=np.array([1,2,3])):
             qml.RX(a[0, 0], wires=[0])
             qml.RX(a[0, 1], wires=[0])
@@ -1107,16 +1107,16 @@ class TestQNodeVariableMap:
 
         expected_kwarg_vars = {
             "a" : [
-                VariableRef(0, "a[0,0]", is_kwarg=True),
-                VariableRef(1, "a[0,1]", is_kwarg=True),
-                VariableRef(2, "a[1,0]", is_kwarg=True),
-                VariableRef(3, "a[1,1]", is_kwarg=True),
+                Variable(0, "a[0,0]", is_kwarg=True),
+                Variable(1, "a[0,1]", is_kwarg=True),
+                Variable(2, "a[1,0]", is_kwarg=True),
+                Variable(3, "a[1,1]", is_kwarg=True),
             ],
             "b" : [
-                VariableRef(0, "b[0]", is_kwarg=True),
-                VariableRef(1, "b[1]", is_kwarg=True),
-                VariableRef(2, "b[2]", is_kwarg=True),
-                VariableRef(3, "b[3]", is_kwarg=True),
+                Variable(0, "b[0]", is_kwarg=True),
+                Variable(1, "b[1]", is_kwarg=True),
+                Variable(2, "b[2]", is_kwarg=True),
+                Variable(3, "b[3]", is_kwarg=True),
             ],
         }
 
@@ -1127,7 +1127,7 @@ class TestQNodeVariableMap:
                 assert var == expected
 
     def test_variadic_arguments(self, mock_device):
-        """Test that variadic arguments are properly converted to VariableRef instances."""
+        """Test that variadic arguments are properly converted to Variable instances."""
         def circuit(a, *b):
             qml.RX(a, wires=[0])
             qml.RX(b[0], wires=[0])
@@ -1140,13 +1140,13 @@ class TestQNodeVariableMap:
         arg_vars, kwarg_vars = node._make_variables([0.1, 0.2, np.array([0, 1, 2, 3]), 0.5], {})
 
         expected_arg_vars = [
-            VariableRef(0, "a"),
-            VariableRef(1, "b[0]"),
-            VariableRef(2, "b[1][0]"),
-            VariableRef(3, "b[1][1]"),
-            VariableRef(4, "b[1][2]"),
-            VariableRef(5, "b[1][3]"),
-            VariableRef(6, "b[2]"),
+            Variable(0, "a"),
+            Variable(1, "b[0]"),
+            Variable(2, "b[1][0]"),
+            Variable(3, "b[1][1]"),
+            Variable(4, "b[1][2]"),
+            Variable(5, "b[1][3]"),
+            Variable(6, "b[2]"),
         ]
 
         assert not kwarg_vars

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -158,9 +158,9 @@ class TestOperation:
             # params must be arrays
             with pytest.raises(TypeError, match='Array parameter expected'):
                 test_class(*n*[0.0], wires=ww)
-            # params must not be VariableRefs
+            # params must not be Variables
             with pytest.raises(TypeError, match='Array parameter expected'):
-                test_class(*n*[qml.variable.VariableRef(0)], wires=ww)
+                test_class(*n*[qml.variable.Variable(0)], wires=ww)
         elif test_class.par_domain == 'N':
             # params must be natural numbers
             with pytest.raises(TypeError, match='Natural number'):
@@ -387,8 +387,8 @@ class TestOperationConstruction:
             par_domain = 'A'
             grad_method = 'F'
 
-        with pytest.raises(TypeError, match="Array parameter expected, got a VariableRef"):
-            DummyOp(qml.variable.VariableRef(0), wires=[0])
+        with pytest.raises(TypeError, match="Array parameter expected, got a Variable"):
+            DummyOp(qml.variable.Variable(0), wires=[0])
 
     def test_array_instead_of_flattened_array(self):
         """Test that an exception is raised if an array is expected, but an array is passed

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -24,7 +24,7 @@ from pennylane.qnodes import QuantumFunctionError
 from pennylane import expval, var, sample
 from pennylane.operation import Sample, Variance, Expectation, Probability
 from pennylane.circuit_graph import CircuitGraph
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 mock_qubit_device_paulis = ["PauliX", "PauliY", "PauliZ"]
 mock_qubit_device_rotations = ["RX", "RY", "RZ"]
@@ -177,7 +177,7 @@ class TestOperations:
                         ]
                      ]
 
-    variable = VariableRef(1)
+    variable = Variable(1)
     symbolic_queue = [
                         [qml.RX(variable, wires=[0])],
                     ]

--- a/tests/test_templates_utils.py
+++ b/tests/test_templates_utils.py
@@ -17,7 +17,7 @@ Tests for the templates utility functions.
 # pylint: disable=protected-access,cell-var-from-loop
 import pytest
 import numpy as np
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 from pennylane.templates.utils import (_check_wires,
                                        _check_shape,
                                        _check_shapes,
@@ -97,9 +97,9 @@ LAYERS_FAIL = [([[[1], [2], [3]], 1], 5),
 NO_VARIABLES_PASS = [[[], np.array([1., 4.])],
                      [1, 'a']]
 
-NO_VARIABLES_FAIL = [[[VariableRef(0.1)], VariableRef([0.1])],
-                     np.array([VariableRef(0.3), VariableRef(4.)]),
-                     VariableRef(-1.)]
+NO_VARIABLES_FAIL = [[[Variable(0.1)], Variable([0.1])],
+                     np.array([Variable(0.3), Variable(4.)]),
+                     Variable(-1.)]
 
 OPTIONS_PASS = [("a", ["a", "b"])]
 
@@ -108,12 +108,12 @@ OPTIONS_FAIL = [("c", ["a", "b"])]
 TYPE_PASS = [(["a"], list, type(None)),
              (1, int, type(None)),
              ("a", int, str),
-             (VariableRef(1.), list, VariableRef)
+             (Variable(1.), list, Variable)
              ]
 
 TYPE_FAIL = [("a", list, type(None)),
-             (VariableRef(1.), int, list),
-             (1., VariableRef, type(None))
+             (Variable(1.), int, list),
+             (1., Variable, type(None))
              ]
 
 

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -17,7 +17,7 @@ Unit tests for :mod:`pennylane.variable`.
 import pytest
 import numpy.random as nr
 
-from pennylane.variable import VariableRef
+from pennylane.variable import Variable
 
 
 # make test deterministic
@@ -33,40 +33,40 @@ par_mults = [1, 0.4, -2.7]
 def par_positional():
     "QNode: positional parameters"
     temp = nr.randn(n)
-    VariableRef.positional_arg_values = temp  # set the values
+    Variable.positional_arg_values = temp  # set the values
     return temp
 
 @pytest.fixture(scope="function")
 def par_keyword():
     "QNode: keyword parameters"
     temp = {name: nr.randn(n) for name in keyword_par_names}
-    VariableRef.kwarg_values = temp  # set the values
+    Variable.kwarg_values = temp  # set the values
     return temp
 
 
 def test_variable_repr():
     """Variable string rep."""
-    p = VariableRef(0)
-    assert repr(p) == "<VariableRef(None:0)>"
-    assert repr(-p) == "<VariableRef(None:0 * -1)>"
-    assert repr(1.2 * p * 0.4) == "<VariableRef(None:0 * 0.48)>"
-    assert repr(1.2 * p / 2.5) == "<VariableRef(None:0 * 0.48)>"
+    p = Variable(0)
+    assert repr(p) == "<Variable(None:0)>"
+    assert repr(-p) == "<Variable(None:0 * -1)>"
+    assert repr(1.2 * p * 0.4) == "<Variable(None:0 * 0.48)>"
+    assert repr(1.2 * p / 2.5) == "<Variable(None:0 * 0.48)>"
 
-    p = VariableRef(0, name="kw1")
-    assert repr(p) == "<VariableRef(kw1:0)>"
-    assert repr(-p) == "<VariableRef(kw1:0 * -1)>"
-    assert repr(1.2 * p * 0.4) == "<VariableRef(kw1:0 * 0.48)>"
-    assert repr(1.2 * p / 2.5) == "<VariableRef(kw1:0 * 0.48)>"
+    p = Variable(0, name="kw1")
+    assert repr(p) == "<Variable(kw1:0)>"
+    assert repr(-p) == "<Variable(kw1:0 * -1)>"
+    assert repr(1.2 * p * 0.4) == "<Variable(kw1:0 * 0.48)>"
+    assert repr(1.2 * p / 2.5) == "<Variable(kw1:0 * 0.48)>"
 
 def test_variable_str():
     """Variable informal string rep."""
-    p = VariableRef(0)
-    assert str(p) == "VariableRef: name = None, idx = 0"
-    assert str(-p) == "VariableRef: name = None, idx = 0, * -1"
+    p = Variable(0)
+    assert str(p) == "Variable: name = None, idx = 0"
+    assert str(-p) == "Variable: name = None, idx = 0, * -1"
 
-    p = VariableRef(0, name="kw1")
-    assert str(p) == "VariableRef: name = kw1, idx = 0"
-    assert str(2.1 * p) == "VariableRef: name = kw1, idx = 0, * 2.1"
+    p = Variable(0, name="kw1")
+    assert str(p) == "Variable: name = kw1, idx = 0"
+    assert str(2.1 * p) == "Variable: name = kw1, idx = 0, * 2.1"
 
 def variable_eval_asserts(v, p, m, tol):
     """Check that variable evaluation (with scalar multiplication) yields the expected results."""
@@ -82,7 +82,7 @@ def variable_eval_asserts(v, p, m, tol):
 @pytest.mark.parametrize("mult", par_mults)
 def test_variable_val(par_positional, ind, mult, tol):
     """Positional variable evaluation."""
-    v = VariableRef(ind)
+    v = Variable(ind)
 
     assert v.name is None
     assert v.mult == 1
@@ -95,7 +95,7 @@ def test_variable_val(par_positional, ind, mult, tol):
 @pytest.mark.parametrize("name", keyword_par_names)
 def test_keyword_variable(par_keyword, name, ind, mult, tol):
     """Keyword variable evaluation."""
-    v = VariableRef(ind, name, is_kwarg=True)
+    v = Variable(ind, name, is_kwarg=True)
 
     assert v.name == name
     assert v.mult == 1


### PR DESCRIPTION
**Context:**

Recently in #488, the `Variable` class was renamed to `VariableRef`, in order to avoid confusion with the TensorFlow `Variable` class, and to better represent what the class represented (a reference to a free parameter).

However, we noticed after the fact that several of the plugins import `qml.Variable` as part of their program conversion logic. Due to time and resource constraints, and the fact that a bugfix release of PennyLane core is imminent, it has been decided to temporarily revert the renaming in PennyLane core, to avoid breaking API changes in a bugfix release/ the need to release new versions of the plugins.

**Description of the Change:**

* Reverts all instances of `VariableRef` to `Variable` across the code base, docs, and test suite.

**Benefits:**

* Avoids breaking API changes in the upcoming bugfix release.

**Possible Drawbacks:**

* With find and replace, it's easier to change `VariableRef` to `Variable` rather than `Variable` to `VariableRef`, due to the use of TensorFlow variables. However, this PR can be reverted later on, allowing us to easily redo the change when needed.

**Related GitHub Issues:** https://github.com/XanaduAI/pennylane-qiskit/pull/71
