### PR TITLE
Kwargs in qml.map and VQECost (example of passing step size)

### DIFF
--- a/pennylane/collections/map.py
+++ b/pennylane/collections/map.py
@@ -27,7 +27,15 @@ from .qnode_collection import QNodeCollection
 MEASURE_MAP = {"expval": expval, "var": var, "sample": sample}
 
 
-def map(template, observables, device, measure="expval", interface="autograd", diff_method="best", **kwargs):
+def map(
+    template,
+    observables,
+    device,
+    measure="expval",
+    interface="autograd",
+    diff_method="best",
+    **kwargs
+):
     """Map a quantum template over a list of observables to create
     a :class:`QNodeCollection`.
 

--- a/pennylane/collections/map.py
+++ b/pennylane/collections/map.py
@@ -27,7 +27,7 @@ from .qnode_collection import QNodeCollection
 MEASURE_MAP = {"expval": expval, "var": var, "sample": sample}
 
 
-def map(template, observables, device, measure="expval", interface="autograd", diff_method="best"):
+def map(template, observables, device, measure="expval", interface="autograd", diff_method="best", **kwargs):
     """Map a quantum template over a list of observables to create
     a :class:`QNodeCollection`.
 
@@ -121,12 +121,12 @@ def map(template, observables, device, measure="expval", interface="autograd", d
         # Python's late binding closure behaviour
         # (see https://docs.python-guide.org/writing/gotchas/#late-binding-closures)
         def circuit(
-            params, _obs=obs, _m=m, _wires=wires, **kwargs
+            params, _obs=obs, _m=m, _wires=wires, **circuit_kwargs
         ):  # pylint: disable=dangerous-default-value, function-redefined
-            template(params, wires=_wires, **kwargs)
+            template(params, wires=_wires, **circuit_kwargs)
             return MEASURE_MAP[_m](_obs)
 
-        qnode = QNode(circuit, dev, interface=interface, diff_method=diff_method)
+        qnode = QNode(circuit, dev, interface=interface, diff_method=diff_method, **kwargs)
         qnodes.append(qnode)
 
     return qnodes

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -194,7 +194,9 @@ class VQECost:
     :doc:`optimizer </introduction/optimizers>`.
     """
 
-    def __init__(self, ansatz, hamiltonian, device, interface="autograd", diff_method="best", **kwargs):
+    def __init__(
+        self, ansatz, hamiltonian, device, interface="autograd", diff_method="best", **kwargs
+    ):
         coeffs, observables = hamiltonian.terms
         self.hamiltonian = hamiltonian
         """Hamiltonian: the hamiltonian defining the VQE problem."""

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -194,13 +194,13 @@ class VQECost:
     :doc:`optimizer </introduction/optimizers>`.
     """
 
-    def __init__(self, ansatz, hamiltonian, device, interface="autograd", diff_method="best"):
+    def __init__(self, ansatz, hamiltonian, device, interface="autograd", diff_method="best", **kwargs):
         coeffs, observables = hamiltonian.terms
         self.hamiltonian = hamiltonian
         """Hamiltonian: the hamiltonian defining the VQE problem."""
 
         self.qnodes = qml.map(
-            ansatz, observables, device, interface=interface, diff_method=diff_method
+            ansatz, observables, device, interface=interface, diff_method=diff_method, **kwargs
         )
         """QNodeCollection: The QNodes to be evaluated. Each QNode corresponds to the
         the expectation value of each observable term after applying the circuit ansatz.

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -139,7 +139,7 @@ class TestMap:
         assert qc[1].ops[1].name == "PauliY"
         assert qc[1].ops[1].return_type == qml.operation.Variance
 
-    def test_invalid_obserable(self):
+    def test_invalid_observable(self):
         """Test that an invalid observable raises an exception"""
         dev = qml.device("default.qubit", wires=1)
 

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -162,7 +162,7 @@ class TestMap:
 
         qc(1)
 
-        assert len(qc[0].ops) == 2
+        assert len(qc) == 2
 
         # Checking the h attribute which contains the step size
         assert qc[0].h == 123

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -149,6 +149,24 @@ class TestMap:
         with pytest.raises(ValueError, match="Some or all observables are not valid"):
             qml.map(template, obs_list, dev, measure=["expval", "var"])
 
+    def test_step_size_set(self):
+        """Test that the step size used for the finite differences
+        differentiation method was passed to the QNode instances using the
+        keyword arguments."""
+        dev = qml.device("default.qubit", wires=1)
+
+        obs_list = [qml.PauliX(0), qml.PauliY(0)]
+        template = lambda x, wires: qml.RX(x, wires=0)
+
+        qc = qml.map(template, obs_list, dev, measure=["expval", "var"], h=123)
+
+        qc(1)
+
+        assert len(qc[0].ops) == 2
+
+        # Checking the h attribute which contains the step size
+        assert qc[0].h == 123
+        assert qc[1].h == 123
 
 class TestApply:
     """Tests for the apply function"""

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -292,6 +292,18 @@ class TestVQE:
         with pytest.raises(ValueError, match="not a callable function."):
             cost = qml.VQECost(4, hamiltonian, mock_device)
 
+    @pytest.mark.parametrize("coeffs, observables, expected", hamiltonians_with_expvals)
+    def test_step_size_set(self, coeffs, observables, expected):
+        """Test that the step size used for the finite differences
+        differentiation method was passed to the QNode instances using the
+        keyword arguments."""
+        dev = qml.device("default.qubit", wires=2)
+        hamiltonian = qml.vqe.Hamiltonian(coeffs, observables)
+        cost = qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev, h=123)
+
+        # Checking the h attribute which contains the step size
+        for qnode in cost.qnodes:
+            assert qnode.h == 123
 
 class TestAutogradInterface:
     """Tests for the Autograd interface (and the NumPy interface for backward compatibility)"""


### PR DESCRIPTION
**Context:**
Recently the ability to pass the step size for the finite differences grad method was added #530. Reflecting this change in `qml.map` and `VQECost` was, however, left out.

**Description of the Change:**
Adds `**kwargs` to the signature of `VQECost.__init__` and `qml.map`.

**Benefits:**
The step size (`h`) can now be passed  as a keyword argument to these funcitons.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A