### PR TITLE
Fix TensorFlow's jacobian when applied to a QNode

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -400,6 +400,9 @@
 
 <h3>Bug fixes</h3>
 
+* `tf.GradientTape().jacobian()` can now be evaluated on QNodes using the TensorFlow interface.
+  [(#626)](https://github.com/XanaduAI/pennylane/pull/626)
+
 * `RandomLayers()` is now compatible with the qiskit devices.
   [(#597)](https://github.com/XanaduAI/pennylane/pull/597)
 

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -16,13 +16,12 @@ This module contains the :func:`to_tf` function to convert Numpy-interfacing qua
 compatible quantum nodes.
 """
 # pylint: disable=redefined-outer-name
+import numbers
+from collections import Iterable
 from functools import partial
 
 import numpy as np
 import tensorflow as tf
-
-from pennylane.utils import unflatten
-
 
 if tf.__version__[0] == "1":
     import tensorflow.contrib.eager as tfe  # pylint: disable=unused-import,ungrouped-imports
@@ -30,6 +29,40 @@ if tf.__version__[0] == "1":
     Variable = tfe.Variable
 else:
     from tensorflow import Variable  # pylint: disable=unused-import,ungrouped-imports
+
+
+def unflatten_tf(flat, model):
+    """Restores an arbitrary nested structure to a flattened TF tensor.
+
+    See also :func:`_unflatten`.
+
+    Args:
+        flat (tf.Tensor): 1D tensor of items
+        model (array, Iterable, Number): model nested structure
+
+    Returns:
+        Union[tf.Tensor, list], array: first elements of flat arranged into the nested
+        structure of model, unused elements of flat
+
+    Raises:
+        TypeError: if ``model`` contains an object of unsupported type
+    """
+    if isinstance(model, (numbers.Number, str)):
+        return flat[0], flat[1:]
+
+    if isinstance(model, (tf.Tensor, tf.Variable)):
+        idx = tf.size(model)
+        res = tf.reshape(flat[:idx], model.shape)
+        return res, flat[idx:]
+
+    if isinstance(model, Iterable):
+        res = []
+        for x in model:
+            val, flat = unflatten_tf(flat, x)
+            res.append(val)
+        return res, flat
+
+    raise TypeError("Unsupported type in the model: {}".format(type(model)))
 
 
 def to_tf(qnode, dtype=None):
@@ -99,30 +132,17 @@ def to_tf(qnode, dtype=None):
             """Returns the vector-Jacobian product"""
             # evaluate the Jacobian matrix of the QNode
             variables = tfkwargs.get("variables", None)
-
             jacobian = qnode.jacobian(args, kwargs)
-            grad_output_np = grad_output.numpy()
-
-            # perform the vector-Jacobian product
-            if not grad_output_np.shape:
-                temp = grad_output_np * jacobian
-            else:
-                temp = grad_output_np.T @ jacobian
-
-            # restore the nested structure of the input args
-            grad_input = unflatten(temp.flat, args)
-
-            if isinstance(grad_input, list):
-                grad_input = [tf.convert_to_tensor(i, dtype=dtype) for i in grad_input]
-            elif isinstance(grad_input, tuple):
-                grad_input = tuple(tf.convert_to_tensor(i, dtype=dtype) for i in grad_input)
-            else:
-                grad_input = tf.convert_to_tensor(grad_input, dtype=dtype)
+            jacobian = tf.constant(jacobian, dtype=dtype)
+            grad_output_row = tf.transpose(tf.reshape(grad_output, [-1, 1]))
+            grad_input = tf.matmul(grad_output_row, jacobian)
+            grad_input = tf.reshape(grad_input, [-1])
+            grad_input_unflattened = unflatten_tf(grad_input, input_)[0]
 
             if variables is not None:
-                return grad_input, variables
+                return grad_input_unflattened, variables
 
-            return grad_input
+            return grad_input_unflattened
 
         return tf.convert_to_tensor(res, dtype=dtype), grad
 

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -34,7 +34,7 @@ else:
 def unflatten_tf(flat, model):
     """Restores an arbitrary nested structure to a flattened TF tensor.
 
-    See also :func:`_unflatten`.
+    See also :func:`~.unflatten`.
 
     Args:
         flat (tf.Tensor): 1D tensor of items
@@ -134,7 +134,11 @@ def to_tf(qnode, dtype=None):
             variables = tfkwargs.get("variables", None)
             jacobian = qnode.jacobian(args, kwargs)
             jacobian = tf.constant(jacobian, dtype=dtype)
+            
+            # Reshape gradient output array as a 2D row-vector.
             grad_output_row = tf.transpose(tf.reshape(grad_output, [-1, 1]))
+            
+            # Calculate the vector-Jacobian matrix product, and flatten the output.
             grad_input = tf.matmul(grad_output_row, jacobian)
             grad_input = tf.reshape(grad_input, [-1])
             grad_input_unflattened = unflatten_tf(grad_input, input_)[0]

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -134,10 +134,10 @@ def to_tf(qnode, dtype=None):
             variables = tfkwargs.get("variables", None)
             jacobian = qnode.jacobian(args, kwargs)
             jacobian = tf.constant(jacobian, dtype=dtype)
-            
+
             # Reshape gradient output array as a 2D row-vector.
             grad_output_row = tf.transpose(tf.reshape(grad_output, [-1, 1]))
-            
+
             # Calculate the vector-Jacobian matrix product, and flatten the output.
             grad_input = tf.matmul(grad_output_row, jacobian)
             grad_input = tf.reshape(grad_input, [-1])

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -34,9 +34,8 @@ except ImportError as e:
 
 import pennylane as qml
 
-from pennylane.utils import _flatten, unflatten
-from pennylane.qnodes import QNode, QuantumFunctionError
-from pennylane._device import DeviceError
+from pennylane.qnodes import QuantumFunctionError
+from pennylane.interfaces.tf import unflatten_tf
 
 from gate_data import CNOT, Rotx, Roty, Rotz, I, Y, Z
 
@@ -463,8 +462,9 @@ class TestTFQNodeParameterHandling:
 class TestIntegration:
     """Integration tests to ensure the TensorFlow QNode agrees with the NumPy QNode"""
 
-    def test_qnode_evaluation_agrees(self, qubit_device_2_wires, tol):
-        """Tests that simple example is consistent."""
+    @pytest.fixture
+    def qnodes(self, qubit_device_2_wires):
+        """Two QNodes to be used for the gradient tests"""
 
         @qml.qnode(qubit_device_2_wires, interface='autograd')
         def circuit(phi, theta):
@@ -481,6 +481,12 @@ class TestIntegration:
             qml.CNOT(wires=[0, 1])
             qml.PhaseShift(theta[0], wires=0)
             return qml.expval(qml.PauliZ(0))
+
+        return circuit, circuit_tf
+
+    def test_qnode_evaluation_agrees(self, qnodes, tol):
+        """Tests that simple example is consistent."""
+        circuit, circuit_tf = qnodes
 
         phi = [0.5, 0.1]
         theta = [0.2]
@@ -492,24 +498,9 @@ class TestIntegration:
         tf_eval = circuit_tf(phi_t, theta_t)
         assert np.allclose(autograd_eval, tf_eval.numpy(), atol=tol, rtol=0)
 
-    def test_qnode_gradient_agrees(self, qubit_device_2_wires, tol):
+    def test_qnode_gradient_agrees(self, qnodes, tol):
         """Tests that simple gradient example is consistent."""
-
-        @qml.qnode(qubit_device_2_wires, interface='autograd')
-        def circuit(phi, theta):
-            qml.RX(phi[0], wires=0)
-            qml.RY(phi[1], wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.PhaseShift(theta[0], wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        @qml.qnode(qubit_device_2_wires, interface='tf')
-        def circuit_tf(phi, theta):
-            qml.RX(phi[0], wires=0)
-            qml.RY(phi[1], wires=1)
-            qml.CNOT(wires=[0, 1])
-            qml.PhaseShift(theta[0], wires=0)
-            return qml.expval(qml.PauliZ(0))
+        circuit, circuit_tf = qnodes
 
         phi = [0.5, 0.1]
         theta = [0.2]
@@ -527,6 +518,28 @@ class TestIntegration:
 
         assert np.allclose(autograd_grad[0], tf_grad[0], atol=tol, rtol=0)
         assert np.allclose(autograd_grad[1], tf_grad[1], atol=tol, rtol=0)
+
+    def test_qnode_jacobian_agrees(self, qnodes, tol):
+        """Tests that simple jacobian example is consistent."""
+        circuit, circuit_tf = qnodes
+
+        phi = [0.5, 0.1]
+        theta = [0.2]
+
+        phi_t = Variable(phi)
+        theta_t = Variable(theta)
+
+        jac = qml.grad(circuit, [0, 1])
+        autograd_jac = jac(phi, theta)
+
+        with tf.GradientTape() as g:
+            g.watch([phi_t, theta_t])
+            y = circuit_tf(phi_t, theta_t)
+
+        tf_jac = g.jacobian(y, [phi_t, theta_t])
+
+        assert np.allclose(autograd_jac[0], tf_jac[0], atol=tol, rtol=0)
+        assert np.allclose(autograd_jac[1], tf_jac[1], atol=tol, rtol=0)
 
 
 gradient_test_data = [
@@ -721,3 +734,47 @@ class TestTFGradients:
             grad2 = tape.gradient(y, b)
 
         assert tf.equal(grad1, grad2)
+
+
+class TestUnflattenTF:
+    """Tests for pennylane.interfaces.tf.unflatten_tf"""
+
+    flat = tf.constant([i for i in range(12)])
+
+    def test_model_number(self):
+        """Test that the function simply splits flat between its first and remaining elements
+        when the model is a number"""
+        unflattened = unflatten_tf(self.flat, 0)
+        assert tf.equal(unflattened[0], 0)
+        assert all(tf.equal(unflattened[1], tf.constant([i for i in range(1, 12)])))
+
+    def test_model_tensor(self):
+        """Test that function correctly takes the first elements of flat and reshapes it into the
+        model tensor, while leaving the remaining elements as a flat tensor"""
+        model = tf.ones((3, 3))
+        unflattened = unflatten_tf(self.flat, model)
+
+        target = tf.reshape(self.flat[:9], (3, 3))
+        remaining = self.flat[-3:]
+
+        assert np.allclose(unflattened[0].numpy(), target.numpy())
+        assert np.allclose(unflattened[1].numpy(), remaining.numpy())
+
+    def test_model_iterable(self):
+        """Test that the function correctly unflattens when the model is a list of numbers,
+        which should result in unflatten_tf returning a list of tensors"""
+        model = [1] * 12
+        unflattened = unflatten_tf(self.flat, model)
+
+        assert all([i.numpy().shape == () for i in unflattened[0]])
+        assert unflattened[1].numpy().size == 0
+
+    def test_model_nested_tensor(self):
+        """Test that the function correctly unflattens when the model is a nested tensor,
+        which should result in unflatten_tf returning a list of tensors of the same shape"""
+        model = [tf.ones(3), tf.ones((2, 2)), tf.ones((3, 1)), tf.ones((1, 2))]
+        unflattened = unflatten_tf(self.flat, model)
+
+        assert all([u.numpy().shape == model[i].numpy().shape for i, u in enumerate(unflattened[
+                                                                                        0])])
+        assert unflattened[1].numpy().size == 0

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -775,6 +775,7 @@ class TestUnflattenTF:
         model = [tf.ones(3), tf.ones((2, 2)), tf.ones((3, 1)), tf.ones((1, 2))]
         unflattened = unflatten_tf(self.flat, model)
 
-        assert all([u.numpy().shape == model[i].numpy().shape for i, u in enumerate(unflattened[
-                                                                                        0])])
+        assert all(
+            [u.numpy().shape == model[i].numpy().shape for i, u in enumerate(unflattened[0])]
+        )
         assert unflattened[1].numpy().size == 0

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -19,9 +19,9 @@ import pytest
 
 import numpy as np
 
-try:
-    import tensorflow as tf
+tf = pytest.importorskip("tensorflow", minversion="1.12")
 
+try:
     if tf.__version__[0] == "1":
         import tensorflow.contrib.eager as tfe
         tf.enable_eager_execution()


### PR DESCRIPTION
This PR fixes https://github.com/XanaduAI/pennylane/issues/613, where it was reported that `tape.jacobian` doesn't work using the TF interface.

Currently, the following code does not work:
```python
import tensorflow as tf
import pennylane as qml

dev = qml.device("default.qubit", wires=1)

@qml.qnode(dev, interface="tf")
def circuit(params, params2):
    qml.RX(params[0], wires=0)
    qml.RY(params[1], wires=0)
    qml.Rot(*params2, wires=0)
    return qml.probs(0)

params = tf.Variable([0.1, 1.0])
params2 = tf.Variable([0.1, 1.0, 2.0])

with tf.GradientTape() as tape:
    res = circuit(params, params2)

print(res)
jacobian = tape.jacobian(res, [params, params2])
print("Jacobian (TF):", jacobian)
```
(note, slightly edited from the issue to make the QNode arguments be multiple tensors)
With this PR, the above now works:
```bash
tf.Tensor([0.29053261 0.70946739], shape=(2,), dtype=float64)
Jacobian (TF): [<tf.Tensor: id=3007, shape=(2, 2), dtype=float64, numpy=
array([[-0.02119752, -0.45124736],
       [ 0.02119752,  0.45124736]])>, <tf.Tensor: id=3015, shape=(2, 3), dtype=float64, numpy=
array([[-6.62550142e-03, -4.53939881e-01,  0.00000000e+00],
       [ 6.62550142e-03,  4.53939881e-01,  5.55111512e-17]])>]
```

This is done by making `grad()` in `to_tf()` operate using TF tensors without converting to numpy arrays, and requires adding of a new `unflatten_tf` (using help from https://github.com/XanaduAI/pennylane/pull/612).

Tests have also been updated, but feedback welcome on adding more!