### PR TITLE
Unset attribute in test

### DIFF
--- a/tests/qnn/test_keras.py
+++ b/tests/qnn/test_keras.py
@@ -79,19 +79,19 @@ def model(get_circuit, n_qubits, output_dim):
     return model
 
 
-def indicies_up_to(n_max):
+def indices_up_to(n_max):
     """Returns an iterator over the number of qubits and output dimension, up to value n_max.
     The output dimension never exceeds the number of qubits."""
     a, b = np.tril_indices(n_max)
     return zip(*[a + 1, b + 1])
 
 
+@pytest.mark.parametrize("interface", ["tf"])  # required for the get_circuit fixture
 @pytest.mark.usefixtures("get_circuit")
 class TestKerasLayer:
     """Unit tests for the pennylane.qnn.keras.KerasLayer class."""
 
-    @pytest.mark.parametrize("interface", ["tf"])  # required for the get_circuit fixture
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_bad_tf_version(self, get_circuit, output_dim, monkeypatch):
         """Test if an ImportError is raised when instantiated with an incorrect version of
         TensorFlow"""
@@ -101,8 +101,7 @@ class TestKerasLayer:
             with pytest.raises(ImportError, match="KerasLayer requires TensorFlow version 2"):
                 KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_no_input(self, get_circuit, output_dim):
         """Test if a TypeError is raised when instantiated with a QNode that does not have an
         argument with name equal to the input_arg class attribute of KerasLayer"""
@@ -111,8 +110,7 @@ class TestKerasLayer:
         with pytest.raises(TypeError, match="QNode must include an argument with name"):
             KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_input_in_weight_shapes(self, get_circuit, n_qubits, output_dim):
         """Test if a ValueError is raised when instantiated with a weight_shapes dictionary that
         contains the shape of the input argument given by the input_arg class attribute of
@@ -127,8 +125,7 @@ class TestKerasLayer:
         ):
             KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_weight_shape_unspecified(self, get_circuit, output_dim):
         """Test if a ValueError is raised when instantiated with a weight missing from the
         weight_shapes dictionary"""
@@ -137,8 +134,7 @@ class TestKerasLayer:
         with pytest.raises(ValueError, match="Must specify a shape for every non-input parameter"):
             KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_var_pos(self, get_circuit, monkeypatch, output_dim):
         """Test if a TypeError is raised when instantiated with a variable number of positional
         arguments"""
@@ -157,8 +153,7 @@ class TestKerasLayer:
             with pytest.raises(TypeError, match="Cannot have a variable number of positional"):
                 KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_var_keyword(self, get_circuit, monkeypatch, output_dim):
         """Test if a TypeError is raised when instantiated with a variable number of keyword
         arguments"""
@@ -177,7 +172,6 @@ class TestKerasLayer:
             with pytest.raises(TypeError, match="Cannot have a variable number of keyword"):
                 KerasLayer(c, w, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
     @pytest.mark.parametrize("n_qubits", [1])
     @pytest.mark.parametrize("output_dim", zip(*[[[1], (1,), 1], [1, 1, 1]]))
     def test_output_dim(self, get_circuit, output_dim):
@@ -187,8 +181,7 @@ class TestKerasLayer:
         layer = KerasLayer(c, w, output_dim[0])
         assert layer.output_dim == output_dim[1]
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(2))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_weight_shapes(self, get_circuit, output_dim, n_qubits):
         """Test if the weight_shapes input argument is correctly processed to be a dictionary
         with values that are tuples."""
@@ -204,8 +197,7 @@ class TestKerasLayer:
             "w7": (),
         }
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_non_input_defaults(self, get_circuit, output_dim, n_qubits):
         """Test if a TypeError is raised when default arguments that are not the input argument are
         present in the QNode"""
@@ -222,8 +214,7 @@ class TestKerasLayer:
         ):
             KerasLayer(c_dummy, {**w, **{"w8": 1}}, output_dim)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(2))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_qnode_weights(self, get_circuit, n_qubits, output_dim):
         """Test if the build() method correctly initializes the weights in the qnode_weights
         dictionary, i.e., that each value of the dictionary has correct shape and name."""
@@ -235,8 +226,7 @@ class TestKerasLayer:
             assert layer.qnode_weights[weight].shape == shape
             assert layer.qnode_weights[weight].name[:-2] == weight
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_qnode_weights_with_spec(self, get_circuit, monkeypatch, output_dim, n_qubits):
         """Test if the build() method correctly passes on user specified weight_specs to the
         inherited add_weight() method. This is done by monkeypatching add_weight() so that it
@@ -271,8 +261,7 @@ class TestKerasLayer:
                     for item in weight_specs[weight].items()
                 )
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(3))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(3))
     @pytest.mark.parametrize("input_shape", [(10, 4), (8, 3)])
     def test_compute_output_shape(self, get_circuit, output_dim, input_shape):
         """Test if the compute_output_shape() method performs correctly, i.e., that it replaces
@@ -284,9 +273,8 @@ class TestKerasLayer:
         assert layer.compute_output_shape(input_shape) == (input_shape[0], output_dim)
         assert isinstance(layer.compute_output_shape(input_shape), tf.TensorShape)
 
-    @pytest.mark.parametrize("interface", qml.qnodes.decorator.ALLOWED_INTERFACES)
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(4))
-    @pytest.mark.parametrize("batch_size", [5, 10, 15])
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
+    @pytest.mark.parametrize("batch_size", [2])
     def test_call(self, get_circuit, output_dim, batch_size, n_qubits):
         """Test if the call() method performs correctly, i.e., that it outputs with shape
         (batch_size, output_dim) with results that agree with directly calling the QNode"""
@@ -299,9 +287,8 @@ class TestKerasLayer:
         assert layer_out.shape == (batch_size, output_dim)
         assert np.allclose(layer_out[0], c(x[0], *weights))
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
-    @pytest.mark.parametrize("batch_size", [5])
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
+    @pytest.mark.parametrize("batch_size", [2])
     def test_call_shuffled_args(self, get_circuit, output_dim, batch_size, n_qubits):
         """Test if the call() method performs correctly when the inputs argument is not the first
         positional argument, i.e., that it outputs with shape (batch_size, output_dim) with
@@ -330,9 +317,8 @@ class TestKerasLayer:
         assert layer_out.shape == (batch_size, output_dim)
         assert np.allclose(layer_out[0], c(x[0], *weights))
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
-    @pytest.mark.parametrize("batch_size", [5])
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
+    @pytest.mark.parametrize("batch_size", [2])
     def test_call_default_input(self, get_circuit, output_dim, batch_size, n_qubits):
         """Test if the call() method performs correctly when the inputs argument is a default
         argument, i.e., that it outputs with shape (batch_size, output_dim) with results that
@@ -361,8 +347,7 @@ class TestKerasLayer:
         assert layer_out.shape == (batch_size, output_dim)
         assert np.allclose(layer_out[0], c(x[0], *weights))
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_str_repr(self, get_circuit, output_dim):
         """Test the __str__ and __repr__ representations"""
         c, w = get_circuit
@@ -371,8 +356,7 @@ class TestKerasLayer:
         assert layer.__str__() == "<Quantum Keras Layer: func=circuit>"
         assert layer.__repr__() == "<Quantum Keras Layer: func=circuit>"
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(1))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
     def test_gradients(self, get_circuit, output_dim, n_qubits):
         """Test if the gradients of the KerasLayer are equal to the gradients of the circuit when
         taken with respect to the trainable variables"""
@@ -394,32 +378,42 @@ class TestKerasLayer:
             assert np.allclose(g_layer[i], g_circuit[i])
 
 
+@pytest.mark.parametrize("interface", qml.qnodes.decorator.ALLOWED_INTERFACES)
+@pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(1))
+@pytest.mark.usefixtures("get_circuit")
+def test_interface_conversion(get_circuit, output_dim):
+    """Test if input QNodes with all types of interface are converted internally to the TensorFlow
+    interface"""
+    c, w = get_circuit
+    layer = KerasLayer(c, w, output_dim)
+    assert layer.qnode.interface == "tf"
+
+
+@pytest.mark.parametrize("interface", ["tf"])
 @pytest.mark.usefixtures("get_circuit", "model")
 class TestKerasLayerIntegration:
     """Integration tests for the pennylane.qnn.keras.KerasLayer class."""
 
-    @pytest.mark.parametrize("interface", qml.qnodes.decorator.ALLOWED_INTERFACES)
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(2))
-    @pytest.mark.parametrize("batch_size", [5, 10])
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
+    @pytest.mark.parametrize("batch_size", [2])
     def test_train_model(self, model, batch_size, n_qubits, output_dim):
         """Test if a model can train using the KerasLayer. The model is composed of a single
         KerasLayer sandwiched between two Dense layers, and the dataset is simply input and output
         vectors of zeros."""
 
-        x = np.zeros((5, n_qubits))
-        y = np.zeros((5, output_dim))
+        x = np.zeros((batch_size, n_qubits))
+        y = np.zeros((batch_size, output_dim))
 
         model.compile(optimizer="sgd", loss="mse")
 
         model.fit(x, y, batch_size=batch_size, verbose=0)
 
-    @pytest.mark.parametrize("interface", qml.qnodes.decorator.ALLOWED_INTERFACES)
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(2))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_model_gradients(self, model, output_dim, n_qubits):
         """Test if a gradient can be calculated with respect to all of the trainable variables in
         the model"""
-        x = tf.zeros((5, n_qubits))
-        y = tf.zeros((5, output_dim))
+        x = tf.zeros((2, n_qubits))
+        y = tf.zeros((2, output_dim))
 
         with tf.GradientTape() as tape:
             out = model(x)
@@ -428,8 +422,7 @@ class TestKerasLayerIntegration:
         gradients = tape.gradient(loss, model.trainable_variables)
         assert all([g.dtype == tf.keras.backend.floatx() for g in gradients])
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("n_qubits, output_dim", indicies_up_to(2))
+    @pytest.mark.parametrize("n_qubits, output_dim", indices_up_to(2))
     def test_model_save_weights(self, model, n_qubits, tmpdir):
         """Test if the model can be successfully saved and reloaded using the get_weights()
         method"""

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -52,22 +52,20 @@ def test_fallback_Jacobian_qnode(monkeypatch):
     """Test the decorator fallsback to Jacobian QNode if it
     can't determine the device model"""
     dev = qml.device('default.gaussian', wires=1)
-    # remember the current value
-    temp = dev._capabilities["model"]
-    dev._capabilities["model"] = 'None'
 
-    @qnode(dev)
-    def circuit(a):
-        qml.Displacement(a, 0, wires=0)
-        return qml.expval(qml.X(wires=0))
+    # use monkeypatch to avoid setting class attributes
+    with monkeypatch.context() as m:
+        m.setitem(dev._capabilities, "model", "None")
 
-    assert not isinstance(circuit, CVQNode)
-    assert not isinstance(circuit, QubitQNode)
-    assert isinstance(circuit, JacobianQNode)
-    assert hasattr(circuit, "jacobian")
+        @qnode(dev)
+        def circuit(a):
+            qml.Displacement(a, 0, wires=0)
+            return qml.expval(qml.X(wires=0))
 
-    # reset attribute so it does not interfere with other tests
-    dev._capabilities["model"] = temp
+        assert not isinstance(circuit, CVQNode)
+        assert not isinstance(circuit, QubitQNode)
+        assert isinstance(circuit, JacobianQNode)
+        assert hasattr(circuit, "jacobian")
 
 def test_torch_interface(skip_if_no_torch_support):
     """Test torch interface conversion"""

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -52,7 +52,9 @@ def test_fallback_Jacobian_qnode(monkeypatch):
     """Test the decorator fallsback to Jacobian QNode if it
     can't determine the device model"""
     dev = qml.device('default.gaussian', wires=1)
-    dev._capabilities["model"] = None
+    # remember the current value
+    temp = dev._capabilities["model"]
+    dev._capabilities["model"] = 'None'
 
     @qnode(dev)
     def circuit(a):
@@ -64,6 +66,8 @@ def test_fallback_Jacobian_qnode(monkeypatch):
     assert isinstance(circuit, JacobianQNode)
     assert hasattr(circuit, "jacobian")
 
+    # reset attribute so it does not interfere with other tests
+    dev._capabilities["model"] = temp
 
 def test_torch_interface(skip_if_no_torch_support):
     """Test torch interface conversion"""


### PR DESCRIPTION
**Context:**

We had a very hard-to-track bug in the tests: When moving a specific test into a subfolder, it would suddenly fail. What happens is that moving the test changes the execution order of tests. As a consequence, a certain troublesome qnode test gets executed first. In it, a device class attribute gets assigned and screws up the later test.

**Description of the Change:**

Unset value of attribute in test that causes trouble.

**Benefits:** Prevents future issues where this test interferes with others.
