### PR TITLE
Refactor old Wires class

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -185,6 +185,16 @@
 
 <h3>Improvements</h3>
 
+* The internal variables ``All`` and ``Any`` to mark a gate to act on all or any 
+  wires were renamed to ``AllWires`` and ``AnyWires`` and their class to
+  ``WireConstants``. 
+  [(#XXX)](https://github.com/XanaduAI/pennylane/pull/XXX)
+
+  For example, ``AllWires`` can now be 
+  imported via
+  
+  >>> qml.operations.WireConstants.AllWires
+
 * The input check functions in `pennylane.templates.utils` are now public
   and visible in the API documentation.
   [(#566)](https://github.com/XanaduAI/pennylane/pull/566)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -179,21 +179,20 @@
 
 <h3>Breaking changes</h3>
 
+* The internal variables ``All`` and ``Any`` to mark a gate to act on all or any 
+  wires were refactored to ``AllWires`` and ``AnyWires`` and their class to
+  ``ActsOn``. 
+  [(#614)](https://github.com/XanaduAI/pennylane/pull/614)
+
+  For example, ``AllWires`` can now be imported via
+  
+  >>> qml.operations.ActOn.AllWires
+                                                                                                                                                                                                                                                                                                      >
 * Probability methods are handled by `QubitDevice` and device method
   requirements are modified to simplify plugin development.
   [(#573)](https://github.com/XanaduAI/pennylane/pull/573)
 
 <h3>Improvements</h3>
-
-* The internal variables ``All`` and ``Any`` to mark a gate to act on all or any 
-  wires were refactored to ``AllWires`` and ``AnyWires`` and their class to
-  ``ActOn``. 
-  [(#614)](https://github.com/XanaduAI/pennylane/pull/614)
-
-  For example, ``AllWires`` can now be 
-  imported via
-  
-  >>> qml.operations.ActOn.AllWires
 
 * The input check functions in `pennylane.templates.utils` are now public
   and visible in the API documentation.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -186,14 +186,14 @@
 <h3>Improvements</h3>
 
 * The internal variables ``All`` and ``Any`` to mark a gate to act on all or any 
-  wires were renamed to ``AllWires`` and ``AnyWires`` and their class to
-  ``WireConstants``. 
-  [(#XXX)](https://github.com/XanaduAI/pennylane/pull/XXX)
+  wires were refactored to ``AllWires`` and ``AnyWires`` and their class to
+  ``ActsOn``. 
+  [(#614)](https://github.com/XanaduAI/pennylane/pull/614)
 
   For example, ``AllWires`` can now be 
   imported via
   
-  >>> qml.operations.WireConstants.AllWires
+  >>> qml.operations.ActsOn.AllWires
 
 * The input check functions in `pennylane.templates.utils` are now public
   and visible in the API documentation.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -187,13 +187,13 @@
 
 * The internal variables ``All`` and ``Any`` to mark a gate to act on all or any 
   wires were refactored to ``AllWires`` and ``AnyWires`` and their class to
-  ``ActsOn``. 
+  ``ActOn``. 
   [(#614)](https://github.com/XanaduAI/pennylane/pull/614)
 
   For example, ``AllWires`` can now be 
   imported via
   
-  >>> qml.operations.ActsOn.AllWires
+  >>> qml.operations.ActOn.AllWires
 
 * The input check functions in `pennylane.templates.utils` are now public
   and visible in the API documentation.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -186,7 +186,7 @@
 
   For example, ``AllWires`` can now be imported via
   
-  >>> qml.operations.ActOn.AllWires
+  >>> qml.operations.ActsOn.AllWires
                                                                                                                                                                                                                                                                                                       >
 * Probability methods are handled by `QubitDevice` and device method
   requirements are modified to simplify plugin development.

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -371,7 +371,11 @@ class Operator(abc.ABC):
                     )
                 )
 
-        if self.num_wires != AllWires and self.num_wires != AnyWires and len(wires) != self.num_wires:
+        if (
+            self.num_wires != AllWires
+            and self.num_wires != AnyWires
+            and len(wires) != self.num_wires
+        ):
             raise ValueError(
                 "{}: wrong number of wires. "
                 "{} wires given, {} expected.".format(self.name, len(wires), self.num_wires)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -119,7 +119,7 @@ from .variable import Variable
 # =============================================================================
 
 
-class ActsOn(IntEnum):
+class ActOn(IntEnum):
     """Integer enumeration class
     to represent the number of wires
     an operation acts on"""
@@ -128,11 +128,11 @@ class ActsOn(IntEnum):
     AllWires = 0
 
 
-AllWires = ActsOn.AllWires
+AllWires = ActOn.AllWires
 """IntEnum: An enumeration which represents all wires in the
 subsystem. It is equivalent to an integer with value 0."""
 
-AnyWires = ActsOn.AnyWires
+AnyWires = ActOn.AnyWires
 """IntEnum: An enumeration which represents any wires in the
 subsystem. It is equivalent to an integer with value -1."""
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -119,20 +119,20 @@ from .variable import Variable
 # =============================================================================
 
 
-class Wires(IntEnum):
+class ActingOn(IntEnum):
     """Integer enumeration class
     to represent the number of wires
     an operation acts on"""
 
-    Any = -1
-    All = 0
+    AnyWires = -1
+    AllWires = 0
 
 
-All = Wires.All
+AllWires = ActingOn.AllWires
 """IntEnum: An enumeration which represents all wires in the
 subsystem. It is equivalent to an integer with value 0."""
 
-Any = Wires.Any
+AnyWires = ActingOn.AnyWires
 """IntEnum: An enumeration which represents any wires in the
 subsystem. It is equivalent to an integer with value -1."""
 
@@ -371,7 +371,7 @@ class Operator(abc.ABC):
                     )
                 )
 
-        if self.num_wires != All and self.num_wires != Any and len(wires) != self.num_wires:
+        if self.num_wires != AllWires and self.num_wires != AnyWires and len(wires) != self.num_wires:
             raise ValueError(
                 "{}: wrong number of wires. "
                 "{} wires given, {} expected.".format(self.name, len(wires), self.num_wires)

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -119,7 +119,7 @@ from .variable import Variable
 # =============================================================================
 
 
-class ActingOn(IntEnum):
+class ActsOn(IntEnum):
     """Integer enumeration class
     to represent the number of wires
     an operation acts on"""
@@ -128,11 +128,11 @@ class ActingOn(IntEnum):
     AllWires = 0
 
 
-AllWires = ActingOn.AllWires
+AllWires = ActsOn.AllWires
 """IntEnum: An enumeration which represents all wires in the
 subsystem. It is equivalent to an integer with value 0."""
 
-AnyWires = ActingOn.AnyWires
+AnyWires = ActsOn.AnyWires
 """IntEnum: An enumeration which represents any wires in the
 subsystem. It is equivalent to an integer with value -1."""
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -119,7 +119,7 @@ from .variable import Variable
 # =============================================================================
 
 
-class ActOn(IntEnum):
+class ActsOn(IntEnum):
     """Integer enumeration class
     to represent the number of wires
     an operation acts on"""
@@ -128,11 +128,11 @@ class ActOn(IntEnum):
     AllWires = 0
 
 
-AllWires = ActOn.AllWires
+AllWires = ActsOn.AllWires
 """IntEnum: An enumeration which represents all wires in the
 subsystem. It is equivalent to an integer with value 0."""
 
-AnyWires = ActOn.AnyWires
+AnyWires = ActsOn.AnyWires
 """IntEnum: An enumeration which represents any wires in the
 subsystem. It is equivalent to an integer with value -1."""
 

--- a/pennylane/ops/__init__.py
+++ b/pennylane/ops/__init__.py
@@ -20,7 +20,7 @@ such as gates, state preparations and observables.
 """
 import numpy as np
 
-from pennylane.operation import Any, Observable, CVObservable
+from pennylane.operation import AnyWires, Observable, CVObservable
 
 from .cv import *
 from .qubit import *
@@ -46,7 +46,7 @@ class Identity(CVObservable):
     corresponds to the trace of the quantum state, which in exact
     simulators should always be equal to 1.
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 0
     par_domain = None
     grad_method = None

--- a/pennylane/ops/cv.py
+++ b/pennylane/ops/cv.py
@@ -35,7 +35,7 @@ quantum operations supported by PennyLane, as well as their conventions.
 import numpy as np
 from scipy.linalg import block_diag
 
-from pennylane.operation import Any, CVOperation, CVObservable
+from pennylane.operation import AnyWires, CVOperation, CVObservable
 
 
 def _rotation(phi, bare=False):
@@ -528,7 +528,7 @@ class Interferometer(CVOperation):
         wires (Sequence[int] or int): the wires the operation acts on
     """
     num_params = 1
-    num_wires = Any
+    num_wires = AnyWires
     par_domain = "A"
     grad_method = None
     grad_recipe = None
@@ -662,7 +662,7 @@ class GaussianState(CVOperation):
             form :math:`(\x_0,\dots,\x_{N-1},\p_0,\dots,\p_{N-1})`
         V (array): the :math:`2N\times 2N` (real and positive definite) covariance matrix
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 2
     par_domain = "A"
     grad_method = "F"
@@ -702,7 +702,7 @@ class FockStateVector(CVOperation):
         state (array): a single ket vector, for single mode state preparation,
             or a multimode ket, with one array dimension per mode
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 1
     par_domain = "A"
     grad_method = "F"
@@ -722,7 +722,7 @@ class FockDensityMatrix(CVOperation):
         state (array): a single mode matrix :math:`\rho_{ij}`, or
             a multimode tensor :math:`\rho_{ij,kl,\dots,mn}`, with two indices per mode
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 1
     par_domain = "A"
     grad_method = "F"
@@ -925,7 +925,7 @@ class PolyXP(CVObservable):
     Args:
         q (array[float]): expansion coefficients
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 1
     par_domain = "A"
 
@@ -979,7 +979,7 @@ class FockStateProjector(CVObservable):
             Note that ``len(n)==len(wires)``, and that ``len(n)`` cannot exceed the
             total number of wires in the QNode.
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 1
     par_domain = "A"
 

--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -21,7 +21,7 @@ import numpy as np
 from scipy.linalg import block_diag
 
 from pennylane.templates import template
-from pennylane.operation import Any, Observable, Operation
+from pennylane.operation import AnyWires, Observable, Operation
 from pennylane.templates.state_preparations import BasisStatePreparation, MottonenStatePreparation
 from pennylane.utils import OperationRecorder, pauli_eigs, expand
 
@@ -592,7 +592,7 @@ class MultiRZ(Operation):
         wires (Sequence[int] or int): the wires the operation acts on
     """
     num_params = 1
-    num_wires = Any
+    num_wires = AnyWires
     par_domain = "R"
     grad_method = "A"
 
@@ -686,7 +686,7 @@ class PauliRot(Operation):
         wires (Sequence[int] or int): the wire the operation acts on
     """
     num_params = 2
-    num_wires = Any
+    num_wires = AnyWires
     do_check_domain = False
     par_domain = "R"
     grad_method = "A"
@@ -1174,7 +1174,7 @@ class QubitUnitary(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = Any
+    num_wires = AnyWires
     par_domain = "A"
     grad_method = None
 
@@ -1219,7 +1219,7 @@ class BasisState(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = Any
+    num_wires = AnyWires
     par_domain = "A"
     grad_method = None
 
@@ -1253,7 +1253,7 @@ class QubitStateVector(Operation):
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
     num_params = 1
-    num_wires = Any
+    num_wires = AnyWires
     par_domain = "A"
     grad_method = None
 
@@ -1294,7 +1294,7 @@ class Hermitian(Observable):
         A (array): square hermitian matrix
         wires (Sequence[int] or int): the wire(s) the operation acts on
     """
-    num_wires = Any
+    num_wires = AnyWires
     num_params = 1
     par_domain = "A"
     grad_method = "F"

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -22,7 +22,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Observable, CV, ActsOn, ObservableReturnTypes
+from pennylane.operation import Observable, CV, ActOn, ObservableReturnTypes
 from pennylane.utils import _flatten, unflatten
 from pennylane.circuit_graph import CircuitGraph, _is_observable
 from pennylane.variable import Variable
@@ -305,7 +305,7 @@ class BaseQNode(qml.QueuingContext):
             self.queue.remove(operator)
 
     def _append_operator(self, operator):
-        if operator.num_wires == ActsOn.AllWires:
+        if operator.num_wires == ActOn.AllWires:
             if set(operator.wires) != set(range(self.num_wires)):
                 raise QuantumFunctionError(
                     "Operator {} must act on all wires".format(operator.name)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -22,7 +22,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Observable, CV, Wires, ObservableReturnTypes
+from pennylane.operation import Observable, CV, ActingOn, ObservableReturnTypes
 from pennylane.utils import _flatten, unflatten
 from pennylane.circuit_graph import CircuitGraph, _is_observable
 from pennylane.variable import Variable
@@ -305,7 +305,7 @@ class BaseQNode(qml.QueuingContext):
             self.queue.remove(operator)
 
     def _append_operator(self, operator):
-        if operator.num_wires == Wires.All:
+        if operator.num_wires == ActingOn.AllWires:
             if set(operator.wires) != set(range(self.num_wires)):
                 raise QuantumFunctionError(
                     "Operator {} must act on all wires".format(operator.name)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -22,7 +22,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Observable, CV, ActOn, ObservableReturnTypes
+from pennylane.operation import Observable, CV, ActsOn, ObservableReturnTypes
 from pennylane.utils import _flatten, unflatten
 from pennylane.circuit_graph import CircuitGraph, _is_observable
 from pennylane.variable import Variable
@@ -305,7 +305,7 @@ class BaseQNode(qml.QueuingContext):
             self.queue.remove(operator)
 
     def _append_operator(self, operator):
-        if operator.num_wires == ActOn.AllWires:
+        if operator.num_wires == ActsOn.AllWires:
             if set(operator.wires) != set(range(self.num_wires)):
                 raise QuantumFunctionError(
                     "Operator {} must act on all wires".format(operator.name)

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -22,7 +22,7 @@ import itertools
 import numpy as np
 
 import pennylane as qml
-from pennylane.operation import Observable, CV, ActingOn, ObservableReturnTypes
+from pennylane.operation import Observable, CV, ActsOn, ObservableReturnTypes
 from pennylane.utils import _flatten, unflatten
 from pennylane.circuit_graph import CircuitGraph, _is_observable
 from pennylane.variable import Variable
@@ -305,7 +305,7 @@ class BaseQNode(qml.QueuingContext):
             self.queue.remove(operator)
 
     def _append_operator(self, operator):
-        if operator.num_wires == ActingOn.AllWires:
+        if operator.num_wires == ActsOn.AllWires:
             if set(operator.wires) != set(range(self.num_wires)):
                 raise QuantumFunctionError(
                     "Operator {} must act on all wires".format(operator.name)

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -357,7 +357,7 @@ class TestDefaultTensorIntegration:
         """Tests that an error is raised if an unsupported gate is applied"""
         op = getattr(qml.ops, gate)
 
-        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
+        if op.num_wires is qml.operation.ActOn.AnyWires or qml.operation.ActOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))
@@ -382,7 +382,7 @@ class TestDefaultTensorIntegration:
 
         op = getattr(qml.ops, observable)
 
-        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
+        if op.num_wires is qml.operation.ActOn.AnyWires or qml.operation.ActOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -357,7 +357,7 @@ class TestDefaultTensorIntegration:
         """Tests that an error is raised if an unsupported gate is applied"""
         op = getattr(qml.ops, gate)
 
-        if op.num_wires is qml.operation.ActingOn.AnyWires or qml.operation.ActingOn.AllWires:
+        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))
@@ -382,7 +382,7 @@ class TestDefaultTensorIntegration:
 
         op = getattr(qml.ops, observable)
 
-        if op.num_wires is qml.operation.ActingOn.AnyWires or qml.operation.ActingOn.AllWires:
+        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -357,7 +357,7 @@ class TestDefaultTensorIntegration:
         """Tests that an error is raised if an unsupported gate is applied"""
         op = getattr(qml.ops, gate)
 
-        if op.num_wires is qml.operation.Wires.Any or qml.operation.Wires.All:
+        if op.num_wires is qml.operation.ActingOn.AnyWires or qml.operation.ActingOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))
@@ -382,7 +382,7 @@ class TestDefaultTensorIntegration:
 
         op = getattr(qml.ops, observable)
 
-        if op.num_wires is qml.operation.Wires.Any or qml.operation.Wires.All:
+        if op.num_wires is qml.operation.ActingOn.AnyWires or qml.operation.ActingOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))

--- a/tests/beta/test_default_tensor.py
+++ b/tests/beta/test_default_tensor.py
@@ -357,7 +357,7 @@ class TestDefaultTensorIntegration:
         """Tests that an error is raised if an unsupported gate is applied"""
         op = getattr(qml.ops, gate)
 
-        if op.num_wires is qml.operation.ActOn.AnyWires or qml.operation.ActOn.AllWires:
+        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))
@@ -382,7 +382,7 @@ class TestDefaultTensorIntegration:
 
         op = getattr(qml.ops, observable)
 
-        if op.num_wires is qml.operation.ActOn.AnyWires or qml.operation.ActOn.AllWires:
+        if op.num_wires is qml.operation.ActsOn.AnyWires or qml.operation.ActsOn.AllWires:
             wires = [0]
         else:
             wires = list(range(op.num_wires))

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -482,7 +482,7 @@ class TestQNodeExceptions:
         class DummyOp(qml.operation.Operation):
             """Dummy operation"""
 
-            num_wires = qml.operation.ActsOn.AllWires
+            num_wires = qml.operation.ActOn.AllWires
             num_params = 0
             par_domain = None
 

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -482,7 +482,7 @@ class TestQNodeExceptions:
         class DummyOp(qml.operation.Operation):
             """Dummy operation"""
 
-            num_wires = qml.operation.ActOn.AllWires
+            num_wires = qml.operation.ActsOn.AllWires
             num_params = 0
             par_domain = None
 

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -482,7 +482,7 @@ class TestQNodeExceptions:
         class DummyOp(qml.operation.Operation):
             """Dummy operation"""
 
-            num_wires = qml.operation.Wires.All
+            num_wires = qml.operation.ActingOn.AllWires
             num_params = 0
             par_domain = None
 

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -482,7 +482,7 @@ class TestQNodeExceptions:
         class DummyOp(qml.operation.Operation):
             """Dummy operation"""
 
-            num_wires = qml.operation.ActingOn.AllWires
+            num_wires = qml.operation.ActsOn.AllWires
             num_params = 0
             par_domain = None
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -526,7 +526,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
-            num_wires = qml.operation.ActingOn.AllWires
+            num_wires = qml.operation.ActsOn.AllWires
             num_params = 0
             par_domain = 'R'
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -526,7 +526,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
-            num_wires = qml.operation.ActOn.AllWires
+            num_wires = qml.operation.ActsOn.AllWires
             num_params = 0
             par_domain = 'R'
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -526,7 +526,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
-            num_wires = qml.operation.ActsOn.AllWires
+            num_wires = qml.operation.ActOn.AllWires
             num_params = 0
             par_domain = 'R'
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -526,7 +526,7 @@ class TestOperatorIntegration:
 
         class DummyOp(qml.operation.Operator):
             r"""Dummy custom operator"""
-            num_wires = qml.operation.Wires.All
+            num_wires = qml.operation.ActingOn.AllWires
             num_params = 0
             par_domain = 'R'
 


### PR DESCRIPTION
**Context:**

To introduce a ``Wires`` class we need to rename a small existing ``Wires`` class. This PR does the refactor.

It also makes the constants defined in the class more specific

**Description of the Change:**

* Refactor ``qml.operations.Wires`` -> ``qml.operations.ActsOn``
* Refactor ``qml.operations.Wires.All`` -> ``qml.operations.ActsOn.AllWires``
* Refactor ``qml.operations.Wires.Any`` -> ``qml.operations.ActsOn.AnyWires``

**Benefits:**  Name is freed and class is more specific.

