### PR TITLE
Minor update to probs example circuit

### DIFF
--- a/pennylane/measure.py
+++ b/pennylane/measure.py
@@ -178,7 +178,6 @@ def probs(wires):
         @qml.qnode(dev)
         def circuit():
             qml.Hadamard(wires=1)
-            qml.CNOT(wires=[0, 1])
             return qml.probs(wires=[0, 1])
 
     Executing this QNode:


### PR DESCRIPTION
The CNOT in the example does not make a difference. We are not creating a Bell state here, as qubit 0 is the control for `CNOT` which was left in the 0 state after the `Hadamard` on the 1. qubit. Therefore adding it might just complicate this example.