### PR TITLE
add PR 566 in changelog

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -175,9 +175,8 @@
 
 <h3>Improvements</h3>
 
-* Made the input check functions in :mod:`pennylane.templates.utils` public,
-  so they can be used when creating new templates, and they are visible in the
-  API documentation.
+* The input check functions in :mod:`pennylane.templates.utils` are now public
+  and visible in the API documentation.
   [(#566)](https://github.com/XanaduAI/pennylane/pull/566)
 
 * Improved the performance of diagonal gates in the `default.qubit` plugin.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -175,6 +175,11 @@
 
 <h3>Improvements</h3>
 
+* Made the input check functions in :mod:`pennylane.templates.utils` public,
+  so they can be used when creating new templates, and they are visible in the
+  API documentation.
+  [(#566)](https://github.com/XanaduAI/pennylane/pull/566)
+
 * Improved the performance of diagonal gates in the `default.qubit` plugin.
   [(#559)](https://github.com/XanaduAI/pennylane/pull/559)
 


### PR DESCRIPTION
**Context:**

In PR #566 the changelog was not updated to account for the template utils functions now being public. This PR rectifies the omission.

**Description of the Change:**

Add entry to CHANGELOG.
