### PR TITLE
Refactor template utils function to be public

### DIFF
--- a/pennylane/templates/broadcast.py
+++ b/pennylane/templates/broadcast.py
@@ -23,7 +23,7 @@ To add a new pattern:
 from collections import Iterable
 
 from pennylane.templates.decorator import template
-from pennylane.templates.utils import _check_wires, _check_type, _get_shape, _check_is_in_options
+from pennylane.templates.utils import check_wires, check_type, get_shape, check_is_in_options
 
 
 # helpers to define pattern wire sequences
@@ -437,27 +437,27 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
     #########
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    _check_type(
+    check_type(
         parameters,
         [Iterable, type(None)],
         msg="'parameters' must be either of type None or "
         "Iterable; got {}".format(type(parameters)),
     )
 
-    _check_type(
+    check_type(
         pattern, [str], msg="'pattern' must be a string; got {}".format(type(pattern)),
     )
 
     if kwargs is None:
         kwargs = {}
 
-    _check_type(
+    check_type(
         kwargs, [dict], msg="'kwargs' must be a dictionary; got {}".format(type(kwargs)),
     )
 
-    _check_is_in_options(
+    check_is_in_options(
         pattern, OPTIONS, msg="did not recognize option {} for 'pattern'".format(pattern),
     )
 
@@ -473,7 +473,7 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
 
     # check that enough parameters for pattern
     if parameters is not None:
-        shape = _get_shape(parameters)
+        shape = get_shape(parameters)
 
         # specific error message for ring edge case of 2 wires
         if (pattern == "ring") and (len(wires) == 2) and (shape[0] != 1):

--- a/pennylane/templates/embeddings/amplitude.py
+++ b/pennylane/templates/embeddings/amplitude.py
@@ -19,11 +19,11 @@ import numpy as np
 from pennylane.templates.decorator import template
 from pennylane.ops import QubitStateVector
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_type,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_type,
+    get_shape,
 )
 from pennylane.variable import Variable
 
@@ -170,37 +170,37 @@ def AmplitudeEmbedding(features, wires, pad=None, normalize=False):
     #############
     # Input checks
 
-    _check_no_variable(pad, msg="'pad' cannot be differentiable")
-    _check_no_variable(normalize, msg="'normalize' cannot be differentiable")
+    check_no_variable(pad, msg="'pad' cannot be differentiable")
+    check_no_variable(normalize, msg="'normalize' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     n_amplitudes = 2 ** len(wires)
     expected_shape = (n_amplitudes,)
     if pad is None:
-        shape = _check_shape(
+        shape = check_shape(
             features,
             expected_shape,
             msg="'features' must be of shape {}; got {}. Use the 'pad' "
             "argument for automated padding."
-            "".format(expected_shape, _get_shape(features)),
+            "".format(expected_shape, get_shape(features)),
         )
     else:
-        shape = _check_shape(
+        shape = check_shape(
             features,
             expected_shape,
             bound="max",
             msg="'features' must be of shape {} or smaller "
             "to be padded; got {}"
-            "".format(expected_shape, _get_shape(features)),
+            "".format(expected_shape, get_shape(features)),
         )
 
-    _check_type(
+    check_type(
         pad,
         [float, complex, type(None)],
         msg="'pad' must be a float or complex; got {}".format(pad),
     )
-    _check_type(normalize, [bool], msg="'normalize' must be a boolean; got {}".format(normalize))
+    check_type(normalize, [bool], msg="'normalize' must be a boolean; got {}".format(normalize))
 
     ###############
 

--- a/pennylane/templates/embeddings/angle.py
+++ b/pennylane/templates/embeddings/angle.py
@@ -19,12 +19,12 @@ from pennylane.templates.decorator import template
 from pennylane.ops import RX, RY, RZ
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_is_in_options,
-    _check_type,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_is_in_options,
+    check_type,
+    get_shape,
 )
 
 
@@ -58,20 +58,20 @@ def AngleEmbedding(features, wires, rotation="X"):
     #############
     # Input checks
 
-    _check_no_variable(rotation, msg="'rotation' cannot be differentiable")
+    check_no_variable(rotation, msg="'rotation' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    _check_shape(
+    check_shape(
         features,
         (len(wires),),
         bound="max",
         msg="'features' must be of shape {} or smaller; "
-        "got {}.".format((len(wires),), _get_shape(features)),
+        "got {}.".format((len(wires),), get_shape(features)),
     )
-    _check_type(rotation, [str], msg="'rotation' must be a string; got {}".format(rotation))
+    check_type(rotation, [str], msg="'rotation' must be a string; got {}".format(rotation))
 
-    _check_is_in_options(
+    check_is_in_options(
         rotation,
         ["X", "Y", "Z"],
         msg="did not recognize option {} for 'rotation'.".format(rotation),

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -52,8 +52,7 @@ def BasisEmbedding(features, wires):
     check_shape(
         features,
         expected_shape,
-        msg="'features' must be of shape {}; got {}"
-        "".format(expected_shape, get_shape(features)),
+        msg="'features' must be of shape {}; got {}" "".format(expected_shape, get_shape(features)),
     )
 
     if any([b not in [0, 1] for b in features]):

--- a/pennylane/templates/embeddings/basis.py
+++ b/pennylane/templates/embeddings/basis.py
@@ -19,7 +19,7 @@ import numpy as np
 
 from pennylane.templates.decorator import template
 from pennylane.ops import BasisState
-from pennylane.templates.utils import _check_shape, _check_wires, _get_shape
+from pennylane.templates.utils import check_shape, check_wires, get_shape
 
 
 @template
@@ -46,14 +46,14 @@ def BasisEmbedding(features, wires):
     #############
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     expected_shape = (len(wires),)
-    _check_shape(
+    check_shape(
         features,
         expected_shape,
         msg="'features' must be of shape {}; got {}"
-        "".format(expected_shape, _get_shape(features)),
+        "".format(expected_shape, get_shape(features)),
     )
 
     if any([b not in [0, 1] for b in features]):

--- a/pennylane/templates/embeddings/displacement.py
+++ b/pennylane/templates/embeddings/displacement.py
@@ -19,11 +19,11 @@ from pennylane.templates.decorator import template
 from pennylane.ops import Displacement
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_is_in_options,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_is_in_options,
+    get_shape,
 )
 
 
@@ -57,21 +57,21 @@ def DisplacementEmbedding(features, wires, method="amplitude", c=0.1):
     #############
     # Input checks
 
-    _check_no_variable(method, msg="'method' cannot be differentiable")
-    _check_no_variable(c, msg="'c' cannot be differentiable")
+    check_no_variable(method, msg="'method' cannot be differentiable")
+    check_no_variable(c, msg="'c' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     expected_shape = (len(wires),)
-    _check_shape(
+    check_shape(
         features,
         expected_shape,
         bound="max",
         msg="'features' must be of shape {} or smaller; got {}."
-        "".format(expected_shape, _get_shape(features)),
+        "".format(expected_shape, get_shape(features)),
     )
 
-    _check_is_in_options(
+    check_is_in_options(
         method,
         ["amplitude", "phase"],
         msg="did not recognize option {} for 'method'" "".format(method),

--- a/pennylane/templates/embeddings/qaoa.py
+++ b/pennylane/templates/embeddings/qaoa.py
@@ -19,11 +19,11 @@ from pennylane.templates.decorator import template
 from pennylane.ops import RX, RY, RZ, CNOT, Hadamard
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_wires,
-    _check_is_in_options,
-    _check_number_of_layers,
-    _get_shape,
+    check_shape,
+    check_wires,
+    check_is_in_options,
+    check_number_of_layers,
+    get_shape,
 )
 
 
@@ -226,48 +226,48 @@ def QAOAEmbedding(features, weights, wires, local_field="Y"):
     #############
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     expected_shape = (len(wires),)
-    _check_shape(
+    check_shape(
         features,
         expected_shape,
         bound="max",
         msg="'features' must be of shape {} or smaller; got {}"
-        "".format((len(wires),), _get_shape(features)),
+        "".format((len(wires),), get_shape(features)),
     )
 
-    _check_is_in_options(
+    check_is_in_options(
         local_field,
         ["X", "Y", "Z"],
         msg="did not recognize option {} for 'local_field'" "".format(local_field),
     )
 
-    repeat = _check_number_of_layers([weights])
+    repeat = check_number_of_layers([weights])
 
     if len(wires) == 1:
         expected_shape = (repeat, 1)
-        _check_shape(
+        check_shape(
             weights,
             expected_shape,
             msg="'weights' must be of shape {}; got {}"
-            "".format(expected_shape, _get_shape(features)),
+            "".format(expected_shape, get_shape(features)),
         )
     elif len(wires) == 2:
         expected_shape = (repeat, 3)
-        _check_shape(
+        check_shape(
             weights,
             expected_shape,
             msg="'weights' must be of shape {}; got {}"
-            "".format(expected_shape, _get_shape(features)),
+            "".format(expected_shape, get_shape(features)),
         )
     else:
         expected_shape = (repeat, 2 * len(wires))
-        _check_shape(
+        check_shape(
             weights,
             expected_shape,
             msg="'weights' must be of shape {}; got {}"
-            "".format(expected_shape, _get_shape(features)),
+            "".format(expected_shape, get_shape(features)),
         )
 
     #####################

--- a/pennylane/templates/embeddings/squeezing.py
+++ b/pennylane/templates/embeddings/squeezing.py
@@ -19,12 +19,12 @@ from pennylane.templates.decorator import template
 from pennylane.ops import Squeezing
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_is_in_options,
-    _get_shape,
-    _check_type,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_is_in_options,
+    get_shape,
+    check_type,
 )
 
 
@@ -59,23 +59,23 @@ def SqueezingEmbedding(features, wires, method="amplitude", c=0.1):
     #############
     # Input checks
 
-    _check_no_variable(method, msg="'method' cannot be differentiable")
-    _check_no_variable(c, msg="'c' cannot be differentiable")
+    check_no_variable(method, msg="'method' cannot be differentiable")
+    check_no_variable(c, msg="'c' cannot be differentiable")
 
-    _check_type(c, [float, int], msg="'c' must be of type float or integer; got {}".format(type(c)))
+    check_type(c, [float, int], msg="'c' must be of type float or integer; got {}".format(type(c)))
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     expected_shape = (len(wires),)
-    _check_shape(
+    check_shape(
         features,
         expected_shape,
         bound="max",
         msg="'features' must be of shape {} or smaller; got {}"
-        "".format(expected_shape, _get_shape(features)),
+        "".format(expected_shape, get_shape(features)),
     )
 
-    _check_is_in_options(
+    check_is_in_options(
         method,
         ["amplitude", "phase"],
         msg="did not recognize option {} for 'method'".format(method),

--- a/pennylane/templates/layers/basic_entangler.py
+++ b/pennylane/templates/layers/basic_entangler.py
@@ -19,11 +19,11 @@ from pennylane.templates.decorator import template
 from pennylane.ops import CNOT, RX
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_number_of_layers,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_number_of_layers,
+    get_shape,
 )
 
 
@@ -140,17 +140,17 @@ def BasicEntanglerLayers(weights, wires, rotation=None):
     if rotation is None:
         rotation = RX
 
-    _check_no_variable(rotation, msg="'rotation' cannot be differentiable")
+    check_no_variable(rotation, msg="'rotation' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    repeat = _check_number_of_layers([weights])
+    repeat = check_number_of_layers([weights])
 
     expected_shape = (repeat, len(wires))
-    _check_shape(
+    check_shape(
         weights,
         expected_shape,
-        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
+        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, get_shape(weights)),
     )
 
     ###############

--- a/pennylane/templates/layers/cv_neural_net.py
+++ b/pennylane/templates/layers/cv_neural_net.py
@@ -19,7 +19,7 @@ from pennylane.templates.decorator import template
 from pennylane.ops import Squeezing, Displacement, Kerr
 from pennylane.templates.subroutines import Interferometer
 from pennylane.templates import broadcast
-from pennylane.templates.utils import _check_wires, _check_number_of_layers, _check_shapes
+from pennylane.templates.utils import check_wires, check_number_of_layers, check_shapes
 
 
 def cv_neural_net_layer(
@@ -111,12 +111,12 @@ def CVNeuralNetLayers(
     #############
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     n_wires = len(wires)
     n_if = n_wires * (n_wires - 1) // 2
     weights_list = [theta_1, phi_1, varphi_1, r, phi_r, theta_2, phi_2, varphi_2, a, phi_a, k]
-    repeat = _check_number_of_layers(weights_list)
+    repeat = check_number_of_layers(weights_list)
 
     expected_shapes = [
         (repeat, n_if),
@@ -131,7 +131,7 @@ def CVNeuralNetLayers(
         (repeat, n_wires),
         (repeat, n_wires),
     ]
-    _check_shapes(weights_list, expected_shapes, msg="wrong shape of weight input(s) detected")
+    check_shapes(weights_list, expected_shapes, msg="wrong shape of weight input(s) detected")
 
     ###############
 

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -19,12 +19,12 @@ import numpy as np
 from pennylane.templates.decorator import template
 from pennylane.ops import CNOT, RX, RY, RZ
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_type,
-    _check_number_of_layers,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_type,
+    check_number_of_layers,
+    get_shape,
 )
 
 
@@ -113,36 +113,36 @@ def RandomLayers(weights, wires, ratio_imprim=0.3, imprimitive=CNOT, rotations=N
     #############
     # Input checks
 
-    _check_no_variable(ratio_imprim, msg="'ratio_imprim' cannot be differentiable")
-    _check_no_variable(imprimitive, msg="'imprimitive' cannot be differentiable")
-    _check_no_variable(rotations, msg="'rotations' cannot be differentiable")
-    _check_no_variable(seed, msg="'seed' cannot be differentiable")
+    check_no_variable(ratio_imprim, msg="'ratio_imprim' cannot be differentiable")
+    check_no_variable(imprimitive, msg="'imprimitive' cannot be differentiable")
+    check_no_variable(rotations, msg="'rotations' cannot be differentiable")
+    check_no_variable(seed, msg="'seed' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    repeat = _check_number_of_layers([weights])
-    n_rots = _get_shape(weights)[1]
+    repeat = check_number_of_layers([weights])
+    n_rots = get_shape(weights)[1]
 
     expected_shape = (repeat, n_rots)
-    _check_shape(
+    check_shape(
         weights,
         expected_shape,
-        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
+        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, get_shape(weights)),
     )
 
-    _check_type(
+    check_type(
         ratio_imprim,
         [float, type(None)],
         msg="'ratio_imprim' must be a float; got {}".format(ratio_imprim),
     )
-    _check_type(n_rots, [int, type(None)], msg="'n_rots' must be an integer; got {}".format(n_rots))
+    check_type(n_rots, [int, type(None)], msg="'n_rots' must be an integer; got {}".format(n_rots))
     # TODO: Check that 'rotations' contains operations
-    _check_type(
+    check_type(
         rotations,
         [list, type(None)],
         msg="'rotations' must be a list of PennyLane operations; got {}" "".format(rotations),
     )
-    _check_type(seed, [int, type(None)], msg="'seed' must be an integer; got {}.".format(seed))
+    check_type(seed, [int, type(None)], msg="'seed' must be an integer; got {}.".format(seed))
 
     ###############
 

--- a/pennylane/templates/layers/simplified_two_design.py
+++ b/pennylane/templates/layers/simplified_two_design.py
@@ -20,11 +20,11 @@ from pennylane.templates.decorator import template
 from pennylane.ops import CZ, RY
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_wires,
-    _check_number_of_layers,
-    _check_type,
-    _get_shape,
+    check_shape,
+    check_wires,
+    check_number_of_layers,
+    check_type,
+    get_shape,
 )
 
 
@@ -140,29 +140,29 @@ def SimplifiedTwoDesign(initial_layer_weights, weights, wires):
     #############
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    repeat = _check_number_of_layers([weights])
+    repeat = check_number_of_layers([weights])
 
-    _check_type(
+    check_type(
         initial_layer_weights,
         [list, np.ndarray],
         msg="'initial_layer_weights' must be of type list or np.ndarray; got type {}".format(
             type(initial_layer_weights)
         ),
     )
-    _check_type(
+    check_type(
         weights,
         [list, np.ndarray],
         msg="'weights' must be of type list or np.ndarray; got type {}".format(type(weights)),
     )
 
     expected_shape_initial = (len(wires),)
-    _check_shape(
+    check_shape(
         initial_layer_weights,
         expected_shape_initial,
         msg="'initial_layer_weights' must be of shape {}; got {}"
-        "".format(expected_shape_initial, _get_shape(initial_layer_weights)),
+        "".format(expected_shape_initial, get_shape(initial_layer_weights)),
     )
 
     if len(wires) in [0, 1]:
@@ -170,11 +170,11 @@ def SimplifiedTwoDesign(initial_layer_weights, weights, wires):
     else:
         expected_shape_weights = (repeat, len(wires) - 1, 2)
 
-    _check_shape(
+    check_shape(
         weights,
         expected_shape_weights,
         msg="'weights' must be of shape {}; got {}"
-        "".format(expected_shape_weights, _get_shape(weights)),
+        "".format(expected_shape_weights, get_shape(weights)),
     )
 
     ###############

--- a/pennylane/templates/layers/strongly_entangling.py
+++ b/pennylane/templates/layers/strongly_entangling.py
@@ -19,12 +19,12 @@ from pennylane.templates.decorator import template
 from pennylane.ops import CNOT, Rot
 from pennylane.templates import broadcast
 from pennylane.templates.utils import (
-    _check_shape,
-    _check_no_variable,
-    _check_wires,
-    _check_type,
-    _check_number_of_layers,
-    _get_shape,
+    check_shape,
+    check_no_variable,
+    check_wires,
+    check_type,
+    check_number_of_layers,
+    get_shape,
 )
 
 
@@ -82,18 +82,18 @@ def StronglyEntanglingLayers(weights, wires, ranges=None, imprimitive=CNOT):
     #############
     # Input checks
 
-    _check_no_variable(ranges, msg="'ranges' cannot be differentiable")
-    _check_no_variable(imprimitive, msg="'imprimitive' cannot be differentiable")
+    check_no_variable(ranges, msg="'ranges' cannot be differentiable")
+    check_no_variable(imprimitive, msg="'imprimitive' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
-    repeat = _check_number_of_layers([weights])
+    repeat = check_number_of_layers([weights])
 
     expected_shape = (repeat, len(wires), 3)
-    _check_shape(
+    check_shape(
         weights,
         expected_shape,
-        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, _get_shape(weights)),
+        msg="'weights' must be of shape {}; got {}" "".format(expected_shape, get_shape(weights)),
     )
 
     if len(wires) > 1:
@@ -102,16 +102,16 @@ def StronglyEntanglingLayers(weights, wires, ranges=None, imprimitive=CNOT):
             ranges = [(l % (len(wires) - 1)) + 1 for l in range(repeat)]
 
         expected_shape = (repeat,)
-        _check_shape(
+        check_shape(
             ranges,
             expected_shape,
             msg="'ranges' must be of shape {}; got {}"
-            "".format(expected_shape, _get_shape(weights)),
+            "".format(expected_shape, get_shape(weights)),
         )
 
-        _check_type(ranges, [list], msg="'ranges' must be a list; got {}" "".format(ranges))
+        check_type(ranges, [list], msg="'ranges' must be a list; got {}" "".format(ranges))
         for r in ranges:
-            _check_type(
+            check_type(
                 r, [int], msg="'ranges' must be a list of integers; got {}" "".format(ranges)
             )
         if any((r >= len(wires) or r == 0) for r in ranges):

--- a/pennylane/templates/state_preparations/basis.py
+++ b/pennylane/templates/state_preparations/basis.py
@@ -18,7 +18,7 @@ Contains the ``BasisStatePreparation`` template.
 import pennylane as qml
 
 from pennylane.templates.decorator import template
-from pennylane.templates.utils import _check_wires, _check_no_variable, _check_shape, _get_shape
+from pennylane.templates.utils import check_wires, check_no_variable, check_shape, get_shape
 
 
 @template
@@ -45,18 +45,18 @@ def BasisStatePreparation(basis_state, wires):
     ######################
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     expected_shape = (len(wires),)
-    _check_shape(
+    check_shape(
         basis_state,
         expected_shape,
         msg=" 'basis_state' must be of shape {}; got {}."
-        "".format(expected_shape, _get_shape(basis_state)),
+        "".format(expected_shape, get_shape(basis_state)),
     )
 
     # basis_state cannot be trainable
-    _check_no_variable(
+    check_no_variable(
         basis_state,
         msg="'basis_state' cannot be differentiable; must be passed as a keyword argument "
         "to the quantum node",

--- a/pennylane/templates/state_preparations/mottonen.py
+++ b/pennylane/templates/state_preparations/mottonen.py
@@ -21,7 +21,7 @@ from scipy import sparse
 import pennylane as qml
 
 from pennylane.templates.decorator import template
-from pennylane.templates.utils import _check_wires, _check_shape, _get_shape
+from pennylane.templates.utils import check_wires, check_shape, get_shape
 from pennylane.variable import Variable
 
 
@@ -246,15 +246,15 @@ def MottonenStatePreparation(state_vector, wires):
     ###############
     # Input checks
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     n_wires = len(wires)
     expected_shape = (2 ** n_wires,)
-    _check_shape(
+    check_shape(
         state_vector,
         expected_shape,
         msg="'state_vector' must be of shape {}; got {}."
-        "".format(expected_shape, _get_shape(state_vector)),
+        "".format(expected_shape, get_shape(state_vector)),
     )
 
     # check if state_vector is normalized

--- a/pennylane/templates/subroutines/interferometer.py
+++ b/pennylane/templates/subroutines/interferometer.py
@@ -18,10 +18,10 @@ Contains the ``Interferometer`` template.
 from pennylane.templates.decorator import template
 from pennylane.ops import Beamsplitter, Rotation
 from pennylane.templates.utils import (
-    _check_shapes,
-    _check_no_variable,
-    _check_wires,
-    _check_is_in_options,
+    check_shapes,
+    check_no_variable,
+    check_wires,
+    check_is_in_options,
 )
 
 
@@ -107,23 +107,23 @@ def Interferometer(theta, phi, varphi, wires, mesh="rectangular", beamsplitter="
 
     #############
     # Input checks
-    _check_no_variable(beamsplitter, msg="'beamsplitter' cannot be differentiable")
-    _check_no_variable(mesh, msg="'mesh' cannot be differentiable")
+    check_no_variable(beamsplitter, msg="'beamsplitter' cannot be differentiable")
+    check_no_variable(mesh, msg="'mesh' cannot be differentiable")
 
-    wires = _check_wires(wires)
+    wires = check_wires(wires)
 
     weights_list = [theta, phi, varphi]
     n_wires = len(wires)
     n_if = n_wires * (n_wires - 1) // 2
     expected_shapes = [(n_if,), (n_if,), (n_wires,)]
-    _check_shapes(weights_list, expected_shapes, msg="wrong shape of weight input(s) detected")
+    check_shapes(weights_list, expected_shapes, msg="wrong shape of weight input(s) detected")
 
-    _check_is_in_options(
+    check_is_in_options(
         beamsplitter,
         ["clements", "pennylane"],
         msg="did not recognize option {} for 'beamsplitter'" "".format(beamsplitter),
     )
-    _check_is_in_options(
+    check_is_in_options(
         mesh,
         ["triangular", "rectangular"],
         msg="did not recognize option {} for 'mesh'" "".format(mesh),

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -22,10 +22,10 @@ from pennylane.variable import Variable
 
 
 def check_no_variable(arg, msg):
-    """Checks that `arg` does not represent or contain a :func:`~.pennylane.Variable` object.
+    """Checks that ``arg`` does not represent or contain a :func:`~.pennylane.Variable` object.
 
-    This ensures that the user has not passed `arg` to the qnode as a
-    positional argument.
+    This ensures that the user has not passed ``arg`` to the qnode as a
+    primary argument.
 
     Args:
         arg: argument to check
@@ -41,11 +41,12 @@ def check_no_variable(arg, msg):
 
 
 def check_wires(wires):
-    """Standard checks for the wires argument.
+    """Checks that ``wires`` is either a non-negative integer or a list of non-negative integers.
+
+    If ``wires`` is an integer, wrap it by a list.
 
     Args:
-        wires (int or list): (subset of) wires of a quantum node, a list of positive integers
-                             or a single positive integer
+        wires (int or list[int]): (subset of) wires of a quantum node
 
     Return:
         list: list of wire indices
@@ -69,15 +70,16 @@ def check_wires(wires):
 
 
 def get_shape(inpt):
-    """Turn ``inpt`` to an array and return its shape.
+    """Turn ``inpt`` into an array and return its shape.
 
     Args:
-        inpt (list): input to a qnode
+        inpt (scalar, list or array): input to a qnode
 
     Returns:
         tuple: shape of ``inpt``
     """
 
+    # avoids incorrect assignment of shape
     if isinstance(inpt, (float, int, complex)):
         shape = ()
 
@@ -98,7 +100,7 @@ def get_shape(inpt):
 
 
 def check_shape(inpt, target_shape, msg, bound=None):
-    """Checks that the shape of ``inpt`` is equal to the target shape.
+    """Check that the shape of ``inpt`` is equal to ``target_shape``.
 
     Args:
         inpt (list): input to a qnode
@@ -126,8 +128,8 @@ def check_shape(inpt, target_shape, msg, bound=None):
 
 
 def check_shapes(inpt_list, target_shapes, msg, bounds=None):
-    """Checks that the shape of elements in the ``inpt`` list are equal to the shapes of elements
-    in the ``target shape`` list.
+    """Check that the shape of elements in the ``inpt`` list are equal to the shapes of elements
+    in the ``target_shapes`` list.
 
     Args:
         inpt_list (list): list of elements of which to check the shape
@@ -150,7 +152,7 @@ def check_shapes(inpt_list, target_shapes, msg, bounds=None):
 
 
 def check_is_in_options(element, options, msg):
-    """Checks that the value of ``element`` is in ``options``.
+    """Check that the value of ``element`` is in ``options``.
 
     Args:
         element: arbitraty variable
@@ -163,7 +165,7 @@ def check_is_in_options(element, options, msg):
 
 
 def check_type(element, types, msg):
-    """Checks that the type of ``element'' is one of ``types``.
+    """Check that the type of ``element`` is one of ``types``.
 
     Args:
         element: variable to check
@@ -176,8 +178,7 @@ def check_type(element, types, msg):
 
 
 def check_number_of_layers(list_of_weights):
-    """Checks that all weights in ``list_of_weights`` have the same first dimension, which is interpreted
-    as the number of layers.
+    """Check that all sequences in ``list_of_weights`` have the same first dimension.
 
     Args:
         list_of_weights (list): list of all weights to the template

--- a/pennylane/templates/utils.py
+++ b/pennylane/templates/utils.py
@@ -21,7 +21,7 @@ import numpy as np
 from pennylane.variable import Variable
 
 
-def _check_no_variable(arg, msg):
+def check_no_variable(arg, msg):
     """Checks that `arg` does not represent or contain a :func:`~.pennylane.Variable` object.
 
     This ensures that the user has not passed `arg` to the qnode as a
@@ -40,7 +40,7 @@ def _check_no_variable(arg, msg):
             raise ValueError(msg)
 
 
-def _check_wires(wires):
+def check_wires(wires):
     """Standard checks for the wires argument.
 
     Args:
@@ -68,7 +68,7 @@ def _check_wires(wires):
     return wires
 
 
-def _get_shape(inpt):
+def get_shape(inpt):
     """Turn ``inpt`` to an array and return its shape.
 
     Args:
@@ -97,7 +97,7 @@ def _get_shape(inpt):
     return shape
 
 
-def _check_shape(inpt, target_shape, msg, bound=None):
+def check_shape(inpt, target_shape, msg, bound=None):
     """Checks that the shape of ``inpt`` is equal to the target shape.
 
     Args:
@@ -110,7 +110,7 @@ def _check_shape(inpt, target_shape, msg, bound=None):
         ValueError
     """
 
-    shape = _get_shape(inpt)
+    shape = get_shape(inpt)
 
     if bound == "max":
         if shape > target_shape:
@@ -125,7 +125,7 @@ def _check_shape(inpt, target_shape, msg, bound=None):
     return shape
 
 
-def _check_shapes(inpt_list, target_shapes, msg, bounds=None):
+def check_shapes(inpt_list, target_shapes, msg, bounds=None):
     """Checks that the shape of elements in the ``inpt`` list are equal to the shapes of elements
     in the ``target shape`` list.
 
@@ -144,12 +144,12 @@ def _check_shapes(inpt_list, target_shapes, msg, bounds=None):
         bounds = [None] * len(inpt_list)
 
     shape_list = [
-        _check_shape(l, t, bound=b, msg=msg) for l, t, b in zip(inpt_list, target_shapes, bounds)
+        check_shape(l, t, bound=b, msg=msg) for l, t, b in zip(inpt_list, target_shapes, bounds)
     ]
     return shape_list
 
 
-def _check_is_in_options(element, options, msg):
+def check_is_in_options(element, options, msg):
     """Checks that the value of ``element`` is in ``options``.
 
     Args:
@@ -162,7 +162,7 @@ def _check_is_in_options(element, options, msg):
         raise ValueError(msg)
 
 
-def _check_type(element, types, msg):
+def check_type(element, types, msg):
     """Checks that the type of ``element'' is one of ``types``.
 
     Args:
@@ -175,7 +175,7 @@ def _check_type(element, types, msg):
         raise ValueError(msg)
 
 
-def _check_number_of_layers(list_of_weights):
+def check_number_of_layers(list_of_weights):
     """Checks that all weights in ``list_of_weights`` have the same first dimension, which is interpreted
     as the number of layers.
 
@@ -189,7 +189,7 @@ def _check_number_of_layers(list_of_weights):
         ValueError
     """
 
-    shapes = [_get_shape(weight) for weight in list_of_weights]
+    shapes = [get_shape(weight) for weight in list_of_weights]
 
     if any(len(s) == 0 for s in shapes):
         raise ValueError(

--- a/tests/test_templates_utils.py
+++ b/tests/test_templates_utils.py
@@ -18,14 +18,14 @@ Tests for the templates utility functions.
 import pytest
 import numpy as np
 from pennylane.variable import Variable
-from pennylane.templates.utils import (_check_wires,
-                                       _check_shape,
-                                       _check_shapes,
-                                       _get_shape,
-                                       _check_number_of_layers,
-                                       _check_no_variable,
-                                       _check_is_in_options,
-                                       _check_type)
+from pennylane.templates.utils import (check_wires,
+                                       check_shape,
+                                       check_shapes,
+                                       get_shape,
+                                       check_number_of_layers,
+                                       check_no_variable,
+                                       check_is_in_options,
+                                       check_type)
 
 #########################################
 # Inputs
@@ -126,90 +126,90 @@ class TestInputChecks:
     @pytest.mark.parametrize("arg", NO_VARIABLES_PASS)
     def test_check_no_variable(self, arg):
         """Tests that variable check succeeds for valid arguments."""
-        _check_no_variable(arg, msg="XXX")
+        check_no_variable(arg, msg="XXX")
 
     @pytest.mark.parametrize("arg", NO_VARIABLES_FAIL)
     def test_check_no_variable_exception(self, arg):
         """Tests that variable check throws error for invalid arguments."""
         with pytest.raises(ValueError, match="XXX"):
-            _check_no_variable(arg, msg="XXX")
+            check_no_variable(arg, msg="XXX")
 
     @pytest.mark.parametrize("wires, target", WIRES_PASS)
     def test_check_wires(self, wires, target):
         """Tests that wires check returns correct wires list and its length."""
-        res = _check_wires(wires=wires)
+        res = check_wires(wires=wires)
         assert res == target
 
     @pytest.mark.parametrize("wires", WIRES_FAIL)
     def test_check_wires_exception(self, wires):
         """Tests that wires check fails if ``wires`` is not a positive integer or iterable of positive integers."""
         with pytest.raises(ValueError, match="wires must be a positive integer"):
-            _check_wires(wires=wires)
+            check_wires(wires=wires)
 
     @pytest.mark.parametrize("inpt, target_shape", GET_SHAPE_PASS)
     def test_get_shape(self, inpt, target_shape):
-        """Tests that ``_get_shape`` returns correct shape."""
-        shape = _get_shape(inpt)
+        """Tests that ``get_shape`` returns correct shape."""
+        shape = get_shape(inpt)
         assert shape == target_shape
 
     @pytest.mark.parametrize("inpt", GET_SHAPE_FAIL)
     def test_get_shape_exception(self, inpt):
-        """Tests that ``_get_shape`` fails if unkown type of arguments."""
+        """Tests that ``get_shape`` fails if unkown type of arguments."""
         with pytest.raises(ValueError, match="could not extract shape of object"):
-            _get_shape(inpt)
+            get_shape(inpt)
 
     @pytest.mark.parametrize("inpt, target_shape, bound", SHAPE_PASS)
     def test_check_shape(self, inpt, target_shape, bound):
         """Tests that shape check succeeds for valid arguments."""
-        _check_shape(inpt, target_shape, bound=bound, msg="XXX")
+        check_shape(inpt, target_shape, bound=bound, msg="XXX")
 
     @pytest.mark.parametrize("inpt, target_shape, bound", SHAPE_LST_PASS)
     def test_check_shape_list_of_inputs(self, inpt, target_shape, bound):
         """Tests that list version of shape check succeeds for valid arguments."""
-        _check_shapes(inpt, target_shape, bounds=[bound] * len(inpt), msg="XXX")
+        check_shapes(inpt, target_shape, bounds=[bound] * len(inpt), msg="XXX")
 
     @pytest.mark.parametrize("inpt, target_shape, bound", SHAPE_FAIL)
     def test_check_shape_exception(self, inpt, target_shape, bound):
         """Tests that shape check fails for invalid arguments."""
         with pytest.raises(ValueError, match="XXX"):
-            _check_shape(inpt, target_shape, bound=bound, msg="XXX")
+            check_shape(inpt, target_shape, bound=bound, msg="XXX")
 
     @pytest.mark.parametrize("inpt, target_shape, bound", SHAPE_LST_FAIL)
     def test_check_shape_list_of_inputs_exception(self, inpt, target_shape, bound):
         """Tests that list version of shape check succeeds for valid arguments."""
         with pytest.raises(ValueError, match="XXX"):
-            _check_shapes(inpt, target_shape, bounds=[bound] * len(inpt), msg="XXX")
+            check_shapes(inpt, target_shape, bounds=[bound] * len(inpt), msg="XXX")
 
     @pytest.mark.parametrize("hp, opts", OPTIONS_PASS)
     def test_check_options(self, hp, opts):
         """Tests that option check succeeds for valid arguments."""
-        _check_is_in_options(hp, opts, msg="XXX")
+        check_is_in_options(hp, opts, msg="XXX")
 
     @pytest.mark.parametrize("hp, opts", OPTIONS_FAIL)
     def test_check_options_exception(self, hp, opts):
         """Tests that option check throws error for invalid arguments."""
         with pytest.raises(ValueError, match="XXX"):
-            _check_is_in_options(hp, opts, msg="XXX")
+            check_is_in_options(hp, opts, msg="XXX")
 
     @pytest.mark.parametrize("hp, typ, alt", TYPE_PASS)
     def test_check_type(self, hp, typ, alt):
         """Tests that type check succeeds for valid arguments."""
-        _check_type(hp, [typ, alt], msg="XXX")
+        check_type(hp, [typ, alt], msg="XXX")
 
     @pytest.mark.parametrize("hp, typ, alt", TYPE_FAIL)
     def test_check_type_exception(self, hp, typ, alt):
         """Tests that type check throws error for invalid arguments."""
         with pytest.raises(ValueError, match="XXX"):
-            _check_type(hp, [typ, alt], msg="XXX")
+            check_type(hp, [typ, alt], msg="XXX")
 
     @pytest.mark.parametrize("inpt, repeat", LAYERS_PASS)
     def test_check_num_layers(self, inpt, repeat):
         """Tests that layer check returns correct number of layers."""
-        n_layers = _check_number_of_layers(inpt)
+        n_layers = check_number_of_layers(inpt)
         assert n_layers == repeat
 
     @pytest.mark.parametrize("inpt, repeat", LAYERS_FAIL)
     def test_check_num_layers_exception(self, inpt, repeat):
         """Tests that layer check throws exception if number of layers not consistent."""
         with pytest.raises(ValueError, match="the first dimension of the weight parameters"):
-            _check_number_of_layers(inpt)
+            check_number_of_layers(inpt)


### PR DESCRIPTION
**Context:**

In PR #564  the issue of having the functions in ``pennylane.templates.utils`` being private came up. Since we want to expose them in the docs for developers to use, it is more consistent to make them public.

**Description of the Change:**

Refactor the names to delete leading underscore.

Minor polish of docstrings.

**Benefits:**

Will make the ``automodapi`` command included in PR #564 show the functions.
