### PR TITLE
Fix estimate prob

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -173,7 +173,7 @@
 
 <h3>Breaking changes</h3>
 
-* Probabilty methods are handled by `QubitDevice` and device method
+* Probability methods are handled by `QubitDevice` and device method
   requirements are modified to simplify plugin development.
   [(#573)](https://github.com/XanaduAI/pennylane/pull/573)
 

--- a/doc/development/plugins.rst
+++ b/doc/development/plugins.rst
@@ -184,7 +184,8 @@ To execute operations on the device, the following methods **must** be defined:
 
     apply
 
-If the device is analytic then it **must** also overwrite:
+If the device is a statevector simulator (it has an ``analytic`` attribute)
+then it **must** also overwrite:
 
 .. autosummary::
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -389,7 +389,7 @@ class QubitDevice(Device):
 
         # count the basis state occurrences, and construct the probability vector
         basis_states, counts = np.unique(indices, return_counts=True)
-        prob = np.zeros([len(wires) ** 2], dtype=np.float64)
+        prob = np.zeros([2 ** len(wires)], dtype=np.float64)
         prob[basis_states] = counts / self.shots
         return prob
 

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -36,9 +36,10 @@ class QubitDevice(Device):
     * :meth:`~.apply`: append circuit operations, compile the circuit (if applicable),
       and perform the quantum computation.
 
-    Devices that generate their own samples (such as hardware) may optionally overwrite
-    :meth:`~.probabilty`, which otherwise automatically computes the probabilities from the
-    generated samples, and **must** overwrite the following method:
+    Devices that generate their own samples (such as hardware) may optionally
+    overwrite :meth:`~.probabilty`. This method otherwise automatically
+    computes the probabilities from the generated samples, and **must**
+    overwrite the following method:
 
     * :meth:`~.generate_samples`: Generate samples from the device from the
       exact or approximate probability distribution.

--- a/tests/test_prob.py
+++ b/tests/test_prob.py
@@ -84,6 +84,19 @@ def test_integration(tol):
     expected = np.array([0.5, 0.5, 0, 0])
     assert np.allclose(res, expected, atol=tol, rtol=0)
 
+def test_integration_analytic_false(tol):
+    """Test the probability is correct for a known state preparation when the
+    analytic attribute is set to False."""
+    dev = qml.device('default.qubit', wires=3, analytic=False)
+
+    @qml.qnode(dev)
+    def circuit():
+        qml.PauliX(0)
+        return qml.probs(wires=[0])
+
+    res = circuit()
+    expected = np.array([0, 1])
+    assert np.allclose(res, expected, atol=tol, rtol=0)
 
 def test_numerical_analytic_diff_agree(init_state, tol):
     """Test that the finite difference and parameter shift rule


### PR DESCRIPTION
**Context:**
Estimating probabilities for the `analytic=False` option was added in #573. However, the current solution results in errors for certain edge cases.
```python
import pennylane as qml

dev = qml.device('default.qubit', wires=1, analytic=False)

@qml.qnode(dev)
def circuit(): 
    qml.PauliX(0) 
    return qml.probs(wires=[0])

circuit()
```
Yields:
```python
~/pennylane/pennylane/_qubit_device.py in probability(self, wires)
    417             return self.analytic_probability(wires=wires)
    418 
--> 419         return self.estimate_probability(wires=wires)
    420 
    421     def marginal_prob(self, prob, wires=None):

~/pennylane/pennylane/_qubit_device.py in estimate_probability(self, wires)
    394         prob = np.zeros([len(wires) ** 2], dtype=np.float64)
    395         print('estimate prob: ', prob, basis_states, counts)
--> 396         prob[basis_states] = counts / self.shots
    397         return prob
    398 

IndexError: index 1 is out of bounds for axis 0 with size 1
```

**Description of the Change:**
* Corrects an internal mismatch of the size of the `prob` array that is being created.
* Adds an integration test that picks up the bug.
* Further implements suggestions from code review.

**Benefits:**
The `QubitDevice.estimate_probability` now does not raise an error.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A