### PR TITLE
Pin version of tensornetwork and update docstring

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,7 +12,7 @@ sphinx-automodapi
 sphinx-copybutton
 sphinxcontrib-bibtex==0.4.2
 tensorflow==2.0.1
-tensornetwork==0.3.1
+tensornetwork==0.3
 toml
 torch==1.3.0+cpu
 torchvision==0.4.1+cpu

--- a/pennylane/beta/plugins/default_tensor.py
+++ b/pennylane/beta/plugins/default_tensor.py
@@ -46,6 +46,39 @@ contract_fns = {
 class DefaultTensor(Device):
     """Experimental Tensor Network simulator device for PennyLane.
 
+    **Short name:** ``default.tensor``
+
+    This experimental device uses the
+    `TensorNetwork <https://github.com/google/tensornetwork>`_ library
+    to provide a basic tensor-network-based simulator backend for PennyLane.
+    Tensor network simulators can faster or more efficient for certain types of
+    circuit structures.
+
+    To use this device, you will need to install TensorNetwork:
+
+    .. code-block:: bash
+
+        pip install tensornetwork==0.3
+
+    The ``default.tensor`` device supports two types of tensor networks: ``"exact"`` and ``"mps"``.
+
+    The (default) ``"exact"`` representation does not make any approximations, using exact dense tensors for
+    the simulator's quantum states and for the matrices of quantum gates and observables.
+
+    The ``"mps"`` representation (standing for "matrix product state") approximates the quantum state
+    using a one-dimensional grid of qubits with nearest-neighbour connectivity. As such, it does not support
+    multi-qubit gates/observables that do not act on nearest-neighbour qubits.
+
+    The preferred contraction method can also be specified when using the ``"exact"`` representation.
+    Available options are "auto", "greedy", "branch", or "optimal".
+    See the `TensorNetwork documentation <https://tensornetwork.readthedocs.io/en/latest/copy_contract.html>`_
+    for more details.
+
+    **Example**
+
+      >>> exact_tensornet = qml.device("default.tensor", wires=2, contraction_method="greedy")
+      >>> mps_tensornet = qml.device("default.tensor", wires=2, representation="mps")
+
     Args:
         wires (int): number of subsystems in the quantum state represented by the device
         shots (int): Number of circuit evaluations/random samples to return when sampling from the device.

--- a/pennylane/beta/plugins/default_tensor.py
+++ b/pennylane/beta/plugins/default_tensor.py
@@ -164,6 +164,7 @@ class DefaultTensor(Device):
         name = "{}{}".format(name, tuple(w for w in wires))
         if isinstance(A, tn.Node):
             A.set_name(name)
+            A.backend = self.backend
             node = A
         else:
             node = tn.Node(A, name=name, backend=self.backend)
@@ -236,7 +237,9 @@ class DefaultTensor(Device):
                             # final wire; no need to split further
                             node = self._add_node(DV, wires=[wire], name=name)
                         nodes.append(node)
-            self.mps = tn.matrixproductstates.finite_mps.FiniteMPS(nodes, canonicalize=False)
+            self.mps = tn.matrixproductstates.finite_mps.FiniteMPS([node.tensor for node in nodes],
+                                                                   canonicalize=False,
+                                                                   backend=self.backend)
             self._free_wire_edges = [node[1] for node in self.mps.nodes]
 
     def _get_operator_matrix(self, operation, par):

--- a/pennylane/beta/plugins/default_tensor.py
+++ b/pennylane/beta/plugins/default_tensor.py
@@ -237,9 +237,9 @@ class DefaultTensor(Device):
                             # final wire; no need to split further
                             node = self._add_node(DV, wires=[wire], name=name)
                         nodes.append(node)
-            self.mps = tn.matrixproductstates.finite_mps.FiniteMPS([node.tensor for node in nodes],
-                                                                   canonicalize=False,
-                                                                   backend=self.backend)
+            self.mps = tn.matrixproductstates.finite_mps.FiniteMPS(
+                [node.tensor for node in nodes], canonicalize=False, backend=self.backend,
+            )
             self._free_wire_edges = [node[1] for node in self.mps.nodes]
 
     def _get_operator_matrix(self, operation, par):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 scipy
 networkx
-tensornetwork>=0.3
+tensornetwork==0.3
 autograd
 toml
 appdirs


### PR DESCRIPTION
The tensor network plugin was causing tests to fail for Python3.6. Upon closer inspection, I determined that this is because Travis is pulling in tensornetwork v0.4.0, which has breaking changes to the UI (the plugin is coded against v0.3.0). 

However, the other Python versions pass all tests, despite also using tensornetwork v0.4.0 :thinking:. Could there be some issue with the provided wheels??