### PR TITLE
Fix print_applied for Probabilities

### DIFF
--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -160,7 +160,7 @@ class CircuitGraph:
         print("\nObservables")
         print("===========")
         for op in self.observables:
-            if op.return_type in return_map:                
+            if op.return_type in return_map:
                 return_type = return_map[op.return_type]
             else:
                 return_type = str(op.return_type)

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -165,7 +165,9 @@ class CircuitGraph:
             else:
                 return_type = str(op.return_type)
 
-            if op.parameters:
+            if op.return_type == qml.operation.Probability:
+                print("{}(wires={})".format(return_type, op.wires))
+            elif op.parameters:
                 params = "".join([str(p) for p in op.parameters])
                 print("{}({}({}, wires={}))".format(return_type, op.name, params, op.wires))
             else:

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -159,7 +159,11 @@ class CircuitGraph:
         print("\nObservables")
         print("===========")
         for op in self.observables:
-            return_type = return_map[op.return_type]
+            if op.return_type in return_map:                
+                return_type = return_map[op.return_type]
+            else:
+                return_type = str(op.return_type)
+
             if op.parameters:
                 params = "".join([str(p) for p in op.parameters])
                 print("{}({}({}, wires={}))".format(return_type, op.name, params, op.wires))

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -154,6 +154,7 @@ class CircuitGraph:
             qml.operation.Expectation: "expval",
             qml.operation.Variance: "var",
             qml.operation.Sample: "sample",
+            qml.operation.Probability: "probs",
         }
 
         print("\nObservables")

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -199,6 +199,56 @@ class TestQNodeOperationQueue:
 
         assert out == expected_qnode_print.format(x=0.1)
 
+    def test_print_applied_with_probs(self, mock_device):
+        """Test that printing applied gates works correctly when probs are returned"""
+
+        H = np.array([[0, 1], [1, 0]])
+
+        def circuit(x):
+            qml.RX(x, wires=[0])
+            qml.CNOT(wires=[0, 1])
+            qml.SWAP(wires=[1, 0])
+            qml.RZ(-0.2, wires=[1])
+            return qml.probs(wires=[0]), qml.var(qml.Hermitian(H, wires=1))
+
+        expected_qnode_print = textwrap.dedent(
+            """\
+            Operations
+            ==========
+            RX({x}, wires=[0])
+            CNOT(wires=[0, 1])
+            SWAP(wires=[1, 0])
+            RZ(-0.2, wires=[1])
+
+            Observables
+            ===========
+            probs(wires=[0])
+            var(Hermitian([[0 1]
+             [1 0]], wires=[1]))"""
+        )
+
+        node = BaseQNode(circuit, mock_device)
+
+        # test before construction
+        f = io.StringIO()
+
+        with contextlib.redirect_stdout(f):
+            node.print_applied()
+            out = f.getvalue().strip()
+
+        assert out == "QNode has not yet been executed."
+
+        # construct QNode
+        f = io.StringIO()
+        node._set_variables([0.1], {})
+        node._construct([0.1], {})
+
+        with contextlib.redirect_stdout(f):
+            node.print_applied()
+            out = f.getvalue().strip()
+
+        assert out == expected_qnode_print.format(x=0.1)
+
     def test_operation_appending(self, mock_device):
         """Tests that operations are correctly appended."""
         CNOT = qml.CNOT(wires=[0, 1])


### PR DESCRIPTION
**Context:**
The `print_applied` function was added to the `QNode` to allow easy inspection of the applied circuit. Later, the possibility of returning probabilities was added to PennyLane via `return qml.probs`. But it was forgotten to add it to the return type dictionary in `print_applied` so that the method crashed when probabilities were returned.

**Description of the Change:**
A fallback was added to the return type dictionary to prevent such errors in the future and an appropriate display of probs was added.

**Benefits:**
One more bug fixed!

**Possible Drawbacks:**
None.