### PR TITLE
Expose the finite difference order when creating a QNode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -186,10 +186,13 @@
 * Improved the performance of diagonal gates in the `default.qubit` plugin.
   [(#559)](https://github.com/XanaduAI/pennylane/pull/559)
 
-* Added a step size keyword argument to the `qnode` decorator, `QNode` and
-  `JacobianQNode` classes to enable setting the step size when using finite
-  difference methods.
+* Added keyword arguments for step size and order to the `qnode` decorator, `QNode` and
+  `JacobianQNode` classes to enable setting the step size and order when using finite
+  difference methods. Exposed these options in `map` and `VQECost` for users creating collections
+  of QNodes.
   [(#530)](https://github.com/XanaduAI/pennylane/pull/530)
+  [(#585)](https://github.com/XanaduAI/pennylane/pull/585)
+  [(#587)](https://github.com/XanaduAI/pennylane/pull/587)
 
 * The decomposition for the `CRY` gate now uses the simpler form `RY @ CNOT @ RY @ CNOT`
   [(#547)](https://github.com/XanaduAI/pennylane/pull/547)

--- a/pennylane/qnodes/decorator.py
+++ b/pennylane/qnodes/decorator.py
@@ -81,6 +81,7 @@ def QNode(func, device, *, interface="autograd", mutable=True, diff_method="best
 
     Keyword Args:
         h (float): step size for the finite-difference method
+        order (int): order for the finite-difference method, must be 1 (default) or 2
     """
     if diff_method is None:
         # QNode is not differentiable
@@ -183,6 +184,7 @@ def qnode(device, *, interface="autograd", mutable=True, diff_method="best", **k
     Keyword Args:
         h (float): Step size for the finite difference method. Default is ``1e-7`` for analytic devices, or
             ``0.3`` for non-analytic devices (those that estimate expectation values with a finite number of shots).
+        order (int): order for the finite-difference method, must be 1 (default) or 2
    """
 
     @lru_cache()

--- a/pennylane/qnodes/jacobian.py
+++ b/pennylane/qnodes/jacobian.py
@@ -46,6 +46,9 @@ class JacobianQNode(BaseQNode):
         self._h = kwargs.get("h", default_step_size)
         """float: step size for the finite difference method"""
 
+        self._order = kwargs.get("order", 1)
+        """float: order for the finite difference method"""
+
     metric_tensor = None
 
     @property
@@ -61,6 +64,15 @@ class JacobianQNode(BaseQNode):
     @h.setter
     def h(self, value):
         self._h = value
+
+    @property
+    def order(self):
+        """float: order for the finite difference method"""
+        return self._order
+
+    @order.setter
+    def order(self, value):
+        self._order = value
 
     def __repr__(self):
         """String representation."""
@@ -197,6 +209,8 @@ class JacobianQNode(BaseQNode):
         # Add the step size into the options, if it was not there already
         if "h" not in options.keys():
             options = {"h": self.h, **options}
+        if "order" not in options.keys():
+            options = {"order": self._order, **options}
 
         # (re-)construct the circuit if necessary
         if self.circuit is None or self.mutable:
@@ -318,12 +332,12 @@ class JacobianQNode(BaseQNode):
         Returns:
             array[float]: partial derivative of the node
         """
-        y0 = options.get("y0", None)
         h = options.get("h", self.h)
         order = options.get("order", 1)
 
         shift_args = args.copy()
         if order == 1:
+            y0 = options.get("y0", None)
             # shift the parameter by h
             shift_args[idx] += h
             y = np.asarray(self.evaluate(shift_args, kwargs))

--- a/pennylane/qnodes/jacobian.py
+++ b/pennylane/qnodes/jacobian.py
@@ -333,7 +333,7 @@ class JacobianQNode(BaseQNode):
             array[float]: partial derivative of the node
         """
         h = options.get("h", self.h)
-        order = options.get("order", 1)
+        order = options.get("order", self.order)
 
         shift_args = args.copy()
         if order == 1:

--- a/tests/collections/test_collections.py
+++ b/tests/collections/test_collections.py
@@ -149,16 +149,16 @@ class TestMap:
         with pytest.raises(ValueError, match="Some or all observables are not valid"):
             qml.map(template, obs_list, dev, measure=["expval", "var"])
 
-    def test_step_size_set(self):
-        """Test that the step size used for the finite differences
-        differentiation method was passed to the QNode instances using the
+    def test_passing_kwargs(self):
+        """Test that the step size and order used for the finite differences
+        differentiation method were passed to the QNode instances using the
         keyword arguments."""
         dev = qml.device("default.qubit", wires=1)
 
         obs_list = [qml.PauliX(0), qml.PauliY(0)]
         template = lambda x, wires: qml.RX(x, wires=0)
 
-        qc = qml.map(template, obs_list, dev, measure=["expval", "var"], h=123)
+        qc = qml.map(template, obs_list, dev, measure=["expval", "var"], h=123, order=2)
 
         qc(1)
 
@@ -167,6 +167,11 @@ class TestMap:
         # Checking the h attribute which contains the step size
         assert qc[0].h == 123
         assert qc[1].h == 123
+
+        # Checking that the order is set in each QNode
+        assert qc[0].order == 2
+        assert qc[1].order == 2
+
 
 class TestApply:
     """Tests for the apply function"""

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -114,6 +114,9 @@ def test_finite_diff_qubit_qnode_passing_order_through_decorator(order):
 
     assert circuit.order == order
 
+    circuit.order = 1
+    assert circuit.order == 1
+
 
 def test_finite_diff_qubit_qnode_passing_step_size_through_decorator():
     """Test that a finite-difference differentiable qubit QNode is correctly

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -81,6 +81,7 @@ def test_torch_interface(skip_if_no_torch_support):
 step_sizes = [(True, DEFAULT_STEP_SIZE_ANALYTIC),
             (False, DEFAULT_STEP_SIZE)]
 
+
 @pytest.mark.parametrize("analytic, step_size", step_sizes)
 def test_finite_diff_qubit_qnode(analytic, step_size):
     """Test that a finite-difference differentiable qubit QNode
@@ -97,6 +98,22 @@ def test_finite_diff_qubit_qnode(analytic, step_size):
     assert isinstance(circuit, JacobianQNode)
     assert hasattr(circuit, "jacobian")
     assert circuit.h == step_size
+    assert circuit.order == 1
+
+
+@pytest.mark.parametrize("order", [1, 2])
+def test_finite_diff_qubit_qnode_passing_order_through_decorator(order):
+    """Test that a finite-difference differentiable qubit QNode is correctly created when
+    diff_method='finite-diff' and the order is set through the decorator."""
+    dev = qml.device('default.qubit', wires=1)
+
+    @qnode(dev, diff_method="finite-diff", order=order)
+    def circuit(a):
+        qml.RX(a, wires=0)
+        return qml.expval(qml.PauliZ(wires=0))
+
+    assert circuit.order == order
+
 
 def test_finite_diff_qubit_qnode_passing_step_size_through_decorator():
     """Test that a finite-difference differentiable qubit QNode is correctly

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -102,9 +102,8 @@ def test_finite_diff_qubit_qnode(analytic, step_size):
 
 
 @pytest.mark.parametrize("order", [1, 2])
-def test_finite_diff_qubit_qnode_passing_order_through_decorator(order):
-    """Test that a finite-difference differentiable qubit QNode is correctly created when
-    diff_method='finite-diff' and the order is set through the decorator."""
+def test_setting_order(order):
+    """Test that the order is correctly set and reset in a finite-difference QNode."""
     dev = qml.device('default.qubit', wires=1)
 
     @qnode(dev, diff_method="finite-diff", order=order)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -293,17 +293,19 @@ class TestVQE:
             cost = qml.VQECost(4, hamiltonian, mock_device)
 
     @pytest.mark.parametrize("coeffs, observables, expected", hamiltonians_with_expvals)
-    def test_step_size_set(self, coeffs, observables, expected):
-        """Test that the step size used for the finite differences
-        differentiation method was passed to the QNode instances using the
+    def test_passing_kwargs(self, coeffs, observables, expected):
+        """Test that the step size and order used for the finite differences
+        differentiation method were passed to the QNode instances using the
         keyword arguments."""
         dev = qml.device("default.qubit", wires=2)
         hamiltonian = qml.vqe.Hamiltonian(coeffs, observables)
-        cost = qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev, h=123)
+        cost = qml.VQECost(lambda params, **kwargs: None, hamiltonian, dev, h=123, order=2)
 
-        # Checking the h attribute which contains the step size
+        # Checking that the qnodes contain the step size and order
         for qnode in cost.qnodes:
             assert qnode.h == 123
+            assert qnode.order == 2
+
 
 class TestAutogradInterface:
     """Tests for the Autograd interface (and the NumPy interface for backward compatibility)"""


### PR DESCRIPTION
**Context:**
This PR allows users to create QNodes with a set order for the finite difference method. Without this PR, the `jacobian` and `_pd_finite_diff` of `JacobianQNode` do allow an `order` option, but this is not  settable upon instantiation.

**Description of the Change:**
Add an `order` attribute that is set when the `JacobianQNode` is instantiated, and passed on to `_pd_finite_diff`. Update tests accordingly.

**Benefits:**
The order can now set when `JacobianQNode` is initialized.

**Possible Drawbacks:**
We were already using the default order of 1, which seems to be the best. Allowing users to more easily change this opens the possibility of it being misused. However, the default is still 1 and it is likely only advanced users will know to change the order.

**Related GitHub Issues:**
This PR: https://github.com/XanaduAI/pennylane/pull/585