### PR TITLE
Rotosolve unflatten fix

### DIFF
--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -107,6 +107,7 @@ class RotoselectOptimizer:
             array: The new variable values :math:`x^{(t+1)}` as well as the new generators.
         """
         x_flat = np.fromiter(_flatten(x), dtype=float)
+        # wrap the objective function so that it accepts the flattened parameter array
         objective_fn_flat = lambda x_flat, gen: objective_fn(unflatten(x_flat, x), generators=gen)
 
         try:

--- a/pennylane/optimize/rotoselect.py
+++ b/pennylane/optimize/rotoselect.py
@@ -107,6 +107,7 @@ class RotoselectOptimizer:
             array: The new variable values :math:`x^{(t+1)}` as well as the new generators.
         """
         x_flat = np.fromiter(_flatten(x), dtype=float)
+        objective_fn_flat = lambda x_flat, gen: objective_fn(unflatten(x_flat, x), generators=gen)
 
         try:
             assert len(x_flat) == len(generators)
@@ -117,7 +118,7 @@ class RotoselectOptimizer:
 
         for d, _ in enumerate(x_flat):
             x_flat[d], generators[d] = self._find_optimal_generators(
-                objective_fn, x_flat, generators, d
+                objective_fn_flat, x_flat, generators, d
             )
 
         return unflatten(x_flat, x), generators

--- a/pennylane/optimize/rotosolve.py
+++ b/pennylane/optimize/rotosolve.py
@@ -90,9 +90,10 @@ class RotosolveOptimizer:
             array: The new variable values :math:`x^{(t+1)}`.
         """
         x_flat = np.fromiter(_flatten(x), dtype=float)
+        objective_fn_flat = lambda x_flat: objective_fn(unflatten(x_flat, x))
 
         for d, _ in enumerate(x_flat):
-            x_flat = self._rotosolve(objective_fn, x_flat, d)
+            x_flat = self._rotosolve(objective_fn_flat, x_flat, d)
 
         return unflatten(x_flat, x)
 

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -476,9 +476,9 @@ class TestOptimizer:
             x = np.array([x])
 
         # helper function for x[d] = theta
-        def insert(x, d, theta):
-            x[d] = theta
-            return x
+        def insert(xf, d, theta):
+            xf[d] = theta
+            return xf
 
         for d, _ in enumerate(x):
             H_0 = float(f(insert(x, d, 0)))
@@ -509,28 +509,36 @@ class TestOptimizer:
 
             assert x_twosteps == pytest.approx(x_twosteps_target, abs=tol)
 
-    def test_rotosolve_optimizer_multivar(self, bunch, tol):
+    @pytest.mark.parametrize('x_start', [[1.2, 0.2],
+                                         [-0.62, -2.1],
+                                         [0.05, 0.8],
+                                         [[0.3], [0.25]],
+                                         [[-0.6], [0.45]],
+                                         [[1.3], [-0.9]]])
+    def test_rotosolve_optimizer_multivar(self, x_start, bunch, tol):
         """Tests that rotosolve optimizer takes one and two steps correctly
         for multi-variate functions."""
 
-        for f in multivariate_funcs:
-            for jdx in range(len(x_vals[:-1])):
-                x_vec = x_vals[jdx:jdx + 2]
+        for func in multivariate_funcs:
+            # alter multivariate_func to accpt nested list
+            f = lambda x: func(np.ravel(x))
 
-                x_onestep = bunch.rotosolve_opt.step(f, x_vec)
-                x_onestep_target = self.rotosolve_step(f, x_vec)
+            x_onestep = bunch.rotosolve_opt.step(f, x_start)
+            x_onestep_target = self.rotosolve_step(f, x_start)
 
-                assert x_onestep == pytest.approx(x_onestep_target, abs=tol)
+            assert x_onestep == pytest.approx(x_onestep_target, abs=tol)
 
-                x_twosteps = bunch.rotosolve_opt.step(f, x_onestep)
-                x_twosteps_target = self.rotosolve_step(f, x_onestep_target)
+            x_twosteps = bunch.rotosolve_opt.step(f, x_onestep)
+            x_twosteps_target = self.rotosolve_step(f, x_onestep_target)
 
-                assert x_twosteps == pytest.approx(x_twosteps_target, abs=tol)
+            assert x_twosteps == pytest.approx(x_twosteps_target, abs=tol)
 
-    @pytest.mark.parametrize('x_start', [[0.3, 0.25], [-0.6, 0.45], [1.3, -0.9]])
+    @pytest.mark.parametrize('x_start', [[1.2, 0.2],
+                                         [-0.62, -2.1],
+                                         [0.05, 0.8]])
     @pytest.mark.parametrize('generators', [list(tup) for tup in it.product([qml.RX, qml.RY, qml.RZ], repeat=2)])
     def test_rotoselect_optimizer(self, x_start, generators, bunch, tol):
-        """Tests that rotoselect optimizer takes one and two steps correctly for the VQE circuit
+        """Tests that rotoselect optimizer finds the optimal generators and parameters for the VQE circuit
         defined in `this rotoselect tutorial <https://pennylane.ai/qml/demos/tutorial_rotoselect.html>`_."""
 
         # the optimal generators for the 2-qubit VQE circuit
@@ -557,23 +565,21 @@ class TestOptimizer:
             return qml.expval(qml.PauliX(0))
 
         def cost_fn(params, generators):
-            # test single parameter inputs
-            if np.ndim(params) == 1:
-                params = [params[0], params[0]]
             Z_1, Y_2 = circuit_1(params, generators=generators)
             X_1 = circuit_2(params, generators=generators)
             return 0.5 * Y_2 + 0.8 * Z_1 - 0.2 * X_1
 
-        x_onestep, generators = bunch.rotoselect_opt.step(cost_fn, x_start, generators)
-        f_best_gen = lambda x: cost_fn(x, generators=optimal_generators)
-        x_onestep_target = self.rotosolve_step(f_best_gen, x_start)
+        f_best_gen = lambda x: cost_fn(x, optimal_generators)
+        optimal_x_start = x_start.copy()
 
-        assert x_onestep == pytest.approx(x_onestep_target, abs=tol)
+        # after four steps the optimzer should find the optimal generators/x_start values
+        for _ in range(4):
+            x_start, generators = bunch.rotoselect_opt.step(cost_fn, x_start, generators)
+            optimal_x_start = self.rotosolve_step(f_best_gen, optimal_x_start)
 
-        x_twosteps, generators = bunch.rotoselect_opt.step(cost_fn, x_onestep, generators)
-        x_twosteps_target = self.rotosolve_step(f_best_gen, x_onestep_target)
+        assert x_start == pytest.approx(optimal_x_start, abs=tol)
+        assert generators == optimal_generators
 
-        assert x_twosteps == pytest.approx(x_twosteps_target, abs=tol)
 
     def test_update_stepsize(self):
         """Tests that the stepsize correctly updates"""

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -520,7 +520,7 @@ class TestOptimizer:
         for multi-variate functions."""
 
         for func in multivariate_funcs:
-            # alter multivariate_func to accpt nested list
+            # alter multivariate_func to accept nested lists of parameters
             f = lambda x: func(np.ravel(x))
 
             x_onestep = bunch.rotosolve_opt.step(f, x_start)


### PR DESCRIPTION
**Context:**
The Rotosolve and Rotoselect optimisers do not work properly with nested weights; throwing an `IndexError: too many indices for array`, in, e.g., this case:

```python
import numpy as np
import pennylane as qml

weights = np.random.random(size=(2, 1))
dev_qubit = qml.device('default.qubit', wires=1)

@qml.qnode(dev_qubit)
def circuit(weights):
    qml.RX(weights[0, 0], wires=0)
    qml.RX(weights[1, 0], wires=0)
    return qml.expval(qml.PauliZ(wires=0))

opt = qml.RotosolveOptimizer()

weights = opt.step(lambda w: circuit(w), weights)
```

**Description of the Change:**
The Rotosolve and Rotoselect optimisers are updated to support nested arrays/lists for input weights. Furthermore, the corresponding tests are updated to test this. They are also fixed so that they work properly (I found some errors in the testing procedure).

**Benefits:**
It's possible to use nested weights for the cost function to use with the optimisers.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
