### PR TITLE
change require wires in docstrin

### DIFF
--- a/pennylane/templates/state_preparations/arbitrary_state_preparation.py
+++ b/pennylane/templates/state_preparations/arbitrary_state_preparation.py
@@ -68,7 +68,7 @@ def ArbitraryStatePreparation(weights, wires):
             return qml.expval(qml.Hermitian(H, wires=[0, 1, 2, 3]))
 
     Args:
-        weights (array[float]): The angles of the Pauli word rotations, needs to have length :math:`2^n - 2`
+        weights (array[float]): The angles of the Pauli word rotations, needs to have length :math:`2^(n+1) - 2`
             where :math:`n` is the number of wires the template acts upon.
         wires (List[int]): The wires on which the arbitrary unitary acts.
     """


### PR DESCRIPTION
**Context:**

There seems to be a bug in the docstring of the ``ArbitraryStatePreparation`` template, which says that 2^n-2 weights are expected, while the template needs (and checks for) 2^(n+1)-2.

**Description of the Change:** Adapt docstring.

