### PR TITLE
Fix Issue 532 - Bug in RandomLayers

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -228,6 +228,9 @@
   
 <h3>Bug fixes</h3>
 
+* `RandomLayers()` is now compatible with the qiskit devices.
+  [(#597)](https://github.com/XanaduAI/pennylane/pull/597)
+
 * `DefaultQubit.probability()` now returns the correct probability when called with
   `device.analytic=False`.
   [(#563)](https://github.com/XanaduAI/pennylane/pull/563)

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 - pip install wheel pytest pytest-cov absl-py --upgrade
 - if [ "$TF" = "2" ]; then pip install tensorflow==2.1; fi
 - if [ "$TF" = "1" ]; then pip install tensorflow==1.13.2; fi
-- pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+- pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -47,11 +47,13 @@ def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):
     i = 0
     while i < len(weights):
         if np.random.random() > ratio_imprim:
+            # Apply a random rotation gate to a random wire
             gate = np.random.choice(rotations)
-            wire = np.random.choice(wires)
+            wire = int(np.random.choice(wires))
             gate(weights[i], wires=wire)
             i += 1
         else:
+            # Apply the imprimitive to two random wires
             if len(wires) > 1:
                 on_wires = np.random.permutation(wires)[:2]
                 on_wires = list(on_wires)

--- a/pennylane/templates/layers/random.py
+++ b/pennylane/templates/layers/random.py
@@ -56,7 +56,7 @@ def random_layer(weights, wires, ratio_imprim, imprimitive, rotations, seed):
             # Apply the imprimitive to two random wires
             if len(wires) > 1:
                 on_wires = np.random.permutation(wires)[:2]
-                on_wires = list(on_wires)
+                on_wires = [int(w) for w in on_wires]
                 imprimitive(wires=on_wires)
 
 


### PR DESCRIPTION
**Context:**

Fix for Issue #532: The RandomLayers template used numpy's ``random.choice`` function to select wires. This function however returns ``numpy`` objects, which some devices - like qiskit - can't deal with.

Note that with our planned improved wire management this bug would not appear.

**Description of the Change:**

Convert wires back to ``int``.

**Related GitHub Issues:**

Fixes #532 