### PR TITLE
Modify analytic_probability from being abstract to raising NotImplementedError

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -340,7 +340,6 @@ class QubitDevice(Device):
         """
         raise NotImplementedError
 
-    @abc.abstractmethod
     def analytic_probability(self, wires=None):
         r"""Return the (marginal) probability of each computational basis
         state from the last run of the device.
@@ -365,6 +364,7 @@ class QubitDevice(Device):
         Returns:
             List[float]: list of the probabilities
         """
+        raise NotImplementedError
 
     def estimate_probability(self, wires=None):
         """Return the estimated probability of each computational basis state

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -141,6 +141,7 @@ class TestOperations:
 
         with monkeypatch.context() as m:
             m.setattr(QubitDevice, "apply", lambda self, x, **kwargs: call_history.extend(x + kwargs.get('rotations', [])))
+            m.setattr(QubitDevice, "analytic_probability", lambda *args: None)
             mock_qubit_device_with_paulis_and_methods.execute(circuit_graph)
 
         assert call_history == queue
@@ -336,6 +337,7 @@ class TestGenerateSamples:
             # Mock the auxiliary methods such that they return the expected values
             m.setattr(QubitDevice, "sample_basis_states", lambda self, wires, b: wires)
             m.setattr(QubitDevice, "states_to_binary", lambda a, b: (a, b))
+            m.setattr(QubitDevice, "analytic_probability", lambda *args: None)
             mock_qubit_device._samples = mock_qubit_device.generate_samples()
 
         assert mock_qubit_device._samples == (number_of_states, mock_qubit_device.num_wires)


### PR DESCRIPTION
**Context:**
As of https://github.com/XanaduAI/pennylane/pull/573 the `analytic_probability` method has been added to the `QubitDevice` and it was made an __abstract method__. What this implies, is that every device inheriting from `QubitDevice` will have to define this method.

This, however, logically should not be required for hardware-like devices.

If `analytic_probability` is not defined, the following ``TypeError`` is raised:
```python
TypeError: Can't instantiate abstract class QPUDevice with abstract methods analytic_probability

../pennylane/pennylane/__init__.py:164: TypeError
```

**Description of the Change:**

- Modifies `QubitDevice.analytic_probability` from being an abstract method to raising `NotImplementedError` upon being called

**Benefits:**
The implication for devices inheriting from `QubitDevice` is the following:
* statevector simulators: (as before) **must** define `analytic_probability`, else a `NotImplementedError` is raised
* hardware like devices: **are allowed** to not have a definition for `analytic_probability`

**Possible Drawbacks:**
* A `NotImplementedError` is raised during runtime and due to the way of how PennyLane places calls on `analytic_probability`.

What this implies, is that if a plugin by mistake calls `analytic_probability` (which was only defined in `QubitDevice`), the error will be raised during execution.

Overall, having `analytic_probability` as an abstract method could be a good solution in a separate `StatevectorDevice` class (as then any device inheriting from this class would indeed have to redefine it due to the `TypeError` being raised).

**Related GitHub Issues:**
N/A

**Further info:**

This change goes parallel with the following renames in `PennyLane-Forest` and `PennyLane-Cirq`:
* `probability` -> `analytic_probability`
    * PL-Cirq: https://github.com/XanaduAI/pennylane-cirq/pull/24
    * PL-Forest: https://github.com/rigetti/pennylane-forest/pull/49/files#r405043439

(It is worth noting that in `PennyLane-Forest` `analytic_probability` will continue to be defined in the parent class `ForestDevice`, something that would be beneficial to be changed in the future.)