### PR TITLE
Fix passthru decomposition

### DIFF
--- a/pennylane/qnodes/passthru.py
+++ b/pennylane/qnodes/passthru.py
@@ -111,7 +111,6 @@ class PassthruQNode(BaseQNode):
                 pennylane.operation.Operator.do_check_domain = False
                 # generate the program queue by executing the quantum circuit function
                 res = self.func(*args, **kwargs)
-
             finally:
                 pennylane.operation.Operator.do_check_domain = True
 

--- a/pennylane/qnodes/passthru.py
+++ b/pennylane/qnodes/passthru.py
@@ -106,11 +106,12 @@ class PassthruQNode(BaseQNode):
                 pennylane.operation.Operator.do_check_domain = False
                 # generate the program queue by executing the quantum circuit function
                 res = self.func(*args, **kwargs)
+
+                # check the validity of the circuit
+                self._check_circuit(res)
             finally:
                 pennylane.operation.Operator.do_check_domain = True
 
-        # check the validity of the circuit
-        self._check_circuit(res)
         del self.queue
         del self.obs_queue
 

--- a/pennylane/qnodes/passthru.py
+++ b/pennylane/qnodes/passthru.py
@@ -106,6 +106,10 @@ class PassthruQNode(BaseQNode):
 
         # set up the context for Operator entry
         with self:
+            # use a try/finally block such that if any errors arise during
+            # checking, and the user manually catches the exception, the class
+            # attribute pennylane.operation.Operator.do_check_domain is
+            # properly reset to True
             try:
                 # turn off domain checking since PassthruQNode qfuncs can take any class as input
                 pennylane.operation.Operator.do_check_domain = False
@@ -114,12 +118,16 @@ class PassthruQNode(BaseQNode):
             finally:
                 pennylane.operation.Operator.do_check_domain = True
 
-        # check the validity of the circuit
-        # turn off domain checking, but outside of the context such that no
-        # queuing takes place (e.g. from decompositions)
-        pennylane.operation.Operator.do_check_domain = False
-        self._check_circuit(res)
-        pennylane.operation.Operator.do_check_domain = True
+        # use a try/finally block here too
+        try:
+            # check the validity of the circuit
+            # turn off domain checking, but outside of the context such that no
+            # queuing takes place (e.g. from decompositions)
+            pennylane.operation.Operator.do_check_domain = False
+            self._check_circuit(res)
+        finally:
+            pennylane.operation.Operator.do_check_domain = True
+
         del self.queue
         del self.obs_queue
 

--- a/pennylane/qnodes/passthru.py
+++ b/pennylane/qnodes/passthru.py
@@ -112,11 +112,15 @@ class PassthruQNode(BaseQNode):
                 # generate the program queue by executing the quantum circuit function
                 res = self.func(*args, **kwargs)
 
-                # check the validity of the circuit
-                self._check_circuit(res)
             finally:
                 pennylane.operation.Operator.do_check_domain = True
 
+        # check the validity of the circuit
+        # turn off domain checking, but outside of the context such that no
+        # queuing takes place (e.g. from decompositions)
+        pennylane.operation.Operator.do_check_domain = False
+        self._check_circuit(res)
+        pennylane.operation.Operator.do_check_domain = True
         del self.queue
         del self.obs_queue
 


### PR DESCRIPTION
**Context:**
The decompositions of operations raise an error within `PassthruQNode` (see #620).

**Description of the Change:**
Turned off domain checking for `PassthruQNode._check_circuit`, but outside of the context such that no queuing takes place (e.g. from decompositions)

**Benefits:**
* Solves #620
* The `"classical"` option can now be passed in the following `default_tensor_tf` test:
https://github.com/XanaduAI/pennylane/blob/f17ce4749416345c2ec172fb46f9b6c9cb839a85/tests/beta/test_default_tensor_tf.py#L682
As per this TODO:
https://github.com/XanaduAI/pennylane/blob/f17ce4749416345c2ec172fb46f9b6c9cb839a85/tests/beta/test_default_tensor_tf.py#L726

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
#620, For code quality: #630