### PR TITLE
Add function 'hf_state' to 'qchem' module

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <h3>New features since last release</h3>
 
-* The function ``hf_state`` generates the occupation-number representation of the 
+* The function ``hf_state`` outputs an array with the occupation-number representation of the 
   Hartree-Fock (HF) state. This function can be used to set the qubit register to encode the HF state which is the typical starting point for quantum chemistry simulations using the VQE algorithm.
   [(#629)](https://github.com/XanaduAI/pennylane/pull/629)
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Release 0.10.0 (development release)
+
+<h3>New features since last release</h3>
+
+* The function ``hf_state`` generates the occupation-number representation of the 
+  Hartree-Fock (HF) state. This function can be used to set the qubit register to encode the HF state which is the typical starting point for quantum chemistry simulations using the VQE algorithm.
+  [(#629)](https://github.com/XanaduAI/pennylane/pull/629)
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Documentation</h3>
+
+<h3>Bug fixes</h3>
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+Juan Miguel Arrazola, Alain Delgado, Josh Izaac, Soran Jahangiri, Maria Schuld

--- a/qchem/pennylane_qchem/_version.py
+++ b/qchem/pennylane_qchem/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.9.0-dev"
+__version__ = "0.10.0-dev"

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -678,7 +678,7 @@ def hf_state(n_electrons, m_spin_orbitals):
     if n_electrons > m_spin_orbitals:
         raise ValueError(
             "The number of active orbitals has to be >= the number of active electrons;"
-            " got 'm_orbitals'={} < 'n_electrons'={}".format(m_spin_orbitals, n_electrons)
+            " got 'm_spin_orbitals'={} < 'n_electrons'={}".format(m_spin_orbitals, n_electrons)
         )        
 
     hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -553,10 +553,13 @@ def generate_hamiltonian(
     )
 
     docc_indices, active_indices = active_space(
-        mol_name, hf_data, n_active_electrons, n_active_orbitals)
+        mol_name, hf_data, n_active_electrons, n_active_orbitals
+    )
 
-    h_of, nr_qubits = decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices,
-                                           active_indices), 2 * len(active_indices)
+    h_of, nr_qubits = (
+        decompose_hamiltonian(mol_name, hf_data, mapping, docc_indices, active_indices),
+        2 * len(active_indices),
+    )
 
     return convert_hamiltonian(h_of), nr_qubits
 
@@ -611,14 +614,14 @@ def sd_excitations(n_electrons, n_orbitals, delta_sz=0):
     if n_orbitals <= n_electrons:
         raise ValueError(
             "The number of active orbitals ({}) "
-            "has to be greater than the number of active electrons ({})."
-            .format(n_orbitals, n_electrons)
+            "has to be greater than the number of active electrons ({}).".format(
+                n_orbitals, n_electrons
+            )
         )
 
     if delta_sz not in (0, 1, -1, 2, -2):
         raise ValueError(
-            "Expected values for 'delta_sz' are 0, +/- 1 and +/- 2 but got ({})."
-             .format(delta_sz)
+            "Expected values for 'delta_sz' are 0, +/- 1 and +/- 2 but got ({}).".format(delta_sz)
         )
 
     # define the single-particle state spin quantum number 'sz'
@@ -626,17 +629,20 @@ def sd_excitations(n_electrons, n_orbitals, delta_sz=0):
 
     # nested list with the indices 'p, r' for each 1particle-1hole (ph) configuration
     ph = [
-           [r, p] 
-           for r in range(n_electrons) for p in range(n_electrons, n_orbitals)
-           if sz[p]-sz[r] == delta_sz
+        [r, p]
+        for r in range(n_electrons)
+        for p in range(n_electrons, n_orbitals)
+        if sz[p] - sz[r] == delta_sz
     ]
 
     # nested list with the indices 's, r, q, p' for each 2particle-2hole (pphh) configuration
     pphh = [
-             [s, r, q, p] 
-             for s in range(n_electrons-1) for r in range(s+1, n_electrons)
-             for q in range(n_electrons, n_orbitals-1) for p in range(q+1, n_orbitals)
-             if (sz[p] + sz[q] - sz[r] - sz[s]) == delta_sz
+        [s, r, q, p]
+        for s in range(n_electrons - 1)
+        for r in range(s + 1, n_electrons)
+        for q in range(n_electrons, n_orbitals - 1)
+        for p in range(q + 1, n_orbitals)
+        if (sz[p] + sz[q] - sz[r] - sz[s]) == delta_sz
     ]
 
     return ph, pphh
@@ -670,15 +676,16 @@ def hf_state(n_electrons, m_spin_orbitals):
 
     if n_electrons <= 0:
         raise ValueError(
-            "The number of active electrons has to be larger than zero; got 'n_electrons' = {}"
-            .format(n_electrons)
+            "The number of active electrons has to be larger than zero; got 'n_electrons' = {}".format(
+                n_electrons
+            )
         )
 
     if n_electrons > m_spin_orbitals:
         raise ValueError(
             "The number of active orbitals cannot be smaller than the number of active electrons;"
             " got 'm_spin_orbitals'={} < 'n_electrons'={}".format(m_spin_orbitals, n_electrons)
-        )        
+        )
 
     hf_state_on = np.where(np.arange(m_spin_orbitals) < n_electrons, 1, 0)
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -646,7 +646,7 @@ def hf_state(n_electrons, m_spin_orbitals):
     r"""Represents the Hartree-Fock (HF) state of :math:`N` electrons by an occupation-
     number vector in a basis of :math:`M` spin orbitals.
 
-    The many-particle wave functon in the HF approximation simplifies to a Slater determinant:
+    The many-particle wave functon in the HF approximation is a Slater determinant:
 
     .. math:
         \Phi({\bf x}_1, {\bf x}_2, \dots ,{\bf x}_N) = \left|\begin{array}{cccc}

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -643,12 +643,12 @@ def sd_excitations(n_electrons, n_orbitals, delta_sz=0):
 
 
 def hf_state(n_electrons, m_spin_orbitals):
-    r"""Represents the Hartree-Fock (HF) state of :math:`N` electrons by an occupation-
-    number vector in a basis of :math:`M` spin orbitals.
+    r"""Generates the occupation-number vector representing the Hartree-Fock (HF)
+    state of :math:`N` electrons in a basis of :math:`M` spin orbitals.
 
     The many-particle wave function in the HF approximation is a `Slater determinant
-    <https://en.wikipedia.org/wiki/Slater_determinant>`_. In Fock space, a Slater determinant is
-    represented by the occupation-number vector:
+    <https://en.wikipedia.org/wiki/Slater_determinant>`_. In Fock space, a Slater determinant
+    is represented by the occupation-number vector:
 
     .. math:
         \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -653,7 +653,7 @@ def hf_state(n_electrons, m_spin_orbitals):
     .. math:
         \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,
 
-        n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N_e \\ 0 & i > N_e \end{array} \right..
+        n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N \\ 0 & i > N \end{array} \right..
 
     **Example**
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -646,17 +646,9 @@ def hf_state(n_electrons, m_spin_orbitals):
     r"""Represents the Hartree-Fock (HF) state of :math:`N` electrons by an occupation-
     number vector in a basis of :math:`M` spin orbitals.
 
-    The many-particle wave functon in the HF approximation is a Slater determinant:
-
-    .. math:
-        \Phi({\bf x}_1, {\bf x}_2, \dots ,{\bf x}_N) = \left|\begin{array}{cccc}
-        \varphi_1({\bf x}_1) & \varphi_2({\bf x}_1) & \cdots & \varphi_N({\bf x}_1) \\
-        \varphi_1({\bf x}_2) & \varphi_2({\bf x}_2) & \cdots & \varphi_N({\bf x}_2) \\
-        \vdots               & \vdots               & \ddots & \vdots            \\
-        \varphi_1({\bf x}_N) & \varphi_2({\bf x}_N) & \cdots & \varphi_N({\bf x}_N),
-
-	where :math:`\varphi_i` denotes the single-particle wave function of the :math:`ith` HF
-	orbital. In Fock space, this determinant is represented by an occupation-number vector:
+    The many-particle wave function in the HF approximation is a `Slater determinant
+    <https://en.wikipedia.org/wiki/Slater_determinant>`_. In Fock space, a Slater determinant is
+    represented by the occupation-number vector:
 
     .. math:
         \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -639,7 +639,47 @@ def sd_excitations(n_electrons, n_orbitals, delta_sz=0):
              if (sz[p] + sz[q] - sz[r] - sz[s]) == delta_sz
     ]
 
-    return ph, pphh    
+    return ph, pphh
+
+
+def hf_state(n_electrons, m_spin_orbitals):
+    r"""Represents the Hartree-Fock (HF) state of :math:`N` electrons by an occupation-
+    number vector in a basis of :math:`M` spin orbitals.
+
+    The many-particle wave functon in the HF approximation simplifies to a Slater determinant:
+
+    .. math: 
+        \Phi({\bf x}_1, {\bf x}_2, \dots ,{\bf x}_N) = \left|\begin{array}{cccc}
+        \varphi_1({\bf x}_1) & \varphi_2({\bf x}_1) & \cdots & \varphi_N({\bf x}_1) \\
+        \varphi_1({\bf x}_2) & \varphi_2({\bf x}_2) & \cdots & \varphi_N({\bf x}_2) \\
+        \vdots               & \vdots               & \ddots & \vdots            \\
+        \varphi_1({\bf x}_N) & \varphi_2({\bf x}_N) & \cdots & \varphi_N({\bf x}_N),
+
+	where :math:`\varphi_i` denotes the single-particle wave function of the :math:`ith` HF 
+	orbital. In Fock space, this determinant is represented by an occupation-number vector:
+
+    .. math: 
+        \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,
+
+        n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N_e \\ 0 & i > N_e \end{array} \right..
+
+    **Example**
+
+    >>> init_state = hf_state(2, 6)
+    >>> print(init_state)
+    [1 1 0 0 0 0]
+    
+    Args: 
+        n_electrons (int): number of electrons 
+        m_spin_orbitals (int): number of spin-orbitals
+
+    Returns:
+        array: NumPy array containing the vector :math:`{\bf n}`
+    """	
+
+	hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]
+
+	return np.array(hf_state_on)
 
 
 __all__ = [
@@ -653,4 +693,5 @@ __all__ = [
     "convert_hamiltonian",
     "generate_hamiltonian",
     "sd_excitations",
+    "hf_state",
 ]

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -648,17 +648,17 @@ def hf_state(n_electrons, m_spin_orbitals):
 
     The many-particle wave functon in the HF approximation simplifies to a Slater determinant:
 
-    .. math: 
+    .. math:
         \Phi({\bf x}_1, {\bf x}_2, \dots ,{\bf x}_N) = \left|\begin{array}{cccc}
         \varphi_1({\bf x}_1) & \varphi_2({\bf x}_1) & \cdots & \varphi_N({\bf x}_1) \\
         \varphi_1({\bf x}_2) & \varphi_2({\bf x}_2) & \cdots & \varphi_N({\bf x}_2) \\
         \vdots               & \vdots               & \ddots & \vdots            \\
         \varphi_1({\bf x}_N) & \varphi_2({\bf x}_N) & \cdots & \varphi_N({\bf x}_N),
 
-	where :math:`\varphi_i` denotes the single-particle wave function of the :math:`ith` HF 
+	where :math:`\varphi_i` denotes the single-particle wave function of the :math:`ith` HF
 	orbital. In Fock space, this determinant is represented by an occupation-number vector:
 
-    .. math: 
+    .. math:
         \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,
 
         n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N_e \\ 0 & i > N_e \end{array} \right..
@@ -668,18 +668,18 @@ def hf_state(n_electrons, m_spin_orbitals):
     >>> init_state = hf_state(2, 6)
     >>> print(init_state)
     [1 1 0 0 0 0]
-    
-    Args: 
-        n_electrons (int): number of electrons 
+
+    Args:
+        n_electrons (int): number of electrons
         m_spin_orbitals (int): number of spin-orbitals
 
     Returns:
         array: NumPy array containing the vector :math:`{\bf n}`
-    """	
+    """
 
-	hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]
+    hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]
 
-	return np.array(hf_state_on)
+    return np.array(hf_state_on)
 
 
 __all__ = [

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -662,12 +662,24 @@ def hf_state(n_electrons, m_spin_orbitals):
     [1 1 0 0 0 0]
 
     Args:
-        n_electrons (int): number of electrons
-        m_spin_orbitals (int): number of spin-orbitals
+        n_electrons (int): number of active electrons
+        m_spin_orbitals (int): number of active **spin-orbitals**
 
     Returns:
-        array: NumPy array containing the vector :math:`{\bf n}`
+        array: NumPy array containing the vector :math:`\vert {\bf n} \rangle`
     """
+
+    if not n_electrons > 0:
+        raise ValueError(
+            "The number of active electrons has to be > 0; got 'n_electrons' = {}"
+            .format(n_electrons)
+        )
+
+    if n_electrons > m_orbitals:
+        raise ValueError(
+            "The number of active orbitals has to be >= the number of active electrons;"
+            " got 'm_orbitals'={} < 'n_electrons'={}".format(m_orbitals, n_electrons)
+        )        
 
     hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -675,10 +675,10 @@ def hf_state(n_electrons, m_spin_orbitals):
             .format(n_electrons)
         )
 
-    if n_electrons > m_orbitals:
+    if n_electrons > m_spin_orbitals:
         raise ValueError(
             "The number of active orbitals has to be >= the number of active electrons;"
-            " got 'm_orbitals'={} < 'n_electrons'={}".format(m_orbitals, n_electrons)
+            " got 'm_orbitals'={} < 'n_electrons'={}".format(m_spin_orbitals, n_electrons)
         )        
 
     hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -652,8 +652,7 @@ def hf_state(n_electrons, m_spin_orbitals):
 
     .. math:
         \vert {\bf n} \rangle = \vert n_1, n_2, \dots, n_M \rangle,
-
-        n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N \\ 0 & i > N \end{array} \right..
+        n_i = \left\lbrace \begin{array}{ll} 1 & i \leq N \\ 0 & i > N \end{array} \right.
 
     **Example**
 
@@ -669,19 +668,19 @@ def hf_state(n_electrons, m_spin_orbitals):
         array: NumPy array containing the vector :math:`\vert {\bf n} \rangle`
     """
 
-    if not n_electrons > 0:
+    if n_electrons <= 0:
         raise ValueError(
-            "The number of active electrons has to be > 0; got 'n_electrons' = {}"
+            "The number of active electrons has to be larger than zero; got 'n_electrons' = {}"
             .format(n_electrons)
         )
 
     if n_electrons > m_spin_orbitals:
         raise ValueError(
-            "The number of active orbitals has to be >= the number of active electrons;"
+            "The number of active orbitals cannot be smaller than the number of active electrons;"
             " got 'm_spin_orbitals'={} < 'n_electrons'={}".format(m_spin_orbitals, n_electrons)
         )        
 
-    hf_state_on = [1 if i < n_electrons else 0 for i in range(m_spin_orbitals)]
+    hf_state_on = np.where(np.arange(m_spin_orbitals) < n_electrons, 1, 0)
 
     return np.array(hf_state_on)
 

--- a/qchem/tests/test_hf_state.py
+++ b/qchem/tests/test_hf_state.py
@@ -7,34 +7,34 @@ import pytest
 from pennylane import qchem
 
 @pytest.mark.parametrize(
-    ("n_electrons", "m_orbitals", "exp_init_state"),
+    ("n_electrons", "m_spin_orbitals", "exp_init_state"),
     [
         (2, 5, np.array([1, 1, 0, 0, 0])),
         (1, 5, np.array([1, 0, 0, 0, 0])),
         (5, 5, np.array([1, 1, 1, 1, 1]))
     ]
 )
-def test_hf_state(n_electrons, m_orbitals, exp_init_state):
+def test_hf_state(n_electrons, m_spin_orbitals, exp_init_state):
 
     r"""Test the correctness of the generated occupation-number vector"""
 
-    res_init_state = qchem.hf_state(n_electrons, m_orbitals)
+    res_init_state = qchem.hf_state(n_electrons, m_spin_orbitals)
 
     assert len(res_init_state) == len(exp_init_state)
     assert np.allclose(res_init_state, exp_init_state)
 
 
 @pytest.mark.parametrize(
-    ("n_electrons", "m_orbitals", "msg_match"),
+    ("n_electrons", "m_spin_orbitals", "msg_match"),
     [
         ( 0, 5, "number of active electrons has to be > 0"),
         (-1, 5, "number of active electrons has to be > 0"),
         ( 6, 5, "number of active orbitals has to be >= the number of active electrons"),
     ]
 )
-def test_inconsistent_input(n_electrons, m_orbitals, msg_match):
+def test_inconsistent_input(n_electrons, m_spin_orbitals, msg_match):
 
     r"""Test that an error is raised if a set of inconsistent arguments is input"""
 
     with pytest.raises(ValueError, match=msg_match):
-        qchem.hf_state(n_electrons, m_orbitals)
+        qchem.hf_state(n_electrons, m_spin_orbitals)

--- a/qchem/tests/test_hf_state.py
+++ b/qchem/tests/test_hf_state.py
@@ -25,9 +25,9 @@ def test_hf_state(n_electrons, m_spin_orbitals, exp_init_state):
 @pytest.mark.parametrize(
     ("n_electrons", "m_spin_orbitals", "msg_match"),
     [
-        (0, 5, "number of active electrons has to be > 0"),
-        (-1, 5, "number of active electrons has to be > 0"),
-        (6, 5, "number of active orbitals has to be >= the number of active electrons"),
+        (0, 5, "number of active electrons has to be larger than zero"),
+        (-1, 5, "number of active electrons has to be larger than zero"),
+        (6, 5, "number of active orbitals cannot be smaller than the number of active"),
     ]
 )
 def test_inconsistent_input(n_electrons, m_spin_orbitals, msg_match):

--- a/qchem/tests/test_hf_state.py
+++ b/qchem/tests/test_hf_state.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 
@@ -27,9 +25,9 @@ def test_hf_state(n_electrons, m_spin_orbitals, exp_init_state):
 @pytest.mark.parametrize(
     ("n_electrons", "m_spin_orbitals", "msg_match"),
     [
-        ( 0, 5, "number of active electrons has to be > 0"),
+        (0, 5, "number of active electrons has to be > 0"),
         (-1, 5, "number of active electrons has to be > 0"),
-        ( 6, 5, "number of active orbitals has to be >= the number of active electrons"),
+        (6, 5, "number of active orbitals has to be >= the number of active electrons"),
     ]
 )
 def test_inconsistent_input(n_electrons, m_spin_orbitals, msg_match):

--- a/qchem/tests/test_hf_state.py
+++ b/qchem/tests/test_hf_state.py
@@ -1,10 +1,10 @@
 import os
 
 import numpy as np
-
 import pytest
 
 from pennylane import qchem
+
 
 @pytest.mark.parametrize(
     ("n_electrons", "m_spin_orbitals", "exp_init_state"),

--- a/qchem/tests/test_hf_state.py
+++ b/qchem/tests/test_hf_state.py
@@ -1,0 +1,40 @@
+import os
+
+import numpy as np
+
+import pytest
+
+from pennylane import qchem
+
+@pytest.mark.parametrize(
+    ("n_electrons", "m_orbitals", "exp_init_state"),
+    [
+        (2, 5, np.array([1, 1, 0, 0, 0])),
+        (1, 5, np.array([1, 0, 0, 0, 0])),
+        (5, 5, np.array([1, 1, 1, 1, 1]))
+    ]
+)
+def test_hf_state(n_electrons, m_orbitals, exp_init_state):
+
+    r"""Test the correctness of the generated occupation-number vector"""
+
+    res_init_state = qchem.hf_state(n_electrons, m_orbitals)
+
+    assert len(res_init_state) == len(exp_init_state)
+    assert np.allclose(res_init_state, exp_init_state)
+
+
+@pytest.mark.parametrize(
+    ("n_electrons", "m_orbitals", "msg_match"),
+    [
+        ( 0, 5, "number of active electrons has to be > 0"),
+        (-1, 5, "number of active electrons has to be > 0"),
+        ( 6, 5, "number of active orbitals has to be >= the number of active electrons"),
+    ]
+)
+def test_inconsistent_input(n_electrons, m_orbitals, msg_match):
+
+    r"""Test that an error is raised if a set of inconsistent arguments is input"""
+
+    with pytest.raises(ValueError, match=msg_match):
+        qchem.hf_state(n_electrons, m_orbitals)


### PR DESCRIPTION
**Context:**
Initialization of the qubit states for QChem applications 

**Description of the Change:**
Add the function ``hf_state`` to ``qchem`` module to generate an array encoding the occupation-number representation of the Hartree-Fock (HF) state. 

**Benefits:**
This function allows to initialize the qubit register to encode the HF state, the typical starting point for quantum chemistry simulations. 
e.g.,
```
n_electrons = 2
m_orbitals = 4
init_state = hf_state(n_electrons, m_orbitals)
qml.BasisState(init_state, wires=wires)
```

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None