### PR TITLE
Officially remove Python 3.5 support, update TF1.X support to >=1.15

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 <h3>Breaking changes</h3>
 
+* Removes support for Python 3.5.
+  [(#639)](https://github.com/XanaduAI/pennylane/pull/639)
+
 <h3>Documentation</h3>
 
 <h3>Bug fixes</h3>

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ install:
 - pip install wheel pytest pytest-cov absl-py --upgrade
 - if [ "$TF" = "2" ]; then pip install tensorflow==2.2; fi
 - if [ "$TF" = "1" ]; then pip install tensorflow==1.15; fi
-- if [ "$TORCH" = "1" ]; pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html; fi
+- if [ "$TORCH" = "1" ]; then pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html; fi
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ matrix:
     env: TF=2
   - python: 3.6
     dist: xenial
-    env: TF=2
-  - python: 3.5
-    dist: xenial
     env: TF=1
   - python: 3.7
     dist: xenial
@@ -30,8 +27,8 @@ env:
 install:
 - pip install -r requirements.txt
 - pip install wheel pytest pytest-cov absl-py --upgrade
-- if [ "$TF" = "2" ]; then pip install tensorflow==2.1; fi
-- if [ "$TF" = "1" ]; then pip install tensorflow==1.13.2; fi
+- if [ "$TF" = "2" ]; then pip install tensorflow==2.2; fi
+- if [ "$TF" = "1" ]; then pip install tensorflow==1.15; fi
 - pip install torch==1.5.0+cpu torchvision==0.6.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 - python3 setup.py bdist_wheel
 - pip install dist/PennyLane*.whl

--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ For a full list of PennyLane plugins, see `the PennyLane website <https://pennyl
 Installation
 ============
 
-PennyLane requires Python version 3.5 and above. Installation of PennyLane, as well
+PennyLane requires Python version 3.6 and above. Installation of PennyLane, as well
 as all dependencies, can be done using pip:
 
 .. code-block:: bash

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -6,7 +6,7 @@ Dependencies
 
 PennyLane requires the following libraries be installed:
 
-* `Python <http://python.org/>`_ >= 3.5
+* `Python <http://python.org/>`_ >= 3.6
 
 as well as the following Python packages:
 

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -48,7 +48,7 @@ requirements are required.
 
   This includes:
 
-  - If ``tf.__version__[0] == "1"``, running ``tf.executing_eagerly()``
+  - If ``tf.__version__[0] == "1"``, running ``tf.enable_eager_execution()``
     before execution.
 
   - Only using the ``tf.GradientTape`` context for gradient computation.

--- a/doc/development/guide/installation.rst
+++ b/doc/development/guide/installation.rst
@@ -37,7 +37,7 @@ requirements are required.
 
 * **PyTorch interface**: ``pytorch >= 1.1``
 
-* **TensorFlow interface**: ``tensorflow >= 1.12``
+* **TensorFlow interface**: ``tensorflow >= 1.15``
 
   Note that any version of TensorFlow supporting eager execution mode
   is supported, however there are slight differences between the eager
@@ -48,10 +48,8 @@ requirements are required.
 
   This includes:
 
-  - If ``tf.__version__[0] == "1"``, running ``tf.enable_eager_execution()``
-    before execution, and importing ``Variable`` from ``tensorflow.contrib.eager``.
-
-  - If ``tf.__version__[0] == "2"``, importing ``Variable`` from ``tensorflow``.
+  - If ``tf.__version__[0] == "1"``, running ``tf.executing_eagerly()``
+    before execution.
 
   - Only using the ``tf.GradientTape`` context for gradient computation.
 

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -23,12 +23,7 @@ from functools import partial
 import numpy as np
 import tensorflow as tf
 
-if tf.__version__[0] == "1":
-    import tensorflow.contrib.eager as tfe  # pylint: disable=unused-import,ungrouped-imports
-
-    Variable = tfe.Variable
-else:
-    from tensorflow import Variable  # pylint: disable=unused-import,ungrouped-imports
+from tensorflow import Variable  # pylint: disable=unused-import,ungrouped-imports
 
 
 def unflatten_tf(flat, model):

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 <h3>Breaking changes</h3>
 
+* Removes support for Python 3.5.
+  [(#639)](https://github.com/XanaduAI/pennylane/pull/639)
+
 <h3>Documentation</h3>
 
 <h3>Bug fixes</h3>

--- a/qchem/setup.py
+++ b/qchem/setup.py
@@ -44,8 +44,9 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3 :: Only",
     "Topic :: Scientific/Engineering :: Physics",
 ]

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',

--- a/tests/collections/conftest.py
+++ b/tests/collections/conftest.py
@@ -25,13 +25,9 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        print(tf.__version__)
-        import tensorflow.contrib.eager as tfe
+        tf.executing_eagerly()
 
-        tf.enable_eager_execution()
-        Variable = tfe.Variable
-    else:
-        from tensorflow import Variable
+    from tensorflow import Variable
 except ImportError as e:
     tf = None
     Variable = None

--- a/tests/collections/conftest.py
+++ b/tests/collections/conftest.py
@@ -25,7 +25,7 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        tf.executing_eagerly()
+        tf.enable_eager_execution()
 
     from tensorflow import Variable
 except ImportError as e:

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -25,9 +25,6 @@ from tensorflow import Variable
 if tf.__version__[0] == "1":
     tf.executing_eagerly()
 
-except ImportError as e:
-    pass
-
 import pennylane as qml
 
 from pennylane.qnodes import QuantumFunctionError

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -19,15 +19,11 @@ import pytest
 
 import numpy as np
 
-tf = pytest.importorskip("tensorflow", minversion="1.12")
+tf = pytest.importorskip("tensorflow", minversion="1.15")
+from tensorflow import Variable
 
-try:
-    if tf.__version__[0] == "1":
-        import tensorflow.contrib.eager as tfe
-        tf.enable_eager_execution()
-        Variable = tfe.Variable
-    else:
-        from tensorflow import Variable
+if tf.__version__[0] == "1":
+    tf.executing_eagerly()
 
 except ImportError as e:
     pass
@@ -44,7 +40,6 @@ def expZ(state):
     return np.abs(state[0]) ** 2 - np.abs(state[1]) ** 2
 
 
-@pytest.mark.usefixtures("skip_if_no_tf_support")
 class TestTFQNodeExceptions():
     """TFQNode basic tests."""
 
@@ -153,7 +148,6 @@ class TestTFQNodeExceptions():
             qf(Variable(0.5))
 
 
-@pytest.mark.usefixtures("skip_if_no_tf_support")
 class TestTFQNodeParameterHandling:
     """Test that the TFQNode properly handles the parameters of qfuncs"""
 
@@ -458,7 +452,6 @@ class TestTFQNodeParameterHandling:
         assert np.allclose(grads, -expected_grad, atol=tol, rtol=0)
 
 
-@pytest.mark.usefixtures("skip_if_no_tf_support")
 class TestIntegration:
     """Integration tests to ensure the TensorFlow QNode agrees with the NumPy QNode"""
 
@@ -550,7 +543,6 @@ gradient_test_data = [
 ]
 
 
-@pytest.mark.usefixtures("skip_if_no_tf_support")
 class TestTFGradients:
     """Integration tests involving gradients of QNodes and hybrid computations using the tf interface"""
 

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -23,7 +23,7 @@ tf = pytest.importorskip("tensorflow", minversion="1.15")
 from tensorflow import Variable
 
 if tf.__version__[0] == "1":
-    tf.executing_eagerly()
+    tf.enable_eager_execution()
 
 import pennylane as qml
 

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -19,7 +19,7 @@ import pytest
 
 import numpy as np
 
-tf = pytest.importorskip("tensorflow", minversion="1.1")
+torch = pytest.importorskip("torch", minversion="1.1")
 from torch.autograd import Variable
 
 import pennylane as qml

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -19,11 +19,8 @@ import pytest
 
 import numpy as np
 
-try:
-    import torch
-    from torch.autograd import Variable
-except ImportError as e:
-    pass
+tf = pytest.importorskip("tensorflow", minversion="1.1")
+from torch.autograd import Variable
 
 import pennylane as qml
 
@@ -38,7 +35,6 @@ def expZ(state):
     return np.abs(state[0]) ** 2 - np.abs(state[1]) ** 2
 
 
-@pytest.mark.usefixtures("skip_if_no_torch_support")
 class TestTorchQNodeExceptions():
     """TorchQNode basic tests."""
 
@@ -147,7 +143,6 @@ class TestTorchQNodeExceptions():
             qf(torch.tensor(0.5))
 
 
-@pytest.mark.usefixtures("skip_if_no_torch_support")
 class TestTorchQNodeParameterHandling:
     """Test that the TorchQNode properly handles the parameters of qfuncs"""
 
@@ -456,7 +451,6 @@ class TestTorchQNodeParameterHandling:
         assert np.allclose(y_t.grad.numpy(), [-np.sin(y)*np.cos(x)], atol=tol, rtol=0)
 
 
-@pytest.mark.usefixtures("skip_if_no_torch_support")
 class TestIntegration():
     """Integration tests to ensure the Torch QNode agrees with the NumPy QNode"""
 
@@ -532,7 +526,6 @@ gradient_test_data = [
 ]
 
 
-@pytest.mark.usefixtures("skip_if_no_torch_support")
 class TestTorchGradients:
     """Integration tests involving gradients of QNodes and hybrid computations using the torch interface"""
 

--- a/tests/templates/test_integration.py
+++ b/tests/templates/test_integration.py
@@ -53,12 +53,9 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        import tensorflow.contrib.eager as tfe
+        tf.executing_eagerly()
 
-        tf.enable_eager_execution()
-        TFVariable = tfe.Variable
-    else:
-        from tensorflow import Variable as TFVariable
+    from tensorflow import Variable as TFVariable
     INTERFACES.append(('tf', TFVariable))
 
 except ImportError as e:

--- a/tests/templates/test_integration.py
+++ b/tests/templates/test_integration.py
@@ -53,7 +53,7 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        tf.executing_eagerly()
+        tf.enable_eager_execution()
 
     from tensorflow import Variable as TFVariable
     INTERFACES.append(('tf', TFVariable))

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -25,9 +25,6 @@ import pennylane as qml
 from pennylane import Configuration
 
 
-pytestmark = pytest.mark.skipif(sys.version_info < (3, 6), reason="tmpdir fixture requires Python 3.6 or higher")
-
-
 log.getLogger('defaults')
 
 
@@ -149,8 +146,7 @@ class TestConfigurationFileInteraction:
         # make a change
         config['strawberryfields.global']['shots'] = 10
 
-        # Need to convert to string for Python 3.5 compatibility
-        temp_config_path = str(tmp_path / 'test_config.toml')
+        temp_config_path = tmp_path / 'test_config.toml'
         config.save(temp_config_path)
 
         result = toml.load(temp_config_path)

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -29,12 +29,10 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        print(tf.__version__)
         import tensorflow.contrib.eager as tfe
-        tf.enable_eager_execution()
-        Variable = tfe.Variable
-    else:
-        from tensorflow import Variable
+        tf.executing_eagerly()
+
+    from tensorflow import Variable
 except ImportError as e:
     pass
 

--- a/tests/test_vqe.py
+++ b/tests/test_vqe.py
@@ -29,8 +29,7 @@ try:
     import tensorflow as tf
 
     if tf.__version__[0] == "1":
-        import tensorflow.contrib.eager as tfe
-        tf.executing_eagerly()
+        tf.enable_eager_execution()
 
     from tensorflow import Variable
 except ImportError as e:


### PR DESCRIPTION
**Context:** Python 3.5 reaches end of life [2020-09-13](https://devguide.python.org/#status-of-python-branches), and several other big Python frameworks (including [NumPy](https://numpy.org/neps/nep-0029-deprecation_policy.html)) have deprecated Python 3.5 support.

In addition, by dropping Python 3.5 support, we can now increase our TF1 support from 1.13 (the highest version support on Python 3.5) to TF 1.15, which is significantly more compatible with TF2 and will ease maintenance.

**Description of the Change:**

* Deprecates official Python 3.5 support, and removes Python 3.5 from the Travis build matrix.

* Increases minimum TensorFlow version from 1.13 to 1.15.

**Benefits:**

We can now use features introduced in Python 3.6, including:

* f-strings:
  ```pycon
  >>> name = "Fred"
  >>> f"He said his name is {name}."
  'He said his name is Fred.'
  ```

* Type hinting of variables:
  ```python
   stats: Dict[str, int] = {"hello": 5}
   ```

* Underscores in numeric literals:
  ```pycon
  >>> 1_000_000_000_000_000
  1000000000000000
  ```

* TensorFlow 1.15 is more compatible with TF2. For example, `tf.contrib.eager.Variable` has been moved to `tf.Variable`, as in TF2.

**Possible Drawbacks:**

* Those on Python 3.5 will be limited to PennyLane v0.9

* The change to Python 3.6 and TF1.15 needed to be made simultaneously.

**Related GitHub Issues:** n/a
