### PR TITLE
Adds Decompositions of Common Gates

### DIFF
--- a/pennylane/ops/qubit.py
+++ b/pennylane/ops/qubit.py
@@ -73,6 +73,11 @@ class Hadamard(Observable, Operation):
         """
         return [RY(-np.pi / 4, wires=self.wires)]
 
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RX(np.pi / 2, wires=wires), RZ(np.pi / 2, wires=wires)]
+        return decomp_ops
+
 
 class PauliX(Observable, Operation):
     r"""PauliX(wires)
@@ -115,6 +120,11 @@ class PauliX(Observable, Operation):
             computational basis.
         """
         return [Hadamard(wires=self.wires)]
+
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RX(np.pi, wires=wires)]
+        return decomp_ops
 
 
 class PauliY(Observable, Operation):
@@ -161,6 +171,11 @@ class PauliY(Observable, Operation):
         """
         return [PauliZ(wires=self.wires), S(wires=self.wires), Hadamard(wires=self.wires)]
 
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RY(np.pi, wires=wires)]
+        return decomp_ops
+
 
 class PauliZ(Observable, DiagonalOperation):
     r"""PauliZ(wires)
@@ -193,6 +208,11 @@ class PauliZ(Observable, DiagonalOperation):
     def diagonalizing_gates(self):
         return []
 
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RZ(np.pi, wires=wires)]
+        return decomp_ops
+
 
 class S(DiagonalOperation):
     r"""S(wires)
@@ -223,6 +243,11 @@ class S(DiagonalOperation):
     def _eigvals(cls, *params):
         return np.array([1, 1j])
 
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RZ(np.pi / 2, wires=wires)]
+        return decomp_ops
+
 
 class T(DiagonalOperation):
     r"""T(wires)
@@ -252,6 +277,11 @@ class T(DiagonalOperation):
     @classmethod
     def _eigvals(cls, *params):
         return np.array([1, cmath.exp(1j * np.pi / 4)])
+
+    @staticmethod
+    def decomposition(wires):
+        decomp_ops = [RZ(np.pi / 4, wires=wires)]
+        return decomp_ops
 
 
 class CNOT(Operation):

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -330,6 +330,76 @@ class TestOperations:
         res = op.matrix
         assert np.allclose(res, mat, atol=tol, rtol=0)
 
+    def test_x_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.PauliX(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 1
+
+        assert res[0].name == "RX"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi
+
+    def test_y_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.PauliY(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 1
+
+        assert res[0].name == "RY"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi
+
+    def test_z_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.PauliZ(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 1
+
+        assert res[0].name == "RZ"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi
+
+    def test_s_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.S(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 1
+
+        assert res[0].name == "RZ"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi / 2
+
+    def test_t_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.T(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 1
+
+        assert res[0].name == "RZ"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi / 4
+
+    def test_hadamard_decomposition(self, tol):
+        """Tests that the decomposition of the PauliX is correct"""
+        op = qml.Hadamard(wires=0)
+        res = op.decomposition(0)
+
+        assert len(res) == 2
+
+        assert res[0].name == "RX"
+        assert res[0].wires == [0]
+        assert res[0].params[0] == np.pi / 2
+
+        assert res[1].name == "RZ"
+        assert res[1].wires == [0]
+        assert res[0].params[0] == np.pi / 2
+
     def test_phase_shift(self, tol):
         """Test phase shift is correct"""
 
@@ -786,25 +856,31 @@ class TestPauliRot:
     def test_matrix_incorrect_pauli_word_error(self):
         """Test that _matrix throws an error if a wrong Pauli word is supplied."""
 
-        with pytest.raises(ValueError, match="The given Pauli word \".*\" contains characters that are not allowed." \
-            " Allowed characters are I, X, Y and Z"):
+        with pytest.raises(
+            ValueError,
+            match='The given Pauli word ".*" contains characters that are not allowed.'
+            " Allowed characters are I, X, Y and Z",
+        ):
             qml.PauliRot._matrix(0.3, "IXYZV")
 
     def test_init_incorrect_pauli_word_error(self):
         """Test that __init__ throws an error if a wrong Pauli word is supplied."""
 
-        with pytest.raises(ValueError, match="The given Pauli word \".*\" contains characters that are not allowed." \
-            " Allowed characters are I, X, Y and Z"):
+        with pytest.raises(
+            ValueError,
+            match='The given Pauli word ".*" contains characters that are not allowed.'
+            " Allowed characters are I, X, Y and Z",
+        ):
             qml.PauliRot(0.3, "IXYZV", wires=[0, 1, 2, 3, 4])
 
-    @pytest.mark.parametrize("pauli_word,wires", [
-        ("XYZ", [0, 1]),
-        ("XYZ", [0, 1, 2, 3]),
-    ])
+    @pytest.mark.parametrize("pauli_word,wires", [("XYZ", [0, 1]), ("XYZ", [0, 1, 2, 3]),])
     def test_init_incorrect_pauli_word_length_error(self, pauli_word, wires):
         """Test that __init__ throws an error if a Pauli word of wrong length is supplied."""
 
-        with pytest.raises(ValueError, match="The given Pauli word has length .*, length .* was expected for wires .*"):
+        with pytest.raises(
+            ValueError,
+            match="The given Pauli word has length .*, length .* was expected for wires .*",
+        ):
             qml.PauliRot(0.3, pauli_word, wires=wires)
 
 


### PR DESCRIPTION
**Context:**

https://github.com/XanaduAI/pennylane/issues/644

**Description of the Change:**

Adds `decomposition` method to PauliX, PauliY, PauliZ, S, T, and Hadamard gates, which decomposes each of these gates into a product of rotation gates.

**Benefits:**

Allows gate decompositions to take place within the PennyLane core, which is helpful when dealing with multiple plugins with multiple different gate sets.

**Possible Drawbacks:**

None.

**Related GitHub Issues:**

https://github.com/XanaduAI/pennylane/issues/644
