### PR TITLE
Fix string representation of devices

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -68,10 +68,10 @@ class Device(abc.ABC):
 
     def __str__(self):
         """Verbose string representation."""
-        return "{}\nShort name: {}\nAPI version: {}\nPlugin version: {}\nAuthor: {}\nWires: {}\nShots: {}".format(
+        return "{}\nShort name: {}\nPackage: {}\nPlugin version: {}\nAuthor: {}\nWires: {}\nShots: {}".format(
             self.name,
             self.short_name,
-            self.pennylane_requires,
+            self.__module__.split(".")[0],
             self.version,
             self.author,
             self.num_wires,

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -62,12 +62,20 @@ class Device(abc.ABC):
 
     def __repr__(self):
         """String representation."""
-        return "{}.\nInstance: ".format(self.__module__, self.__class__.__name__, self.name)
+        return "<{} ({}, wires={}, shots={}) at {}>".format(
+            self.__class__.__name__, self.short_name, self.num_wires, self.shots, hex(id(self))
+        )
 
     def __str__(self):
         """Verbose string representation."""
-        return "{}\nName: \nAPI version: \nPlugin version: \nAuthor: ".format(
-            self.name, self.pennylane_requires, self.version, self.author
+        return "{}\nShort name: {}\nAPI version: {}\nPlugin version: {}\nAuthor: {}\nWires: {}\nShots: {}".format(
+            self.name,
+            self.short_name,
+            self.pennylane_requires,
+            self.version,
+            self.author,
+            self.num_wires,
+            self.shots,
         )
 
     @property

--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -62,8 +62,8 @@ class Device(abc.ABC):
 
     def __repr__(self):
         """String representation."""
-        return "<{} ({}, wires={}, shots={}) at {}>".format(
-            self.__class__.__name__, self.short_name, self.num_wires, self.shots, hex(id(self))
+        return "<{} device (wires={}, shots={}) at {}>".format(
+            self.__class__.__name__, self.num_wires, self.shots, hex(id(self))
         )
 
     def __str__(self):


### PR DESCRIPTION
**Context:** The existing `__str__()` and `__repr__()` methods of the abstract `Device` class were missing format parameters.

**Description of the Change:** Adds in string parameters.

Example:

```pycon
>>> import pennylane as qml
>>> dev1 = qml.device("qiskit.basicaer", wires=4)
>>> dev1
<BasicAerDevice (qiskit.basicaer, wires=4, shots=1024) at 0x7f05108a37f0>
>>> print(dev1)
Qiskit PennyLane plugin
Short name: qiskit.basicaer
Package: pennylane_qiskit
Plugin version: 0.9.0-dev
Author: Xanadu
Wires: 4
Shots: 1024
```

If a plugin developer wants to display additional plugin-specific information, they will need to manually define `__str__`. E.g., if the Qiskit device wants to display the provider information.

**Benefits:** Printing devices works as expected.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** Fixes #632 
