### PR TITLE
Fix bug in the functions "test_single_ex_unitary_operations" and "test_double_ex_unitary_operations"

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -371,7 +371,7 @@ Thomas Bromley, Alain Delgado Gran, Josh Izaac, Nicola Vitucci
 
 <h3>Improvements</h3>
 
-* A new `Wires` class was introduced for the internal
+* A new `Wires` class was introduced for the internal 
   bookkeeping of wire indices.
   [(#615)](https://github.com/XanaduAI/pennylane/pull/615)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -85,6 +85,11 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes a bug in the unit tests ``test_single_ex_unitary_operations`` and
+  ``test_double_ex_unitary_operations`` in order to test the correctness of the
+  entire set of quantum gates applied for building the UCCSD ansatz.
+  [(#659)](https://github.com/XanaduAI/pennylane/pull/659)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -31,11 +31,13 @@
   exponentiate the Coupled-Cluster double excitation operator. This template is required to
   build the Unitary Coupled-Cluster Singles and Doubles (UCCSD) ansatz for VQE simulations.
   [(#638)](https://github.com/XanaduAI/pennylane/pull/638)
+  [(#659)](https://github.com/XanaduAI/pennylane/pull/659)
 
 * Contains the new template ``SingleExcitationUnitary`` implementing the quantum circuit to
   exponentiate the Coupled-Cluster single excitation operator. This template is required to
   build the Unitary Coupled-Cluster Singles and Doubles (UCCSD) ansatz for VQE simulations.
   [(#622)](https://github.com/XanaduAI/pennylane/pull/622)
+  [(#659)](https://github.com/XanaduAI/pennylane/pull/659)
 
 * Placeholder for variable/tensor refactor. So far this has included:
   [(#648)](https://github.com/XanaduAI/pennylane/pull/648)
@@ -84,11 +86,6 @@
 <h3>Documentation</h3>
 
 <h3>Bug fixes</h3>
-
-* Fixes a bug in the unit tests ``test_single_ex_unitary_operations`` and
-  ``test_double_ex_unitary_operations`` in order to test the correctness of the
-  entire set of quantum gates applied for building the UCCSD ansatz.
-  [(#659)](https://github.com/XanaduAI/pennylane/pull/659)
 
 <h3>Contributors</h3>
 
@@ -374,7 +371,7 @@ Thomas Bromley, Alain Delgado Gran, Josh Izaac, Nicola Vitucci
 
 <h3>Improvements</h3>
 
-* A new `Wires` class was introduced for the internal 
+* A new `Wires` class was introduced for the internal
   bookkeeping of wire indices.
   [(#615)](https://github.com/XanaduAI/pennylane/pull/615)
 

--- a/tests/templates/test_subroutines.py
+++ b/tests/templates/test_subroutines.py
@@ -562,7 +562,7 @@ class TestDoubleExcitationUnitary:
 
         assert len(rec.queue) == sqg + cnots
 
-        for i, gate in enumerate(ref_gates):
+        for gate in ref_gates:
             idx = gate[0]
 
             exp_gate = gate[1]

--- a/tests/templates/test_subroutines.py
+++ b/tests/templates/test_subroutines.py
@@ -369,21 +369,22 @@ class TestSingleExcitationUnitary:
         with qml.utils.OperationRecorder() as rec:
             SingleExcitationUnitary(weight, wires=ph)
 
-        idx = ref_gates[0][0]
+        assert len(rec.queue) == sqg + cnots            
 
-        exp_gate = ref_gates[0][1]
-        res_gate = rec.queue[idx]
+        for gate in ref_gates:
+            idx = gate[0]
 
-        exp_wires = ref_gates[0][2]
-        res_wires = rec.queue[idx]._wires
+            exp_gate = gate[1]
+            res_gate = rec.queue[idx]
+            assert isinstance(res_gate, exp_gate)
 
-        exp_weight = ref_gates[0][3]
-        res_weight = rec.queue[idx].parameters        
+            exp_wires = gate[2]
+            res_wires = rec.queue[idx]._wires
+            assert res_wires == exp_wires
 
-        assert len(rec.queue) == sqg + cnots
-        assert isinstance(res_gate, exp_gate) 
-        assert res_wires == exp_wires
-        assert res_weight == exp_weight
+            exp_weight = gate[3]
+            res_weight = rec.queue[idx].parameters
+            assert res_weight == exp_weight
 
     @pytest.mark.parametrize(
         ("weight", "ph", "msg_match"),
@@ -559,21 +560,22 @@ class TestDoubleExcitationUnitary:
         with qml.utils.OperationRecorder() as rec:
             DoubleExcitationUnitary(weight, wires=pphh)
 
-        idx = ref_gates[0][0]
-
-        exp_gate = ref_gates[0][1]
-        res_gate = rec.queue[idx]
-
-        exp_wires = ref_gates[0][2]
-        res_wires = rec.queue[idx]._wires
-
-        exp_weight = ref_gates[0][3]
-        res_weight = rec.queue[idx].parameters        
-
         assert len(rec.queue) == sqg + cnots
-        assert isinstance(res_gate, exp_gate) 
-        assert res_wires == exp_wires
-        assert res_weight == exp_weight
+
+        for i, gate in enumerate(ref_gates):
+            idx = gate[0]
+
+            exp_gate = gate[1]
+            res_gate = rec.queue[idx]
+            assert isinstance(res_gate, exp_gate)
+
+            exp_wires = gate[2]
+            res_wires = rec.queue[idx]._wires
+            assert res_wires == exp_wires
+
+            exp_weight = gate[3]
+            res_weight = rec.queue[idx].parameters
+            assert res_weight == exp_weight
 
     @pytest.mark.parametrize(
         ("weight", "pphh", "msg_match"),


### PR DESCRIPTION
**Context:**
This PR fixes a bug in the unit tests ``test_single_ex_unitary_operations`` and ``'test_double_ex_unitary_operations``. This is very simple fix but a very important one as it allows to test correctness of the entire set of quantum gates applied for building the UCCSD ansatz. 

**Description of the Change:**
Add a loop in functions ``test_single_ex_unitary_operations`` and ``test_double_ex_unitary_operations`` in the module ``test_subroutines.py``.

**Benefits:**
Improves significantly the robustness of the unit tests.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None