### PR TITLE
Serialize CircuitGraph to QASM

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 <h3>Improvements</h3>
 
+* The ``CircuitGraph`` class now supports serializing contained circuit operations
+  and measurement basis rotations to an OpenQASM2.0 script via the new
+  ``CircuitGraph.to_openqasm()`` method.
+  [(#623)](https://github.com/XanaduAI/pennylane/pull/623)
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>
@@ -14,6 +19,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Josh Izaac
 
 # Release 0.9.0 (current release)
 

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -209,8 +209,13 @@ class CircuitGraph:
     def to_qasm(self, rotations=True):
         """Serialize the circuit as an OpenQASM program.
 
-        Note that only operations are serialized; all measurements
+        Only operations are serialized; all measurements
         are assumed to take place in the computational basis.
+
+        .. note::
+
+            The serialized OpenQASM program assumes that gate definitions
+            in ``qelib1.inc`` is available.
 
         Args:
             rotations (bool): in addition to serializing user-specified
@@ -245,6 +250,9 @@ class CircuitGraph:
         #
         # Question: do other implementations of QASM exist that
         # don't use the qelib1.inc gate definitions?
+        # Perhaps we allow developers to pass their own native_qasm_gates dictionary
+        # to this method, which is used instead of the default below
+        # if provided.
         native_qasm_gates = {
             "CNOT": "cx",
             "CZ": "cz",

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -219,7 +219,7 @@ class CircuitGraph:
         .. note::
 
             The serialized OpenQASM program assumes that gate definitions
-            in ``qelib1.inc`` is available.
+            in ``qelib1.inc`` are available.
 
         Args:
             rotations (bool): in addition to serializing user-specified

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -115,7 +115,7 @@ class CircuitGraph:
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
         for k, op in enumerate(ops):
-            self.num_wires = max(self.num_wires, max(op.wires) + 1)
+            self.num_wires = max(self.num_wires, max(list(_flatten(op.wires))) + 1)
             op.queue_idx = k  # store the queue index in the Operator
             for w in set(
                 _flatten(op.wires)

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -113,7 +113,7 @@ class CircuitGraph:
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
         for k, op in enumerate(ops):
-            self.num_wires = max(self.num_wires, max(op.wires)+1)
+            self.num_wires = max(self.num_wires, max(op.wires) + 1)
             op.queue_idx = k  # store the queue index in the Operator
             for w in set(
                 _flatten(op.wires)
@@ -232,7 +232,7 @@ class CircuitGraph:
 
         # add the QASM headers
         qasm_str = "OPENQASM 2.0;\n"
-        qasm_str += "include \"qelib1.inc\";\n"
+        qasm_str += 'include "qelib1.inc";\n'
 
         if self.num_wires == 0:
             # empty circuit

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -210,8 +210,8 @@ class CircuitGraph:
         """
         return hash(self.serialize())
 
-    def to_qasm(self, rotations=True):
-        """Serialize the circuit as an OpenQASM program.
+    def to_openqasm(self, rotations=True):
+        """Serialize the circuit as an OpenQASM 2.0 program.
 
         Only operations are serialized; all measurements
         are assumed to take place in the computational basis.

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -20,7 +20,6 @@ from collections import Counter, OrderedDict, namedtuple
 import networkx as nx
 
 import pennylane as qml
-import pennylane.qnodes.base
 from pennylane.operation import Sample
 
 from .circuit_drawer import CHARSETS, CircuitDrawer
@@ -270,6 +269,9 @@ class CircuitGraph:
         Returns:
             str: OpenQASM serialization of the circuit
         """
+        # We import decompose_queue here to avoid a circular import
+        from pennylane.qnodes.base import decompose_queue  # pylint: disable=import-outside-toplevel
+
         class QASMSerializerDevice:
             """A mock device, to be used when performing the decomposition.
             The short_name is used in error messages if the decomposition fails.
@@ -300,7 +302,7 @@ class CircuitGraph:
             operations += self.diagonalizing_gates
 
         # decompose the queue
-        decomposed_ops = pennylane.qnodes.base.decompose_queue(operations, QASMSerializerDevice)
+        decomposed_ops = decompose_queue(operations, QASMSerializerDevice)
 
         # create the QASM code representing the operations
         for op in decomposed_ops:

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -103,6 +103,7 @@ class CircuitGraph:
         variable_deps (dict[int, list[ParameterDependency]]): Free parameters of the quantum circuit.
             The dictionary key is the parameter index.
     """
+    # pylint: disable=too-many-public-methods
 
     def __init__(self, ops, variable_deps):
         self.variable_deps = variable_deps
@@ -228,7 +229,7 @@ class CircuitGraph:
             str: OpenQASM serialization of the circuit
         """
         # We import decompose_queue here to avoid a circular import
-        from pennylane.qnodes.base import decompose_queue
+        from pennylane.qnodes.base import decompose_queue # pylint: disable=import-outside-toplevel
 
         # add the QASM headers
         qasm_str = "OPENQASM 2.0;\n"
@@ -274,7 +275,7 @@ class CircuitGraph:
             "RX": "rx",
             "RY": "ry",
             "RZ": "rz",
-            "CRZ": "crx",
+            "CRX": "crx",
             "CRY": "cry",
             "CRZ": "crz",
             "SWAP": "swap",
@@ -291,10 +292,11 @@ class CircuitGraph:
             # to circuit observables
             operations += self.diagonalizing_gates
 
-        # Create a mock QASMDevice, to be used when performing the decomposition.
-        # The short_name is not strictly necessary, but it used in error messages
-        # if the decomposition fails.
         class QASMDevice:
+            """A mock device, to be used when performing the decomposition.
+            The short_name is used in error messages if the decomposition fails.
+            """
+            # pylint: disable=too-few-public-methods
             short_name = "QASM serializer"
             supports_operation = staticmethod(lambda x: x in native_qasm_gates)
 

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -108,12 +108,12 @@ class CircuitGraph:
 
     def __init__(self, ops, variable_deps):
         self.variable_deps = variable_deps
-        self.num_wires = 0
 
         self._grid = {}
         """dict[int, list[Operator]]: dictionary representing the quantum circuit as a grid.
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
+        self.num_wires = 0
         for k, op in enumerate(ops):
             self.num_wires = max(self.num_wires, max(list(_flatten(op.wires))) + 1)
             op.queue_idx = k  # store the queue index in the Operator

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -294,7 +294,7 @@ class CircuitGraph:
             # to circuit observables
             operations += self.diagonalizing_gates
 
-        class QASMDevice:
+        class QASMSerializerDevice:
             """A mock device, to be used when performing the decomposition.
             The short_name is used in error messages if the decomposition fails.
             """
@@ -304,10 +304,10 @@ class CircuitGraph:
             supports_operation = staticmethod(lambda x: x in native_qasm_gates)
 
         # decompose the queue
-        operations = decompose_queue(operations, QASMDevice)
+        decomposed_ops = decompose_queue(operations, QASMSerializerDevice)
 
         # create the QASM code representing the operations
-        for op in operations:
+        for op in decomposed_ops:
             gate = native_qasm_gates[op.name]
             wires = ",".join(["q[{}]".format(w) for w in op.wires])
             params = ""

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -114,6 +114,7 @@ class CircuitGraph:
         Here, the key is the wire number, and the value is a list containing the operators on that wire.
         """
         self.num_wires = 0
+        """int: number of wires the circuit contains"""
         for k, op in enumerate(ops):
             self.num_wires = max(self.num_wires, max(list(_flatten(op.wires))) + 1)
             op.queue_idx = k  # store the queue index in the Operator

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -103,6 +103,7 @@ class CircuitGraph:
         variable_deps (dict[int, list[ParameterDependency]]): Free parameters of the quantum circuit.
             The dictionary key is the parameter index.
     """
+
     # pylint: disable=too-many-public-methods
 
     def __init__(self, ops, variable_deps):
@@ -229,7 +230,7 @@ class CircuitGraph:
             str: OpenQASM serialization of the circuit
         """
         # We import decompose_queue here to avoid a circular import
-        from pennylane.qnodes.base import decompose_queue # pylint: disable=import-outside-toplevel
+        from pennylane.qnodes.base import decompose_queue  # pylint: disable=import-outside-toplevel
 
         # add the QASM headers
         qasm_str = "OPENQASM 2.0;\n"
@@ -296,6 +297,7 @@ class CircuitGraph:
             """A mock device, to be used when performing the decomposition.
             The short_name is used in error messages if the decomposition fails.
             """
+
             # pylint: disable=too-few-public-methods
             short_name = "QASM serializer"
             supports_operation = staticmethod(lambda x: x in native_qasm_gates)

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -289,7 +289,7 @@ class CircuitGraph:
         operations = self.operations
 
         if rotations:
-            # if requested, append on diagonalizing gates corresponding
+            # if requested, append diagonalizing gates corresponding
             # to circuit observables
             operations += self.diagonalizing_gates
 

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -1,0 +1,702 @@
+# Copyright 2018-2020 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for the :mod:`pennylane.circuit_graph.to_qasm()` method.
+"""
+# pylint: disable=no-self-use,too-many-arguments,protected-access
+from textwrap import dedent
+
+import numpy as np
+import pytest
+
+import pennylane as qml
+from pennylane import CircuitGraph
+
+
+class TestToQasmUnitTests:
+    """Unit tests for the to_qasm() method"""
+
+    def test_empty_circuit(self):
+        """Test that an empty circuit graph is properly
+        serialized into an empty QASM program."""
+        circuit = CircuitGraph([], {})
+        res = circuit.to_qasm()
+        expected = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\n"
+        assert res == expected
+
+    def test_native_qasm_gates(self):
+        """Test that a circuit containing solely native QASM
+        gates is properly serialized."""
+        ops = [
+            qml.RX(0.43, wires=0),
+            qml.RY(0.35, wires=1),
+            qml.RZ(0.35, wires=2),
+            qml.CNOT(wires=[0, 1]),
+            qml.Hadamard(wires=2),
+            qml.CNOT(wires=[2, 0]),
+            qml.PauliX(wires=1),
+        ]
+
+        circuit = CircuitGraph(ops, {})
+        res = circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            rx(0.43) q[0];
+            ry(0.35) q[1];
+            rz(0.35) q[2];
+            cx q[0],q[1];
+            h q[2];
+            cx q[2],q[0];
+            x q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            """
+        )
+
+        assert res == expected
+
+    def test_native_inverse_gates(self):
+        """Test that a circuit containing inverse gates that are supported
+        natively by QASM, such as sdg, are correctly serialized."""
+        ops = [
+            qml.S(wires=0),
+            qml.S(wires=0).inv(),
+            qml.T(wires=0),
+            qml.T(wires=0).inv(),
+        ]
+
+        circuit = CircuitGraph(ops, {})
+        res = circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            creg c[1];
+            s q[0];
+            sdg q[0];
+            t q[0];
+            tdg q[0];
+            measure q[0] -> c[0];
+            """
+        )
+
+        assert res == expected
+
+    def test_unused_wires(self):
+        """Test that unused wires are correctly taken into account"""
+        ops = [
+            qml.Hadamard(wires=4),
+            qml.CNOT(wires=[1, 0]),
+        ]
+
+        circuit = CircuitGraph(ops, {})
+        res = circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[5];
+            creg c[5];
+            h q[4];
+            cx q[1],q[0];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            measure q[3] -> c[3];
+            measure q[4] -> c[4];
+            """
+        )
+
+        assert res == expected
+
+    def test_rotation_gate_decomposition(self):
+        """Test that gates not natively supported by QASM, such as the
+        rotation gate, are correctly decomposed and serialized."""
+        ops1 = [qml.Rot(0.3, 0.1, 0.2, wires=1)]
+        circuit1 = CircuitGraph(ops1, {})
+        qasm1 = circuit1.to_qasm()
+
+        ops2 = qml.Rot.decomposition(0.3, 0.1, 0.2, wires=1)
+        circuit2 = CircuitGraph(ops2, {})
+        qasm2 = circuit2.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[2];
+            creg c[2];
+            rz(0.3) q[1];
+            ry(0.1) q[1];
+            rz(0.2) q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            """
+        )
+
+        assert qasm1 == expected
+        assert qasm1 == qasm2
+
+    def test_state_initialization_decomposition(self):
+        """Test that the Mottonen state prepration decomposition
+        is correctly applied."""
+        psi = np.array([1, -1, -1, 1]) / np.sqrt(4)
+
+        ops1 = [qml.QubitStateVector(psi, wires=[0, 1])]
+        circuit1 = CircuitGraph(ops1, {})
+        qasm1 = circuit1.to_qasm()
+
+        ops2 = qml.QubitStateVector.decomposition(psi, wires=[0, 1])
+        circuit2 = CircuitGraph(ops2, {})
+        qasm2 = circuit2.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[2];
+            creg c[2];
+            ry(1.5707963267948968) q[1];
+            ry(1.5707963267948963) q[0];
+            cx q[1],q[0];
+            ry(0.0) q[0];
+            cx q[1],q[0];
+            rz(0.0) q[0];
+            cx q[1],q[0];
+            rz(3.141592653589793) q[0];
+            cx q[1],q[0];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            """
+        )
+
+        assert qasm1 == expected
+        assert qasm1 == qasm2
+
+    def test_basis_state_initialization_decomposition(self):
+        """Test that the basis state prepration decomposition
+        is correctly applied."""
+        basis_state = np.array([1, 0, 1, 1])
+
+        ops1 = [qml.BasisState(basis_state, wires=[0, 1, 2, 3])]
+        circuit1 = CircuitGraph(ops1, {})
+        qasm1 = circuit1.to_qasm()
+
+        ops2 = qml.BasisState.decomposition(basis_state, wires=[0, 1, 2, 3])
+        circuit2 = CircuitGraph(ops2, {})
+        qasm2 = circuit2.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[4];
+            creg c[4];
+            x q[0];
+            x q[2];
+            x q[3];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            measure q[3] -> c[3];
+            """
+        )
+
+        assert qasm1 == expected
+        assert qasm1 == qasm2
+
+    def test_unsupported_gate(self):
+        """Test an exception is raised if an unsupported operation is
+        applied."""
+        U = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+        ops = [
+            qml.S(wires=0),
+            qml.QubitUnitary(U, wires=[0, 1])
+        ]
+
+        circuit = CircuitGraph(ops, {})
+
+        with pytest.raises(qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"):
+            res = circuit.to_qasm()
+
+    def test_rotations(self):
+        """Test that observable rotations are correctly applied."""
+        ops = [
+            qml.Hadamard(wires=0),
+            qml.CNOT(wires=[0, 1]),
+            qml.expval(qml.PauliX(0)),
+            qml.expval(qml.PauliZ(1)),
+            qml.expval(qml.Hadamard(2)),
+        ]
+
+        circuit = CircuitGraph(ops, {})
+        res = circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            h q[0];
+            cx q[0],q[1];
+            h q[0];
+            ry(-0.7853981633974483) q[2];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            """
+        )
+
+        assert res == expected
+
+        ops2 = circuit.operations + circuit.diagonalizing_gates
+        circuit2 = CircuitGraph(ops2, {})
+        qasm2 = circuit2.to_qasm()
+
+        assert res == qasm2
+
+
+class TestQNodeQasmIntegrationTests:
+    """Test that the QASM serialization works correctly
+    when circuits are created via QNodes."""
+
+    def test_empty_circuit(self):
+        """Test that an empty QNode is properly
+        serialized into an empty QASM program."""
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def qnode():
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode()
+
+        res = qnode.circuit.to_qasm()
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            creg c[1];
+            measure q[0] -> c[0];
+            """
+        )
+        assert res == expected
+
+    def test_native_qasm_gates(self):
+        """Test that a QNode containing solely native QASM
+        gates is properly serialized."""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.RX(0.43, wires=0)
+            qml.RY(0.35, wires=1)
+            qml.RZ(0.35, wires=2)
+            qml.CNOT(wires=[0, 1])
+            qml.Hadamard(wires=2)
+            qml.CNOT(wires=[2, 0])
+            qml.PauliX(wires=1)
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode()
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            rx(0.43) q[0];
+            ry(0.35) q[1];
+            rz(0.35) q[2];
+            cx q[0],q[1];
+            h q[2];
+            cx q[2],q[0];
+            x q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            """
+        )
+
+        assert res == expected
+
+    def test_parametrized_native_qasm_gates(self):
+        """Test that a QNode containing solely native QASM
+        gates, as well as input parameters, is properly serialized.
+        In addition, double check the serialization changes as parameters
+        are changed."""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qnode(x, y):
+            qml.RX(x, wires=0)
+            qml.RY(y[0], wires=1)
+            qml.RZ(y[1], wires=2)
+            qml.CNOT(wires=[0, 1])
+            qml.Hadamard(wires=2)
+            qml.CNOT(wires=[2, 0])
+            qml.PauliX(wires=1)
+            return qml.expval(qml.PauliZ(0))
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            rx({}) q[0];
+            ry({}) q[1];
+            rz({}) q[2];
+            cx q[0],q[1];
+            h q[2];
+            cx q[2],q[0];
+            x q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            """
+        )
+
+        # execute the QNode with parameters, and serialize
+        params = np.array([0.5, [0.2, 0.1]])
+        qnode(*params)
+        res = qnode.circuit.to_qasm()
+        assert res == expected.format(*np.hstack(params))
+
+        # execute the QNode with new parameters, and serialize again
+        params = np.array([0.1, [0.3, 0.2]])
+        qnode(*params)
+        res = qnode.circuit.to_qasm()
+        assert res == expected.format(*np.hstack(params))
+
+    def test_native_inverse_gates(self):
+        """Test that a QNode containing inverse gates that are supported
+        natively by QASM, such as sdg, are correctly serialized."""
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.S(wires=0)
+            qml.S(wires=0).inv()
+            qml.T(wires=0)
+            qml.T(wires=0).inv()
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode()
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[1];
+            creg c[1];
+            s q[0];
+            sdg q[0];
+            t q[0];
+            tdg q[0];
+            measure q[0] -> c[0];
+            """
+        )
+
+        assert res == expected
+
+    def test_unused_wires(self):
+        """Test that unused wires are correctly taken into account"""
+        dev = qml.device("default.qubit", wires=5)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.Hadamard(wires=4)
+            qml.CNOT(wires=[1, 0])
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode()
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[5];
+            creg c[5];
+            h q[4];
+            cx q[1],q[0];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            measure q[3] -> c[3];
+            measure q[4] -> c[4];
+            """
+        )
+
+        assert res == expected
+
+    def test_rotation_gate_decomposition(self):
+        """Test that gates not natively supported by QASM, such as the
+        rotation gate, are correctly decomposed and serialized."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.Rot(0.3, 0.1, 0.2, wires=1)
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode()
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[2];
+            creg c[2];
+            rz(0.3) q[1];
+            ry(0.1) q[1];
+            rz(0.2) q[1];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            """
+        )
+
+        assert res == expected
+
+    def test_state_initialization_decomposition(self):
+        """Test that the Mottonen state prepration decomposition
+        is correctly applied."""
+        dev = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(dev)
+        def qnode(state=None):
+            qml.QubitStateVector(state, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode(state=np.array([1, -1, -1, 1]) / np.sqrt(4))
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[2];
+            creg c[2];
+            ry(1.5707963267948968) q[1];
+            ry(1.5707963267948963) q[0];
+            cx q[1],q[0];
+            ry(0.0) q[0];
+            cx q[1],q[0];
+            rz(0.0) q[0];
+            cx q[1],q[0];
+            rz(3.141592653589793) q[0];
+            cx q[1],q[0];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            """
+        )
+
+        assert res == expected
+
+    def test_basis_state_initialization_decomposition(self):
+        """Test that the basis state prepration decomposition
+        is correctly applied."""
+        dev = qml.device("default.qubit", wires=4)
+
+        @qml.qnode(dev)
+        def qnode(state=None):
+            qml.BasisState(state, wires=[0, 1, 2, 3])
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode(state=np.array([1, 0, 1, 1]))
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[4];
+            creg c[4];
+            x q[0];
+            x q[2];
+            x q[3];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            measure q[3] -> c[3];
+            """
+        )
+
+        assert res == expected
+
+    def test_unsupported_gate(self):
+        """Test an exception is raised if an unsupported operation is
+        applied."""
+        U = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.S(wires=0)
+            qml.QubitUnitary(U, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        qnode()
+
+        with pytest.raises(qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"):
+            qnode.circuit.to_qasm()
+
+    def test_rotations(self):
+        """Test that observable rotations are correctly applied."""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qnode():
+            qml.Hadamard(wires=0)
+            qml.CNOT(wires=[0, 1])
+            return [
+                qml.expval(qml.PauliX(0)),
+                qml.expval(qml.PauliZ(1)),
+                qml.expval(qml.Hadamard(2)),
+            ]
+
+        qnode()
+        res = qnode.circuit.to_qasm()
+
+        expected = dedent("""\
+            OPENQASM 2.0;
+            include "qelib1.inc";
+            qreg q[3];
+            creg c[3];
+            h q[0];
+            cx q[0],q[1];
+            h q[0];
+            ry(-0.7853981633974483) q[2];
+            measure q[0] -> c[0];
+            measure q[1] -> c[1];
+            measure q[2] -> c[2];
+            """
+        )
+
+        assert res == expected
+
+
+class TestQASMConformanceTests:
+    """Conformance tests to ensure that the CircuitGraph
+    serialized QASM conforms to the QASM standard as implemented
+    by Qiskit. Note that this test class requires Qiskit and
+    pennylane-qiskit as a dependency."""
+
+    @pytest.fixture
+    def check_dependencies(self):
+        self.qiskit = pytest.importorskip("qiskit", minversion="0.14.1")
+        pl_qiskit = pytest.importorskip("pennylane_qiskit")
+
+    def test_agrees_qiskit_plugin(self, check_dependencies):
+        """Test that the QASM generated by the CircuitGraph agrees
+        with the QASM generated by the PennyLane-Qiskit plugin."""
+        dev = qml.device("qiskit.basicaer", wires=3)
+
+        @qml.qnode(dev)
+        def qnode(x):
+            qml.Hadamard(wires=0)
+            qml.RY(x[1], wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x[0], wires=1)
+            return [
+                qml.expval(qml.PauliX(0)),
+                qml.expval(qml.PauliZ(1)),
+                qml.expval(qml.Hadamard(2)),
+            ]
+
+        qnode([0.1, 0.2])
+        res = qnode.circuit.to_qasm()
+
+        # Note: Qiskit hardcodes in pi as a QASM constant.
+        # Here, we replace it with its numerical value.
+        expected = dev._circuit.qasm().replace("pi/4", str(np.pi/4))
+
+        assert res == expected
+
+    def test_basis_state_agrees_qiskit_plugin(self, check_dependencies):
+        """Test that the basis state prepration QASM agrees
+        with that generated by the PennyLane-Qiskit plugin. This is
+        a useful test to ensure that we are using the correct qubit
+        ordering convention."""
+        dev = qml.device("qiskit.basicaer", wires=4)
+
+        @qml.qnode(dev)
+        def qnode(state=None):
+            qml.BasisState(state, wires=[0, 1, 2, 3])
+            return qml.expval(qml.PauliZ(0))
+
+        # construct the qnode circuit
+        qnode(state=np.array([1, 0, 1, 1]))
+        res = qnode.circuit.to_qasm()
+        expected = dev._circuit.qasm()
+
+        assert res == expected
+
+    def test_qiskit_load_generated_qasm(self, check_dependencies):
+        """Test that the QASM generated by the CircuitGraph
+        corresponds to valid QASM, that can be loaded by Qiskit."""
+        dev = qml.device("default.qubit", wires=3)
+
+        @qml.qnode(dev)
+        def qnode(x):
+            qml.Hadamard(wires=0)
+            qml.RY(x[1], wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RX(x[0], wires=1)
+            return [
+                qml.expval(qml.PauliX(0)),
+                qml.expval(qml.PauliZ(1)),
+                qml.expval(qml.Hadamard(2)),
+            ]
+
+        params = [0.1, 0.2]
+        qnode(params)
+        qasm = qnode.circuit.to_qasm()
+        qc = self.qiskit.QuantumCircuit.from_qasm_str(qasm)
+
+        gates = [g for g, _, _ in qc.data]
+
+        for idx, g in enumerate(gates):
+            g.wires = [q.index for q in qc.data[idx][1]]
+
+        # operations
+        assert gates[0].name == "h"
+        assert gates[0].wires == [0]
+
+        assert gates[1].name == "ry"
+        assert gates[1].wires == [0]
+        assert gates[1].params == [params[1]]
+
+        assert gates[2].name == "cx"
+        assert gates[2].wires == [0, 1]
+
+        assert gates[4].name == "rx"
+        assert gates[4].wires == [1]
+        assert gates[4].params == [params[0]]
+
+        # rotations
+        assert gates[3].name == "h"
+        assert gates[3].wires == [0]
+
+        assert gates[5].name == "ry"
+        assert gates[5].wires == [2]
+        assert gates[5].params == [-np.pi/4]

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -194,7 +194,8 @@ class TestToQasmUnitTests:
         assert qasm1 == qasm2
 
     def test_basis_state_initialization_decomposition(self):
-        """Test that the basis state prepration decomposition
+        """Test that the basis state preparation decomposition
+
         is correctly applied."""
         basis_state = np.array([1, 0, 1, 1])
 
@@ -637,7 +638,8 @@ class TestQASMConformanceTests:
     """Conformance tests to ensure that the CircuitGraph
     serialized QASM conforms to the QASM standard as implemented
     by Qiskit. Note that this test class requires Qiskit and
-    pennylane-qiskit as a dependency."""
+    PennyLane-Qiskit as a dependency."""
+
 
     @pytest.fixture
     def check_dependencies(self):
@@ -714,6 +716,9 @@ class TestQASMConformanceTests:
         gates = [g for g, _, _ in qc.data]
 
         for idx, g in enumerate(gates):
+            # attach a wires attribute to each gate, containing
+            # a list of wire integers it acts on, so we can assert
+            # correctness below.
             g.wires = [q.index for q in qc.data[idx][1]]
 
         # operations

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -32,7 +32,7 @@ class TestToQasmUnitTests:
         serialized into an empty QASM program."""
         circuit = CircuitGraph([], {})
         res = circuit.to_qasm()
-        expected = "OPENQASM 2.0;\ninclude \"qelib1.inc\";\n"
+        expected = 'OPENQASM 2.0;\ninclude "qelib1.inc";\n'
         assert res == expected
 
     def test_native_qasm_gates(self):
@@ -51,7 +51,8 @@ class TestToQasmUnitTests:
         circuit = CircuitGraph(ops, {})
         res = circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[3];
@@ -84,7 +85,8 @@ class TestToQasmUnitTests:
         circuit = CircuitGraph(ops, {})
         res = circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[1];
@@ -109,7 +111,8 @@ class TestToQasmUnitTests:
         circuit = CircuitGraph(ops, {})
         res = circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[5];
@@ -137,7 +140,8 @@ class TestToQasmUnitTests:
         circuit2 = CircuitGraph(ops2, {})
         qasm2 = circuit2.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[2];
@@ -166,7 +170,8 @@ class TestToQasmUnitTests:
         circuit2 = CircuitGraph(ops2, {})
         qasm2 = circuit2.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[2];
@@ -201,7 +206,8 @@ class TestToQasmUnitTests:
         circuit2 = CircuitGraph(ops2, {})
         qasm2 = circuit2.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[4];
@@ -223,14 +229,13 @@ class TestToQasmUnitTests:
         """Test an exception is raised if an unsupported operation is
         applied."""
         U = np.array([[1, 1], [1, -1]]) / np.sqrt(2)
-        ops = [
-            qml.S(wires=0),
-            qml.QubitUnitary(U, wires=[0, 1])
-        ]
+        ops = [qml.S(wires=0), qml.QubitUnitary(U, wires=[0, 1])]
 
         circuit = CircuitGraph(ops, {})
 
-        with pytest.raises(qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"):
+        with pytest.raises(
+            qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"
+        ):
             res = circuit.to_qasm()
 
     def test_rotations(self):
@@ -246,7 +251,8 @@ class TestToQasmUnitTests:
         circuit = CircuitGraph(ops, {})
         res = circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[3];
@@ -287,7 +293,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
 
         res = qnode.circuit.to_qasm()
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[1];
@@ -317,7 +324,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[3];
@@ -355,7 +363,8 @@ class TestQNodeQasmIntegrationTests:
             qml.PauliX(wires=1)
             return qml.expval(qml.PauliZ(0))
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[3];
@@ -402,7 +411,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[1];
@@ -431,7 +441,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[5];
@@ -462,7 +473,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[2];
@@ -491,7 +503,8 @@ class TestQNodeQasmIntegrationTests:
         qnode(state=np.array([1, -1, -1, 1]) / np.sqrt(4))
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[2];
@@ -526,7 +539,8 @@ class TestQNodeQasmIntegrationTests:
         qnode(state=np.array([1, 0, 1, 1]))
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[4];
@@ -557,7 +571,9 @@ class TestQNodeQasmIntegrationTests:
 
         qnode()
 
-        with pytest.raises(qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"):
+        with pytest.raises(
+            qml.DeviceError, match="Gate QubitUnitary not supported on device QASM serializer"
+        ):
             qnode.circuit.to_qasm()
 
     def test_rotations(self):
@@ -577,7 +593,8 @@ class TestQNodeQasmIntegrationTests:
         qnode()
         res = qnode.circuit.to_qasm()
 
-        expected = dedent("""\
+        expected = dedent(
+            """\
             OPENQASM 2.0;
             include "qelib1.inc";
             qreg q[3];
@@ -628,7 +645,7 @@ class TestQASMConformanceTests:
 
         # Note: Qiskit hardcodes in pi as a QASM constant.
         # Here, we replace it with its numerical value.
-        expected = dev._circuit.qasm().replace("pi/4", str(np.pi/4))
+        expected = dev._circuit.qasm().replace("pi/4", str(np.pi / 4))
 
         assert res == expected
 
@@ -699,4 +716,4 @@ class TestQASMConformanceTests:
 
         assert gates[5].name == "ry"
         assert gates[5].wires == [2]
-        assert gates[5].params == [-np.pi/4]
+        assert gates[5].params == [-np.pi / 4]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@
 """
 Pytest configuration file for PennyLane test suite.
 """
-import torch
 import os
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@
 """
 Pytest configuration file for PennyLane test suite.
 """
+import torch
 import os
 
 import pytest


### PR DESCRIPTION
**Description of the Change:**

* Adds `CircuitGraph.to_openqasm()` method, which serializes the circuit graph as an OpenQASM string. A dummy 'QASM Serialization' device is also created, allowing the serialization method to take advantage of built-in decomposition logic. For example:

  ```pycon
  >>> dev = qml.device("default.qubit", wires=2)
  >>> @qml.qnode(dev)
  >>> def qnode(x, y, z):
  ...    qml.Rot(x, y, z, wires=1)
  ...    return qml.expval(qml.PauliX(0))
  >>> qnode(0.3, 0.1, 0.2) # construct the qnode
  >>> print(qnode.circuit.to_qasm())
  OPENQASM 2.0;
  include "qelib1.inc";
  qreg q[2];
  creg c[2];
  rz(0.3) q[1];
  ry(0.1) q[1];
  rz(0.2) q[1];
  h q[0];
  measure q[0] -> c[0];
  measure q[1] -> c[1];
  ```

* Adds `circuit_graph/test_qasm.py` test file, containing three test classes:

  - Unit tests, directly testing the `CircuitGraph.to_openqasm()` method

  - Integration tests, checking that QASM serialization continues to work when the circuit is created via a QNode.

  - Conformance tests, to ensure that the generated QASM is valid and agrees with that generated by the PennyLane-Qiskit plugin.

* Adds the `self.num_wires` attribute to the CircuitGraph, so that the number of wires in the graph can be extracted.

**Benefits:**

- Provides a circuit serialization method that conforms to the OpenQASM standard, allowing easy integration with plugins that support QASM.

**Possible Drawbacks:**

- Currently, the QASM serialization assumes that the `qelib1.inc` file is included, which contains additional gate definitions. Some implementations of QASM might not provide this header file, or may support additional gate definitions.

- PennyLane currently does not have an in-built decomposition for arbitrary unitaries, so `QubitUnitary` is not supported.

- The conformance tests require PennyLane-Qiskit and Qiskit.

- The generated QASM string does not take into account QNode variables; all QASM gate parameters will be numeric, and the QASM string will be re-generated every time the method is called. A future optimization could perform 'parametric serialization', similar to the parametric compilation performed by the Forest plugin.

  In this case, serialization would only happen on the first call, with free parameters encoded as QASM variables. Another `CircuitGraph` method could be used to get a dictionary of QASM variables to numeric values.

  E.g., in Qiskit:

   ```pycon
   >>> from qiskit.circuit import Parameter
   >>> from qiskit import QuantumCircuit
   >>> theta = Parameter('θ')
   >>> angle = 0.5
   >>> qc = QuantumCircuit(2)
   >>> qc.rz(theta, [0])
   >>> print(qc.qasm())
   OPENQASM 2.0;
   include "qelib1.inc";
   qreg q[2];
   rz(θ) q[0];
   ```
   However, it is unclear if the benefits of supporting 'parametric serialization' are significantly useful or not, so I suggest leaving this as a future possible enhancement.

**Related GitHub Issues:** n/a
