### PR TITLE
Fix bug in single qubit strongly entangling layers

### DIFF
--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -96,25 +96,28 @@ def StronglyEntanglingLayers(weights, wires, ranges=None, imprimitive=CNOT):
         msg="'weights' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
     )
 
-    if ranges is None:
-        # tile ranges with iterations of range(1, n_wires)
-        ranges = [(l % (len(wires) - 1)) + 1 for l in range(repeat)]
+    if len(wires) > 1:
+        if ranges is None:
+            # tile ranges with iterations of range(1, n_wires)
+            ranges = [(l % (len(wires) - 1)) + 1 for l in range(repeat)]
 
-    expected_shape = (repeat,)
-    _check_shape(
-        ranges,
-        expected_shape,
-        msg="'ranges' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
-    )
-
-    _check_type(ranges, [list], msg="'ranges' must be a list; got {}" "".format(ranges))
-    for r in ranges:
-        _check_type(r, [int], msg="'ranges' must be a list of integers; got {}" "".format(ranges))
-    if any((r >= len(wires) or r == 0) for r in ranges):
-        raise ValueError(
-            "the range for all layers needs to be smaller than the number of "
-            "qubits; got ranges {}.".format(ranges)
+        expected_shape = (repeat,)
+        _check_shape(
+            ranges,
+            expected_shape,
+            msg="'ranges' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
         )
+
+        _check_type(ranges, [list], msg="'ranges' must be a list; got {}" "".format(ranges))
+        for r in ranges:
+            _check_type(r, [int], msg="'ranges' must be a list of integers; got {}" "".format(ranges))
+        if any((r >= len(wires) or r == 0) for r in ranges):
+            raise ValueError(
+                "the range for all layers needs to be smaller than the number of "
+                "qubits; got ranges {}.".format(ranges)
+            )
+    else:
+        ranges = [0] * repeat
 
     ###############
 

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -105,12 +105,15 @@ def StronglyEntanglingLayers(weights, wires, ranges=None, imprimitive=CNOT):
         _check_shape(
             ranges,
             expected_shape,
-            msg="'ranges' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
+            msg="'ranges' must be of shape {}; got {}"
+            "".format(expected_shape, _get_shape(weights)),
         )
 
         _check_type(ranges, [list], msg="'ranges' must be a list; got {}" "".format(ranges))
         for r in ranges:
-            _check_type(r, [int], msg="'ranges' must be a list of integers; got {}" "".format(ranges))
+            _check_type(
+                r, [int], msg="'ranges' must be a list of integers; got {}" "".format(ranges)
+            )
         if any((r >= len(wires) or r == 0) for r in ranges):
             raise ValueError(
                 "the range for all layers needs to be smaller than the number of "

--- a/tests/test_templates_layers.py
+++ b/tests/test_templates_layers.py
@@ -19,9 +19,7 @@ Integration tests should be placed into ``test_templates.py``.
 import pytest
 import pennylane as qml
 from pennylane import numpy as np
-from pennylane.templates.layers import (CVNeuralNetLayers,
-                                        StronglyEntanglingLayers,
-                                        RandomLayers)
+from pennylane.templates.layers import CVNeuralNetLayers, StronglyEntanglingLayers, RandomLayers
 from pennylane.templates.layers.random import random_layer
 from pennylane import RX, RY, RZ, CZ, CNOT
 
@@ -37,29 +35,73 @@ class TestCVNeuralNet:
     @pytest.fixture(scope="class")
     def weights(self):
         return [
-                np.array([[ 5.48791879, 6.08552046, 5.46131036, 3.33546468, 1.46227521, 0.0716208 ],
-                          [ 3.36869403, 0.63074883, 4.59400392, 5.9040016 , 5.92704296, 2.35455147]]),
-                np.array([[ 2.70471535, 2.52804815, 3.28406182, 3.0058243 , 3.48940764, 3.41419504],
-                         [ 3.74320919, 4.15936005, 3.20807161, 2.95870535, 0.05574621, 0.42660569]]),
-                np.array([[ 4.7808479 , 4.47598146, 3.89357744, 2.67721355],
-                         [ 2.73203094, 2.71115444, 1.16794164, 3.32823666]]),
-                np.array([[ 0.27344502, 0.68431314, 0.30026443, 0.23128064],
-                         [ 0.45945175, 0.53255468, 0.28383751, 0.34263728]]),
-                np.array([[2.3936353, 4.80135971, 5.89867895, 2.00867023],
-                          [5.14552399, 3.31578667, 5.90119363, 4.54515204]]),
-            np.array([[ 0.4134863 , 6.17555778, 0.80334114, 2.02400747, 0.44574704, 1.41227118],
-                         [ 5.16969442, 3.6890488 , 4.43916808, 3.20808287, 5.21543123, 4.52815349]]),
-                np.array([[ 2.47328111, 5.63064513, 2.17059932, 6.1873632 , 0.18052879, 2.20970037],
-                         [ 5.44288268, 1.27806129, 1.87574979, 2.98956484, 3.10140853, 3.81814174]]),
-                np.array([[ 5.03318258, 4.01017269, 0.43159284, 3.7928101 ],
-                         [ 3.5329307 , 4.79661266, 5.0683084 , 1.87631749]]),
-                np.array([[ 1.61159166, 0.1608155 , 0.96535086, 1.60132783],
-                         [ 0.36293094, 1.30725604, 0.11578591, 1.5983082 ]]),
-                np.array([[ 6.21267547, 3.71076099, 0.34060195, 2.86031556],
-                         [ 3.20443756, 6.26536946, 6.18450567, 1.50406923]]),
-                np.array([[ 0.1376345 , 0.22541113, 0.14306356, 0.13019402],
-                         [ 0.26999146, 0.26256351, 0.14722687, 0.23137066]])
-            ]
+            np.array(
+                [
+                    [5.48791879, 6.08552046, 5.46131036, 3.33546468, 1.46227521, 0.0716208],
+                    [3.36869403, 0.63074883, 4.59400392, 5.9040016, 5.92704296, 2.35455147],
+                ]
+            ),
+            np.array(
+                [
+                    [2.70471535, 2.52804815, 3.28406182, 3.0058243, 3.48940764, 3.41419504],
+                    [3.74320919, 4.15936005, 3.20807161, 2.95870535, 0.05574621, 0.42660569],
+                ]
+            ),
+            np.array(
+                [
+                    [4.7808479, 4.47598146, 3.89357744, 2.67721355],
+                    [2.73203094, 2.71115444, 1.16794164, 3.32823666],
+                ]
+            ),
+            np.array(
+                [
+                    [0.27344502, 0.68431314, 0.30026443, 0.23128064],
+                    [0.45945175, 0.53255468, 0.28383751, 0.34263728],
+                ]
+            ),
+            np.array(
+                [
+                    [2.3936353, 4.80135971, 5.89867895, 2.00867023],
+                    [5.14552399, 3.31578667, 5.90119363, 4.54515204],
+                ]
+            ),
+            np.array(
+                [
+                    [0.4134863, 6.17555778, 0.80334114, 2.02400747, 0.44574704, 1.41227118],
+                    [5.16969442, 3.6890488, 4.43916808, 3.20808287, 5.21543123, 4.52815349],
+                ]
+            ),
+            np.array(
+                [
+                    [2.47328111, 5.63064513, 2.17059932, 6.1873632, 0.18052879, 2.20970037],
+                    [5.44288268, 1.27806129, 1.87574979, 2.98956484, 3.10140853, 3.81814174],
+                ]
+            ),
+            np.array(
+                [
+                    [5.03318258, 4.01017269, 0.43159284, 3.7928101],
+                    [3.5329307, 4.79661266, 5.0683084, 1.87631749],
+                ]
+            ),
+            np.array(
+                [
+                    [1.61159166, 0.1608155, 0.96535086, 1.60132783],
+                    [0.36293094, 1.30725604, 0.11578591, 1.5983082],
+                ]
+            ),
+            np.array(
+                [
+                    [6.21267547, 3.71076099, 0.34060195, 2.86031556],
+                    [3.20443756, 6.26536946, 6.18450567, 1.50406923],
+                ]
+            ),
+            np.array(
+                [
+                    [0.1376345, 0.22541113, 0.14306356, 0.13019402],
+                    [0.26999146, 0.26256351, 0.14722687, 0.23137066],
+                ]
+            ),
+        ]
 
     def test_cvneuralnet_uses_correct_weights(self, weights):
         """Tests that the CVNeuralNetLayers template uses the weigh parameters correctly."""
@@ -70,18 +112,24 @@ class TestCVNeuralNet:
         # Test that gates appear in the right order for each layer:
         # BS-R-S-BS-R-D-K
         for l in range(2):
-            gates = [qml.Beamsplitter, qml.Rotation, qml.Squeezing,
-                     qml.Beamsplitter, qml.Rotation, qml.Displacement]
+            gates = [
+                qml.Beamsplitter,
+                qml.Rotation,
+                qml.Squeezing,
+                qml.Beamsplitter,
+                qml.Rotation,
+                qml.Displacement,
+            ]
 
             # count the position of each group of gates in the layer
             num_gates_per_type = [0, 6, 4, 4, 6, 4, 4, 4]
             s = np.cumsum(num_gates_per_type)
-            gc = l*sum(num_gates_per_type)+np.array(list(zip(s[:-1], s[1:])))
+            gc = l * sum(num_gates_per_type) + np.array(list(zip(s[:-1], s[1:])))
 
             # loop through expected gates
             for idx, g in enumerate(gates):
                 # loop through where these gates should be in the queue
-                for opidx, op in enumerate(rec.queue[gc[idx, 0]:gc[idx, 1]]):
+                for opidx, op in enumerate(rec.queue[gc[idx, 0] : gc[idx, 1]]):
                     # check that op in queue is correct gate
                     assert isinstance(op, g)
 
@@ -148,7 +196,7 @@ class TestStronglyEntangling:
             StronglyEntanglingLayers(weights, wires=range(num_wires))
 
         # Test that gates appear in the right order
-        exp_gates = [qml.Rot]*num_wires + [qml.CNOT]*num_wires
+        exp_gates = [qml.Rot] * num_wires + [qml.CNOT] * num_wires
         exp_gates *= n_layers
         res_gates = rec.queue
 
@@ -157,7 +205,7 @@ class TestStronglyEntangling:
 
         # test the device parameters
         for l in range(n_layers):
-            layer_ops = rec.queue[2*l*num_wires:2*(l+1)*num_wires]
+            layer_ops = rec.queue[2 * l * num_wires : 2 * (l + 1) * num_wires]
 
             # check each rotation gate parameter
             for n in range(num_wires):
@@ -171,17 +219,18 @@ class TestStronglyEntangling:
         weights = np.random.randn(n_layers, n_subsystems, 3)
 
         with qml.utils.OperationRecorder() as rec:
-            StronglyEntanglingLayers(weights=weights, wires=range(n_subsystems), imprimitive=imprimitive)
+            StronglyEntanglingLayers(
+                weights=weights, wires=range(n_subsystems), imprimitive=imprimitive
+            )
 
         types = [type(q) for q in rec.queue]
-        assert types.count(imprimitive) == n_subsystems*n_layers
+        assert types.count(imprimitive) == n_subsystems * n_layers
 
-    @pytest.mark.parametrize("n_wires, n_layers, ranges", [(2, 2, [2, 1]),
-                                                           (3, 1, [5])])
+    @pytest.mark.parametrize("n_wires, n_layers, ranges", [(2, 2, [2, 1]), (3, 1, [5])])
     def test_strong_ent_layers_ranges_equals_wires_exception(self, n_layers, n_wires, ranges):
         """Test that StronglyEntanglingLayers throws and exception if a range is equal to or
         larger than the number of wires."""
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_wires, 3)
 
         def circuit(weights):
@@ -197,11 +246,11 @@ class TestStronglyEntangling:
         """Test that StronglyEntanglingLayers throws and exception if ``ranges`` parameter of illegal type."""
         n_wires = 2
         n_layers = 2
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_wires, 3)
 
         def circuit(weights):
-            StronglyEntanglingLayers(weights=weights, wires=range(n_wires), ranges=['a', 'a'])
+            StronglyEntanglingLayers(weights=weights, wires=range(n_wires), ranges=["a", "a"])
             return qml.expval(qml.PauliZ(0))
 
         qnode = qml.QNode(circuit, dev)
@@ -209,13 +258,12 @@ class TestStronglyEntangling:
         with pytest.raises(ValueError, match="'ranges' must be a list of integers"):
             qnode(weights)
 
-    @pytest.mark.parametrize("n_layers, ranges", [(2, [1, 2, 4]),
-                                                  (5, [2])])
+    @pytest.mark.parametrize("n_layers, ranges", [(2, [1, 2, 4]), (5, [2])])
     def test_strong_ent_layers_wrong_size_ranges_exception(self, n_layers, ranges):
         """Test that StronglyEntanglingLayers throws and exception if ``ranges`` parameter
         not of shape (len(wires),)."""
         n_wires = 5
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_wires, 3)
 
         def circuit(weights):
@@ -231,18 +279,15 @@ class TestStronglyEntangling:
 class TestRandomLayers:
     """Tests for the RandomLayers method from the pennylane.templates module."""
 
-    @pytest.fixture(scope="class",
-                    params=[0.2, 0.6])
+    @pytest.fixture(scope="class", params=[0.2, 0.6])
     def ratio(self, request):
         return request.param
 
-    @pytest.fixture(scope="class",
-                    params=[CNOT, CZ])
+    @pytest.fixture(scope="class", params=[CNOT, CZ])
     def impr(self, request):
         return request.param
 
-    @pytest.fixture(scope="class",
-                    params=[[RX], [RY, RZ]])
+    @pytest.fixture(scope="class", params=[[RX], [RY, RZ]])
     def rots(self, request):
         return request.param
 
@@ -250,7 +295,7 @@ class TestRandomLayers:
         """Test that RandomLayers() acts deterministically when using fixed seed."""
         n_rots = 1
         n_wires = 2
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_rots)
 
         def circuit1(weights):
@@ -269,7 +314,7 @@ class TestRandomLayers:
         """Test that RandomLayers() acts deterministically when using default seed."""
         n_rots = 1
         n_wires = 2
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_rots)
 
         def circuit1(weights):
@@ -289,7 +334,7 @@ class TestRandomLayers:
         """Test that RandomLayers() does not have the same output for two different seeds."""
         n_rots = 10
         n_wires = 2
-        dev = qml.device('default.qubit', wires=n_wires)
+        dev = qml.device("default.qubit", wires=n_wires)
         weights = np.random.randn(n_layers, n_rots)
 
         def circuit1(weights):
@@ -327,8 +372,14 @@ class TestRandomLayers:
         weights = np.random.randn(n_rots)
 
         with qml.utils.OperationRecorder() as rec:
-            random_layer(weights=weights, wires=range(n_wires), ratio_imprim=ratio,
-                         imprimitive=CNOT, rotations=[RX, RY, RZ], seed=42)
+            random_layer(
+                weights=weights,
+                wires=range(n_wires),
+                ratio_imprim=ratio,
+                imprimitive=CNOT,
+                rotations=[RX, RY, RZ],
+                seed=42,
+            )
 
         types = [type(q) for q in rec.queue]
         ratio_impr = types.count(impr) / len(types)
@@ -340,8 +391,14 @@ class TestRandomLayers:
         weights = np.random.randn(n_rots)
 
         with qml.utils.OperationRecorder() as rec:
-            random_layer(weights=weights, wires=range(n_subsystems), ratio_imprim=0.3,
-                         imprimitive=impr, rotations=rots, seed=42)
+            random_layer(
+                weights=weights,
+                wires=range(n_subsystems),
+                ratio_imprim=0.3,
+                imprimitive=impr,
+                rotations=rots,
+                seed=42,
+            )
 
         types = [type(q) for q in rec.queue]
         unique = set(types)
@@ -354,8 +411,14 @@ class TestRandomLayers:
         weights = np.random.randn(n_rots)
 
         with qml.utils.OperationRecorder() as rec:
-            random_layer(weights=weights, wires=range(n_subsystems), ratio_imprim=0.3,
-                         imprimitive=qml.CNOT, rotations=[RX, RY, RZ], seed=42)
+            random_layer(
+                weights=weights,
+                wires=range(n_subsystems),
+                ratio_imprim=0.3,
+                imprimitive=qml.CNOT,
+                rotations=[RX, RY, RZ],
+                seed=42,
+            )
 
         types = [type(q) for q in rec.queue]
         assert len(types) - types.count(qml.CNOT) == n_rots
@@ -366,8 +429,14 @@ class TestRandomLayers:
         weights = np.random.randn(n_rots)
 
         with qml.utils.OperationRecorder() as rec:
-            random_layer(weights=weights, wires=range(n_subsystems), ratio_imprim=0.3,
-                         imprimitive=qml.CNOT, rotations=[RX, RY, RZ], seed=42)
+            random_layer(
+                weights=weights,
+                wires=range(n_subsystems),
+                ratio_imprim=0.3,
+                imprimitive=qml.CNOT,
+                rotations=[RX, RY, RZ],
+                seed=42,
+            )
 
         wires = [q._wires for q in rec.queue]
         wires_flat = [item for w in wires for item in w]
@@ -381,10 +450,15 @@ class TestRandomLayers:
         weights = np.random.randn(n_rots)
 
         with qml.utils.OperationRecorder() as rec:
-            random_layer(weights=weights, wires=range(n_subsystems), ratio_imprim=0.3,
-                         imprimitive=qml.CNOT, rotations=[RX, RY, RZ], seed=4)
+            random_layer(
+                weights=weights,
+                wires=range(n_subsystems),
+                ratio_imprim=0.3,
+                imprimitive=qml.CNOT,
+                rotations=[RX, RY, RZ],
+                seed=4,
+            )
 
         params = [q.parameters for q in rec.queue]
         params_flat = [item for p in params for item in p]
         assert np.allclose(weights.flatten(), params_flat, atol=tol)
-

--- a/tests/test_templates_layers.py
+++ b/tests/test_templates_layers.py
@@ -126,6 +126,16 @@ class TestCVNeuralNet:
 class TestStronglyEntangling:
     """Tests for the StronglyEntanglingLayers method from the pennylane.templates.layers module."""
 
+    @pytest.mark.parametrize("n_layers", range(1, 4))
+    def test_single_qubit(self, n_layers):
+        weights = np.zeros((n_layers, 1, 3))
+        with qml.utils.OperationRecorder() as rec:
+            StronglyEntanglingLayers(weights, wires=range(1))
+
+        assert len(rec.queue) == n_layers
+        assert all([isinstance(q, qml.Rot) for q in rec.queue])
+        assert all([q._wires[0] == 0 for q in rec.queue])
+
     def test_strong_ent_layers_uses_correct_weights(self, n_subsystems):
         """Test that StronglyEntanglingLayers uses the correct weights in the circuit."""
         np.random.seed(12)


### PR DESCRIPTION
Currently, the user receives a `ZeroDivisionError` when using a `StronglyEntanglingLayer` on just one qubit. This is due to the `l % (len(wires) - 1)` term in line 102 which is for checking the ranges of the two qubit gates.

This PR fixes this bug by only initiating and checking `ranges` if the number or wires is above 1. Otherwise, `ranges` is set to be a list of all zeros.

MWE:
```python
import numpy as np
import pennylane as qml
from pennylane.templates import StronglyEntanglingLayers

n_qubits = 1
dev = qml.device("default.qubit", wires=n_qubits)

@qml.qnode(dev, interface='tf')
def circuit(weights):

    StronglyEntanglingLayers(weights, wires=list(range(n_qubits)))
    
    return qml.expval(qml.PauliZ(0))

weights = np.random.random((3, n_qubits, 3))
circuit(weights)
```

EDIT: At one point I thought maybe the strongly entangling layers aren't defined for single qubits (in this case, what are we entangling?). However, in https://pennylane.readthedocs.io/en/stable/code/api/pennylane.templates.layers.StronglyEntanglingLayers.html we say "If applied to one qubit only, this template will use no imprimitive gates." so it looks to the user like you can apply to one qubit. Moreover, I think we *should* let `StronglyEntanglingLayers` be applicable to one qubit as it makes prototyping easier (e.g., varying qubit number) and still has some utility (i.e., of applying layers of rotations).