### PR TITLE
Rename the classical diff_method to backprop

### DIFF
--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -209,7 +209,7 @@ class DefaultTensorTF(DefaultTensor):
       tightly integrated with your TensorFlow computation:
 
       >>> dev = qml.device("default.tensor.tf", wires=1)
-      >>> @qml.qnode(dev, interface="tf", diff_method="classical")
+      >>> @qml.qnode(dev, interface="tf", diff_method="backprop")
       >>> def circuit(x):
       ...     qml.RX(x[1], wires=0)
       ...     qml.Rot(x[0], x[1], x[2], wires=0)

--- a/pennylane/qnodes/decorator.py
+++ b/pennylane/qnodes/decorator.py
@@ -25,7 +25,7 @@ from .passthru import PassthruQNode
 
 
 PARAMETER_SHIFT_QNODES = {"qubit": QubitQNode, "cv": CVQNode}
-ALLOWED_DIFF_METHODS = ("best", "classical", "device", "parameter-shift", "finite-diff")
+ALLOWED_DIFF_METHODS = ("best", "backprop", "device", "parameter-shift", "finite-diff")
 ALLOWED_INTERFACES = ("autograd", "numpy", "torch", "tf")
 
 
@@ -69,12 +69,12 @@ def _get_qnode_class(device, interface, diff_method):
             # parameter-shift analytic differentiation
             return PARAMETER_SHIFT_QNODES[model]
 
-    if diff_method == "classical":
+    if diff_method == "backprop":
         if allows_passthru:
             if interface != passthru_interface:
                 raise ValueError(
                     "Device {} only supports the {} interface when "
-                    "diff_method='classical'".format(device.short_name, passthru_interface)
+                    "diff_method='backprop'".format(device.short_name, passthru_interface)
                 )
             return PassthruQNode
 
@@ -189,7 +189,7 @@ def QNode(func, device, *, interface="autograd", mutable=True, diff_method="best
               device directly to compute the gradient if supported, otherwise will use
               the analytic parameter-shift rule where possible with finite-difference as a fallback.
 
-            * ``"classical"``: Use classical backpropagation. Only allowed on simulator
+            * ``"backprop"``: Use classical backpropagation. Only allowed on simulator
               devices that are classically end-to-end differentiable, for example
               :class:`default.tensor.tf <~.DefaultTensorTF>`. Note that the returned
               QNode can only be used with the machine learning framework supported
@@ -263,7 +263,7 @@ def qnode(device, *, interface="autograd", mutable=True, diff_method="best", **k
               device directly to compute the gradient if supported, otherwise will use
               the analytic parameter-shift rule where possible with finite-difference as a fallback.
 
-            * ``"classical"``: Use classical backpropagation. Only allowed on simulator
+            * ``"backprop"``: Use classical backpropagation. Only allowed on simulator
               devices that are classically end-to-end differentiable, for example
               :class:`default.tensor.tf <~.DefaultTensorTF>`. Note that the returned
               QNode can only be used with the machine learning framework supported

--- a/tests/beta/test_default_tensor_tf.py
+++ b/tests/beta/test_default_tensor_tf.py
@@ -718,7 +718,7 @@ class TestHybridInterfaceDeviceIntegration:
         return cost_fn
 
     @pytest.mark.parametrize("interface", ["tf"])
-    @pytest.mark.parametrize("diff_method", ["classical"])
+    @pytest.mark.parametrize("diff_method", ["backprop"])
     def test_tf_interface_classical_diff(self, cost_with_decomposition, interface, diff_method, tol):
         """Tests that the gradient of an arbitrary U3 gate (that gets
         decomposed) is correct using the TensorFlow interface and the classical
@@ -749,7 +749,7 @@ class TestHybridInterfaceDeviceIntegration:
         from torch.autograd import Variable
 
         interface = "torch"
-        diff_method = "classical"
+        diff_method = "backprop"
 
         params = Variable(torch.tensor(self.p), requires_grad=True)
 
@@ -774,7 +774,7 @@ class TestHybridInterfaceDeviceIntegration:
         """Tests that an error is raised if for the classical differentiation
         method when using the autograd interface"""
         interface = "autograd"
-        diff_method = "classical"
+        diff_method = "backprop"
 
         params = self.p
 

--- a/tests/beta/test_default_tensor_tf.py
+++ b/tests/beta/test_default_tensor_tf.py
@@ -767,7 +767,7 @@ class TestHybridInterfaceDeviceIntegration:
 
             return circuit(params[0], w=0)
 
-        with pytest.raises(ValueError, match="Device default.tensor.tf only supports the tf interface when diff_method='classical'"):
+        with pytest.raises(ValueError, match="Device default.tensor.tf only supports the tf interface when diff_method='backprop'"):
             res = cost_raising_error(params)
 
     def test_error_classical_diff_autograd(self, tol):
@@ -789,5 +789,5 @@ class TestHybridInterfaceDeviceIntegration:
 
             return circuit(params[0], w=0)
 
-        with pytest.raises(ValueError, match="Device default.tensor.tf only supports the tf interface when diff_method='classical'"):
+        with pytest.raises(ValueError, match="Device default.tensor.tf only supports the tf interface when diff_method='backprop'"):
             res = cost_raising_error(params)

--- a/tests/qnodes/test_qnode_decorator.py
+++ b/tests/qnodes/test_qnode_decorator.py
@@ -223,7 +223,7 @@ def test_classical_diff_method_unsupported():
     with pytest.raises(ValueError, match=r"device does not support native computations with "
             "autodifferentiation frameworks"):
 
-        @qnode(dev, diff_method="classical")
+        @qnode(dev, diff_method="backprop")
         def circuit(a):
             qml.RX(a, wires=0)
             return qml.expval(qml.PauliZ(wires=0))


### PR DESCRIPTION
**Description of the Change:** Renames `diff_method="classical"` to `"backprop"` 

**Benefits:** Better describes the differentiation method than "classical". Note that I have not updated the changelog, as this will cause a non-trivial clash with #634; I will update it there once merged in.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
