### PR TITLE
[WIRES] small tweaks to wires class

### DIFF
--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -124,7 +124,7 @@ class Wires(Sequence):
         return list(self.wire_tuple)
 
     def get_label(self, idx):
-        """Returns the wire representation at the given position in the wires object.
+        """Returns the wire label at the given position in the wires object.
 
         >>> w = Wires([0, 'q1', 16])
         >>> w.get_label(1)

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -129,7 +129,7 @@ class Wires(Sequence):
         >>> w = Wires([0, 'q1', 16])
         >>> w[1]
         'q1'
-        >>> w[2]
+        >>> w.at_index(2)
         16
 
         Args:

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -31,7 +31,7 @@ def _process(wires):
         # if input is already a Wires object, just return its wire tuple
         return wires.wire_tuple
 
-    elif isinstance(wires, Number) or isinstance(wires, str):
+    elif isinstance(wires, (Number, str)):
         # interpret as a single wire
         return (wires,)
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -136,7 +136,7 @@ class Wires(Sequence):
             int: index of wire to return
 
         Returns:
-            Number or str: representation of the wire
+            Number or str: label of the wire
         """
         return self.wire_tuple[idx]
 

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -31,6 +31,10 @@ def _process(wires):
         # if input is already a Wires object, just return its wire tuple
         return wires.wire_tuple
 
+    elif isinstance(wires, Number) or isinstance(wires, str):
+        # interpret as a single wire
+        return (wires,)
+
     elif isinstance(wires, Iterable) and all(isinstance(w, Wires) for w in wires):
         # if the elements are themselves Wires objects, merge them to a new one
         return tuple(w for wires_ in wires for w in wires_.tolist())
@@ -40,10 +44,6 @@ def _process(wires):
     ):
         # if the elements are strings or numbers, turn iterable into tuple
         return tuple(wires)
-
-    elif isinstance(wires, Number):
-        # if the input is a single number, interpret as a single wire
-        return (wires,)
 
     else:
         raise WireError(
@@ -122,6 +122,23 @@ class Wires(Sequence):
             List: list representing Wires object
         """
         return list(self.wire_tuple)
+
+    def at_index(self, idx):
+        """Returns the wire at index ``idx``.
+
+        >>> w = Wires([0, 'q1', 16])
+        >>> w[1]
+        'q1'
+        >>> w[2]
+        16
+
+        Args:
+            int: index of wire to return
+
+        Returns:
+            Number or str: representation of the wire
+        """
+        return self.wire_tuple[idx]
 
     def index(self, wire):
         """Overwrites a Sequence's ``index()`` function which returns the index of ``wire``.

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -127,7 +127,7 @@ class Wires(Sequence):
         """Returns the wire at index ``idx``.
 
         >>> w = Wires([0, 'q1', 16])
-        >>> w[1]
+        >>> w.at_index(1)
         'q1'
         >>> w.at_index(2)
         16

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -124,7 +124,7 @@ class Wires(Sequence):
         return list(self.wire_tuple)
 
     def at_index(self, idx):
-        """Returns the wire at index ``idx``.
+        """Returns the wire representation at the given position in the wires object.
 
         >>> w = Wires([0, 'q1', 16])
         >>> w.at_index(1)

--- a/pennylane/wires.py
+++ b/pennylane/wires.py
@@ -123,13 +123,13 @@ class Wires(Sequence):
         """
         return list(self.wire_tuple)
 
-    def at_index(self, idx):
+    def get_label(self, idx):
         """Returns the wire representation at the given position in the wires object.
 
         >>> w = Wires([0, 'q1', 16])
-        >>> w.at_index(1)
+        >>> w.get_label(1)
         'q1'
-        >>> w.at_index(2)
+        >>> w.get_label(2)
         16
 
         Args:

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -59,7 +59,7 @@ class TestWires:
         wires = Wires(iterable)
         assert wires.wire_tuple == tuple(iterable)
 
-    @pytest.mark.parametrize("wire", [1, 'a', -1.4])
+    @pytest.mark.parametrize("wire", [1, -2, 'a', 'q1', -1.4])
     def test_creation_from_single_object(self, wire):
         """Tests that a Wires object can be created from a non-iterable object
         representing a single wire index."""
@@ -167,6 +167,15 @@ class TestWires:
         list_ = wires.tolist()
         assert isinstance(list_, list)
         assert list_ == [4, 0, 1]
+
+    def test_at_index_method(self):
+        """Tests the at_index() method."""
+
+        wires = Wires([0, 'q1', 16])
+
+        assert wires.at_index(0) == 0
+        assert wires.at_index(1) == 'q1'
+        assert wires.at_index(2) == 16
 
     @pytest.mark.parametrize("iterable", [[4, 1, 0, 3],
                                           ['a', 'b', 'c']])

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -168,7 +168,7 @@ class TestWires:
         assert isinstance(list_, list)
         assert list_ == [4, 0, 1]
 
-    def test_at_index_method(self):
+    def test_get_label_method(self):
         """Tests the get_label() method."""
 
         wires = Wires([0, 'q1', 16])

--- a/tests/test_wires.py
+++ b/tests/test_wires.py
@@ -169,13 +169,13 @@ class TestWires:
         assert list_ == [4, 0, 1]
 
     def test_at_index_method(self):
-        """Tests the at_index() method."""
+        """Tests the get_label() method."""
 
         wires = Wires([0, 'q1', 16])
 
-        assert wires.at_index(0) == 0
-        assert wires.at_index(1) == 'q1'
-        assert wires.at_index(2) == 16
+        assert wires.get_label(0) == 0
+        assert wires.get_label(1) == 'q1'
+        assert wires.get_label(2) == 16
 
     @pytest.mark.parametrize("iterable", [[4, 1, 0, 3],
                                           ['a', 'b', 'c']])


### PR DESCRIPTION
**Context:**

Part of wires refactor. 

**Description of the Change:**

Adds ``at_index`` function to wires class, which returns the wire representation at a given index.

Adapts the class to deal correctly with strings as inputs. Formerly we would have

>>> Wires('h')
<Wires=['h', 'i']>

but now we have

>>> Wires('h')
<Wires=['hi']>

Added test for both.
