### PR TITLE
[WIRES] Undo PR#653 which made operation.wires a Wires class object

### DIFF
--- a/pennylane/_device.py
+++ b/pennylane/_device.py
@@ -191,7 +191,7 @@ class Device(abc.ABC):
             self.pre_apply()
 
             for operation in queue:
-                self.apply(operation.name, operation.wires.tolist(), operation.parameters)
+                self.apply(operation.name, operation.wires, operation.parameters)
 
             self.post_apply()
 
@@ -201,9 +201,9 @@ class Device(abc.ABC):
 
                 if isinstance(obs, Tensor):
                     # if obs is a tensor observable, use a list of individual wires
-                    wires = [ob.wires.tolist() for ob in obs.obs]
+                    wires = [ob.wires for ob in obs.obs]
                 else:
-                    wires = obs.wires.tolist()
+                    wires = obs.wires
 
                 if obs.return_type is Expectation:
                     results.append(self.expval(obs.name, wires, obs.parameters))

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -26,7 +26,6 @@ import numpy as np
 from pennylane.operation import Sample, Variance, Expectation, Probability
 from pennylane.qnodes import QuantumFunctionError
 from pennylane import Device
-from pennylane.wires import Wires
 
 
 class QubitDevice(Device):

--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -217,8 +217,8 @@ class QubitDevice(Device):
         >>> op = qml.RX(0.2, wires=[0])
         >>> op.name # returns the operation name
         "RX"
-        >>> op.wires # returns a Wires object representing the wires that the operation acts on
-        Wires([0])
+        >>> op.wires # wires that the operation acts on
+        [0]
         >>> op.parameters # returns a list of parameters
         [0.2]
         >>> op.inverse # check if the operation should be inverted
@@ -245,11 +245,11 @@ class QubitDevice(Device):
                 we are gathering the active wires
 
         Returns:
-            Wires: all wires activated by the specified operators
+            set[int]: the set of wires activated by the specified operators
         """
-        list_of_wires = [op.wires for op in operators]
+        list_of_wires = [w for op in operators for w in op.wires]
 
-        return Wires.all_wires(list_of_wires)
+        return set(list_of_wires)
 
     def statistics(self, observables):
         """Process measurement results from circuit execution and return statistics.
@@ -279,7 +279,7 @@ class QubitDevice(Device):
                 results.append(np.array(self.sample(obs)))
 
             elif obs.return_type is Probability:
-                results.append(self.probability(wires=obs.wires.tolist()))
+                results.append(self.probability(wires=obs.wires))
 
             elif obs.return_type is not None:
                 raise QuantumFunctionError(
@@ -494,7 +494,7 @@ class QubitDevice(Device):
         return self._gather(prob, perm)
 
     def expval(self, observable):
-        wires = observable.wires.tolist()  # TODO: re-asses for nonconsecutive wires
+        wires = observable.wires  # TODO: re-asses for nonconsecutive wires
 
         if self.analytic:
             # exact expectation value
@@ -506,7 +506,7 @@ class QubitDevice(Device):
         return np.mean(self.sample(observable))
 
     def var(self, observable):
-        wires = observable.wires.tolist()  # TODO: re-asses for nonconsecutive wires
+        wires = observable.wires  # TODO: re-asses for nonconsecutive wires
 
         if self.analytic:
             # exact variance value
@@ -518,7 +518,7 @@ class QubitDevice(Device):
         return np.var(self.sample(observable))
 
     def sample(self, observable):
-        wires = observable.wires.tolist()  # TODO: re-asses for nonconsecutive wires
+        wires = observable.wires  # TODO: re-asses for nonconsecutive wires
         name = observable.name
 
         if isinstance(name, str) and name in {"PauliX", "PauliY", "PauliZ", "Hadamard"}:

--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -239,7 +239,7 @@ class DefaultTensorTF(DefaultTensor):
             # (which contains the evaluated numeric parameter values),
             # pass op_params[operation], which contains numeric values
             # for fixed parameters, and tf.Variable objects for free parameters.
-            super().apply(operation.name, operation.wires.tolist(), self.op_params[operation])
+            super().apply(operation.name, operation.wires, self.op_params[operation])
 
     def apply(self, operation, wires, par):
         # individual operations are already applied inside self.pre_apply()

--- a/pennylane/circuit_drawer/circuit_drawer.py
+++ b/pennylane/circuit_drawer/circuit_drawer.py
@@ -132,7 +132,7 @@ class CircuitDrawer:
         all_operators = list(qml.utils._flatten(raw_operation_grid)) + list(
             qml.utils._flatten(raw_observable_grid)
         )
-        all_wires = [op.wires.tolist() for op in all_operators if op is not None]
+        all_wires = [op.wires for op in all_operators if op is not None]
         circuit_wires = sorted(set(qml.utils._flatten(all_wires)))
         internal_wires = list(range(len(circuit_wires)))
 
@@ -229,7 +229,7 @@ class CircuitDrawer:
                 if op is None:
                     continue
 
-                wires = op.wires.tolist()
+                wires = op.wires
 
                 if len(wires) > 1:
                     internal_wires = self.circuit_wires_to_internal_wires(wires)
@@ -307,7 +307,7 @@ class CircuitDrawer:
                     continue
 
                 if len(op.wires) > 1:
-                    sorted_wires = op.wires.tolist().copy()
+                    sorted_wires = op.wires.copy()
                     sorted_wires.sort()
 
                     blocked_wires = list(range(sorted_wires[0], sorted_wires[-1] + 1))
@@ -318,7 +318,7 @@ class CircuitDrawer:
                         if other_op is None:
                             continue
 
-                        other_sorted_wires = other_op.wires.tolist().copy()
+                        other_sorted_wires = other_op.wires.copy()
                         other_sorted_wires.sort()
                         other_blocked_wires = list(
                             range(other_sorted_wires[0], other_sorted_wires[-1] + 1)

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -333,7 +333,7 @@ class RepresentationResolver:
 
         # Display a control symbol for all controlling qubits of a controlled Operation
         if base_name in self.control_wire_dict and wire in [
-            op.wires.tolist()[control_idx] for control_idx in self.control_wire_dict[base_name]
+            op.wires[control_idx] for control_idx in self.control_wire_dict[base_name]
         ]:
             # No need to add a -1 for inverse here
             return self.charset.CONTROL
@@ -343,7 +343,7 @@ class RepresentationResolver:
 
         elif base_name == "PauliRot":
             representation = "R{0}({1})".format(
-                op.params[1][op.wires.tolist().index(wire)],
+                op.params[1][op.wires.index(wire)],
                 self.single_parameter_representation(op.params[0]),
             )
 
@@ -377,9 +377,7 @@ class RepresentationResolver:
 
         elif base_name in {"BasisState", "FockStateVector"}:
             representation = (
-                self.charset.PIPE
-                + str(op.params[0][op.wires.tolist().index(wire)])
-                + self.charset.RANGLE
+                self.charset.PIPE + str(op.params[0][op.wires.index(wire)]) + self.charset.RANGLE
             )
 
         # Operations that only have matrix arguments

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -155,9 +155,9 @@ class CircuitGraph:
         self.num_wires = 0
         """int: number of wires the circuit contains"""
         for k, op in enumerate(ops):
-            self.num_wires = max(self.num_wires, max(op.wires.tolist()) + 1)
+            self.num_wires = max(self.num_wires, max(op.wires) + 1)
             op.queue_idx = k  # store the queue index in the Operator
-            for w in set(op.wires.tolist()):
+            for w in set(op.wires):
                 # Add op to the grid, to the end of wire w
                 self._grid.setdefault(w, []).append(op)
 
@@ -222,7 +222,7 @@ class CircuitGraph:
                     serialization_string += str(param)
                     serialization_string += delimiter
 
-            serialization_string += str(op.wires.tolist())
+            serialization_string += str(op.wires)
 
         # Adding a distinct separating string that could not occur by any combination of the
         # name of the operation and wires
@@ -235,7 +235,7 @@ class CircuitGraph:
                 serialization_string += str(param)
                 serialization_string += delimiter
 
-            serialization_string += str(obs.wires.tolist())
+            serialization_string += str(obs.wires)
 
         return serialization_string
 
@@ -305,7 +305,7 @@ class CircuitGraph:
         # create the QASM code representing the operations
         for op in decomposed_ops:
             gate = OPENQASM_GATES[op.name]
-            wires = ",".join(["q[{}]".format(w) for w in op.wires.tolist()])
+            wires = ",".join(["q[{}]".format(w) for w in op.wires])
             params = ""
 
             if op.num_params > 0:

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -408,38 +408,6 @@ class Operator(abc.ABC):
             return "{}({}, wires={})".format(self.name, params, self.wires)
         return "{}(wires={})".format(self.name, self.wires)
 
-    def _check_wires(self, wires):
-        """Check the validity of the operator wires.
-        Args:
-            wires (Sequence[Any]): wires to check
-        Raises:
-            TypeError, ValueError: list of wires is invalid
-        Returns:
-            tuple[int]: wires converted to integers
-        """
-        for w in wires:
-            if not isinstance(w, numbers.Integral):
-                raise TypeError(
-                    "{}: Wires must be integers, or integer-valued nondifferentiable parameters in mutable circuits.".format(
-                        self.name
-                    )
-                )
-
-        if (
-            self.num_wires != AllWires
-            and self.num_wires != AnyWires
-            and len(wires) != self.num_wires
-        ):
-            raise ValueError(
-                "{}: wrong number of wires. "
-                "{} wires given, {} expected.".format(self.name, len(wires), self.num_wires)
-            )
-
-        if len(set(wires)) != len(wires):
-            raise ValueError("{}: wires must be unique, got {}.".format(self.name, wires))
-
-        return tuple(int(w) for w in wires)
-
     def check_domain(self, p, flattened=False):
         """Check the validity of a parameter.
 

--- a/pennylane/plugins/default_qubit.py
+++ b/pennylane/plugins/default_qubit.py
@@ -121,25 +121,24 @@ class DefaultQubit(QubitDevice):
         Args:
             operation (~.Operation): operation to apply on the device
         """
-        wires = operation.wires.tolist()  # TODO: translation to nonconsec wires indices
 
         if isinstance(operation, QubitStateVector):
-            self._apply_state_vector(operation.parameters[0], wires)
+            self._apply_state_vector(operation.parameters[0], operation.wires)
             return
 
         if isinstance(operation, BasisState):
-            self._apply_basis_state(operation.parameters[0], wires)
+            self._apply_basis_state(operation.parameters[0], operation.wires)
             return
 
         matrix = self._get_unitary_matrix(operation)
 
         if isinstance(operation, DiagonalOperation):
-            self._apply_diagonal_unitary(matrix, wires)
+            self._apply_diagonal_unitary(matrix, operation.wires)
         elif len(operation.wires) <= 2:
             # Einsum is faster for small gates
-            self._apply_unitary_einsum(matrix, wires)
+            self._apply_unitary_einsum(matrix, operation.wires)
         else:
-            self._apply_unitary(matrix, wires)
+            self._apply_unitary(matrix, operation.wires)
 
     def _get_unitary_matrix(self, unitary):  # pylint: disable=no-self-use
         """Return the matrix representing a unitary operation.

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -97,7 +97,7 @@ def _decompose_queue(ops, device):
         if device.supports_operation(op.name):
             new_ops.append(op)
         else:
-            decomposed_ops = op.decomposition(*op.params, wires=op.wires.tolist())
+            decomposed_ops = op.decomposition(*op.params, wires=op.wires)
             if op.inverse:
                 decomposed_ops = qml.inv(decomposed_ops)
 
@@ -360,13 +360,13 @@ class BaseQNode(qml.QueuingContext):
 
     def _append_operator(self, operator):
         if operator.num_wires == ActsOn.AllWires:  # TODO: re-assess for nonconsec wires
-            if set(operator.wires.tolist()) != set(range(self.num_wires)):
+            if set(operator.wires) != set(range(self.num_wires)):
                 raise QuantumFunctionError(
                     "Operator {} must act on all wires".format(operator.name)
                 )
 
         # Make sure only existing wires are used.
-        for w in operator.wires.tolist():  # TODO: re-assess for for nonconsec wires
+        for w in operator.wires:
             if w < 0 or w >= self.num_wires:
                 raise QuantumFunctionError(
                     "Operation {} applied to invalid wire {} "

--- a/pennylane/qnodes/qubit.py
+++ b/pennylane/qnodes/qubit.py
@@ -243,7 +243,7 @@ class QubitQNode(JacobianQNode):
             # for each operation in the layer, get the generator and convert it to a variance
             for n, op in enumerate(curr_ops):
                 gen, s = op.generator
-                w = op.wires.tolist()
+                w = op.wires
 
                 if gen is None:
                     raise QuantumFunctionError(

--- a/pennylane/qnodes/rev.py
+++ b/pennylane/qnodes/rev.py
@@ -156,7 +156,7 @@ class ReversibleQNode(QubitQNode):
         wires = obs.wires
 
         vec1_indices = ABC[: self.num_wires]
-        obs_in_indices = "".join(ABC_ARRAY[wires.tolist()].tolist())
+        obs_in_indices = "".join(ABC_ARRAY[wires].tolist())
         obs_out_indices = ABC[self.num_wires : self.num_wires + len(wires)]
         obs_indices = "".join([obs_in_indices, obs_out_indices])
         vec2_indices = reduce(

--- a/pennylane/templates/broadcast.py
+++ b/pennylane/templates/broadcast.py
@@ -572,4 +572,5 @@ def broadcast(unitary, wires, pattern, parameters=None, kwargs=None):
 
     # broadcast the unitary
     for wires, pars in zip(wire_sequence[pattern], parameters):
+        wires = wires.tolist()  # TODO: Delete once operator takes Wires objects
         unitary(*pars, wires=wires, **kwargs)

--- a/pennylane/vqe/vqe.py
+++ b/pennylane/vqe/vqe.py
@@ -114,7 +114,7 @@ class Hamiltonian:
                 obs_strs = ["{}{}".format(OBS_MAP[i.name], i.wires[0]) for i in obs.obs]
                 term = " ".join(obs_strs)
             elif isinstance(obs, Observable):
-                term = "{}{}".format(OBS_MAP[obs.name], obs.wires.tolist()[0])
+                term = "{}{}".format(OBS_MAP[obs.name], obs.wires[0])
 
             terms.append(coeff.format(term))
 

--- a/qchem/pennylane_qchem/qchem.py
+++ b/qchem/pennylane_qchem/qchem.py
@@ -414,7 +414,7 @@ def _terms_to_qubit_operator(coeffs, ops):
     for coeff, op in zip(coeffs, ops):
 
         # wire ids
-        wires = op.wires.tolist()
+        wires = op.wires
 
         # Pauli axis names, note s[-1] expects only 'Pauli{X,Y,Z}'
         pauli_names = [s[-1] for s in op.name]

--- a/tests/circuit_drawer/test_circuit_drawer.py
+++ b/tests/circuit_drawer/test_circuit_drawer.py
@@ -93,7 +93,7 @@ def to_layer(operation_list, num_wires):
     layer = [None] * num_wires
 
     for op in operation_list:
-        for wire in op.wires.tolist():
+        for wire in op.wires:
             layer[wire] = op
 
     return layer

--- a/tests/circuit_graph/test_circuit_graph.py
+++ b/tests/circuit_graph/test_circuit_graph.py
@@ -206,7 +206,7 @@ class TestCircuitGraph:
 
         assert len(diag_gates) == 1
         assert isinstance(diag_gates[0], qml.Hadamard)
-        assert diag_gates[0].wires == Wires([0])
+        assert diag_gates[0].wires == [0]  # Wires([0])
 
     def test_is_sampled(self):
         """Test that circuit graphs with sampled observables properly return

--- a/tests/circuit_graph/test_qasm.py
+++ b/tests/circuit_graph/test_qasm.py
@@ -724,23 +724,23 @@ class TestQASMConformanceTests:
 
         # operations
         assert gates[0].name == "h"
-        assert gates[0].wires == Wires([0])
+        assert gates[0].wires == [0]  #Wires([0])
 
         assert gates[1].name == "ry"
-        assert gates[1].wires == Wires([0])
+        assert gates[1].wires == [0]  #Wires([0])
         assert gates[1].params == [params[1]]
 
         assert gates[2].name == "cx"
-        assert gates[2].wires == Wires([0, 1])
+        assert gates[2].wires == [0,1]  #Wires([0, 1])
 
         assert gates[4].name == "rx"
-        assert gates[4].wires == Wires([1])
+        assert gates[4].wires == [1]  #Wires([1])
         assert gates[4].params == [params[0]]
 
         # rotations
         assert gates[3].name == "h"
-        assert gates[3].wires == Wires([0])
+        assert gates[3].wires == [0]  #Wires([0])
 
         assert gates[5].name == "ry"
-        assert gates[5].wires == Wires([2])
+        assert gates[5].wires == [2]  #Wires([2])
         assert gates[5].params == [-np.pi / 4]

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -337,15 +337,15 @@ class TestOperations:
         assert len(res) == 3
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
         
         assert res[1].name == "RX"
-        assert res[1].wires == qml.wires.Wires([0])
+        assert res[1].wires == [0]  #qml.wires.Wires([0])
         assert res[1].params[0] == np.pi
         
         assert res[2].name == "PhaseShift"
-        assert res[2].wires == qml.wires.Wires([0])
+        assert res[2].wires == [0]  #qml.wires.Wires([0])
         assert res[2].params[0] == np.pi / 2
 
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
@@ -359,15 +359,15 @@ class TestOperations:
         assert len(res) == 3
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
         
         assert res[1].name == "RY"
-        assert res[1].wires == qml.wires.Wires([0])
+        assert res[1].wires == [0]  #qml.wires.Wires([0])
         assert res[1].params[0] == np.pi
         
         assert res[2].name == "PhaseShift"
-        assert res[2].wires == qml.wires.Wires([0])
+        assert res[2].wires == [0]  #qml.wires.Wires([0])
         assert res[2].params[0] == np.pi / 2
         
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
@@ -381,7 +381,7 @@ class TestOperations:
         assert len(res) == 1
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi
         
         decomposed_matrix = res[0].matrix
@@ -395,7 +395,7 @@ class TestOperations:
         assert len(res) == 1
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
         
         decomposed_matrix = res[0].matrix
@@ -409,7 +409,7 @@ class TestOperations:
         assert len(res) == 1
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 4
         
         decomposed_matrix = res[0].matrix
@@ -423,15 +423,15 @@ class TestOperations:
         assert len(res) == 3
 
         assert res[0].name == "PhaseShift"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
 
         assert res[1].name == "RX"
-        assert res[1].wires == qml.wires.Wires([0])
+        assert res[1].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
         
         assert res[2].name == "PhaseShift"
-        assert res[2].wires == qml.wires.Wires([0])
+        assert res[2].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == np.pi / 2
         
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
@@ -446,7 +446,7 @@ class TestOperations:
         assert len(res) == 1
 
         assert res[0].name == "RZ"
-        assert res[0].wires == qml.wires.Wires([0])
+        assert res[0].wires == [0]  #qml.wires.Wires([0])
         assert res[0].params[0] == 0.3
         
         decomposed_matrix = res[0].matrix
@@ -810,7 +810,7 @@ class TestPauliRot:
         assert len(decomp_ops) == 1
 
         assert decomp_ops[0].name == "MultiRZ"
-        assert decomp_ops[0].wires == Wires([0, 1])
+        assert decomp_ops[0].wires == [0,1]  #Wires([0, 1])
         assert decomp_ops[0].params[0] == theta
 
     def test_PauliRot_decomposition_XY(self):
@@ -823,21 +823,21 @@ class TestPauliRot:
         assert len(decomp_ops) == 5
 
         assert decomp_ops[0].name == "Hadamard"
-        assert decomp_ops[0].wires == Wires([0])
+        assert decomp_ops[0].wires == [0]  #Wires([0])
 
         assert decomp_ops[1].name == "RX"
-        assert decomp_ops[1].wires == Wires([1])
+        assert decomp_ops[1].wires == [1]  #Wires([1])
         assert decomp_ops[1].params[0] == np.pi / 2
 
         assert decomp_ops[2].name == "MultiRZ"
-        assert decomp_ops[2].wires == Wires([0, 1])
+        assert decomp_ops[2].wires == [0,1]  #Wires([0, 1])
         assert decomp_ops[2].params[0] == theta
 
         assert decomp_ops[3].name == "Hadamard"
-        assert decomp_ops[3].wires == Wires([0])
+        assert decomp_ops[3].wires == [0]  #Wires([0])
 
         assert decomp_ops[4].name == "RX"
-        assert decomp_ops[4].wires == Wires([1])
+        assert decomp_ops[4].wires == [1]  #Wires([1])
         assert decomp_ops[4].params[0] == -np.pi / 2
 
     def test_PauliRot_decomposition_XIYZ(self):
@@ -850,21 +850,21 @@ class TestPauliRot:
         assert len(decomp_ops) == 5
 
         assert decomp_ops[0].name == "Hadamard"
-        assert decomp_ops[0].wires == Wires([0])
+        assert decomp_ops[0].wires == [0]  #Wires([0])
 
         assert decomp_ops[1].name == "RX"
-        assert decomp_ops[1].wires == Wires([2])
+        assert decomp_ops[1].wires == [2]  #Wires([2])
         assert decomp_ops[1].params[0] == np.pi / 2
 
         assert decomp_ops[2].name == "MultiRZ"
-        assert decomp_ops[2].wires == Wires([0, 2, 3])
+        assert decomp_ops[2].wires == [0, 2, 3]  #Wires([0, 2, 3])
         assert decomp_ops[2].params[0] == theta
 
         assert decomp_ops[3].name == "Hadamard"
-        assert decomp_ops[3].wires == Wires([0])
+        assert decomp_ops[3].wires == [0]  #Wires([0])
 
         assert decomp_ops[4].name == "RX"
-        assert decomp_ops[4].wires == Wires([2])
+        assert decomp_ops[4].wires == [2]  #Wires([2])
         assert decomp_ops[4].params[0] == -np.pi / 2
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
@@ -971,14 +971,14 @@ class TestMultiRZ:
         decomp_ops = op.decomposition(theta, wires=[0, 1])
 
         assert decomp_ops[0].name == "CNOT"
-        assert decomp_ops[0].wires == Wires([1, 0])
+        assert decomp_ops[0].wires == [1, 0]  #Wires([1, 0])
 
         assert decomp_ops[1].name == "RZ"
-        assert decomp_ops[1].wires == Wires([0])
+        assert decomp_ops[1].wires == [0]  #Wires([0])
         assert decomp_ops[1].params[0] == theta
 
         assert decomp_ops[2].name == "CNOT"
-        assert decomp_ops[2].wires == Wires([1, 0])
+        assert decomp_ops[2].wires == [1, 0]  #Wires([1, 0])
 
     def test_MultiRZ_decomposition_ZZZ(self):
         """Test that the decomposition for a ZZZ rotation is correct."""
@@ -988,20 +988,20 @@ class TestMultiRZ:
         decomp_ops = op.decomposition(theta, wires=[0, 2, 3])
 
         assert decomp_ops[0].name == "CNOT"
-        assert decomp_ops[0].wires == Wires([3, 2])
+        assert decomp_ops[0].wires == [3, 2]  #Wires([3, 2])
 
         assert decomp_ops[1].name == "CNOT"
-        assert decomp_ops[1].wires == Wires([2, 0])
+        assert decomp_ops[1].wires == [2, 0]  #Wires([2, 0])
 
         assert decomp_ops[2].name == "RZ"
-        assert decomp_ops[2].wires == Wires([0])
+        assert decomp_ops[2].wires == [0]  #Wires([0])
         assert decomp_ops[2].params[0] == theta
 
         assert decomp_ops[3].name == "CNOT"
-        assert decomp_ops[3].wires == Wires([2, 0])
+        assert decomp_ops[3].wires == [2, 0]  #Wires([2, 0])
 
         assert decomp_ops[4].name == "CNOT"
-        assert decomp_ops[4].wires == Wires([3, 2])
+        assert decomp_ops[4].wires == [3, 2]  #Wires([3, 2])
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
     def test_differentiability(self, angle):
@@ -1057,5 +1057,5 @@ class TestDiagonalQubitUnitary:
         decomp = qml.DiagonalQubitUnitary.decomposition(D, [0, 1, 2])
 
         assert decomp[0].name == "QubitUnitary"
-        assert decomp[0].wires == Wires([0, 1, 2])
+        assert decomp[0].wires == [0, 1, 2]  #Wires([0, 1, 2])
         assert np.allclose(decomp[0].params[0], np.diag(D))

--- a/tests/plugins/test_default_qubit.py
+++ b/tests/plugins/test_default_qubit.py
@@ -1487,7 +1487,7 @@ class TestTensorSample:
         dev.sample(obs)
 
         s1 = obs.eigvals
-        p = dev.probability(wires=obs.wires.tolist())
+        p = dev.probability(wires=obs.wires)
 
         # s1 should only contain 1 and -1
         assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
@@ -1527,7 +1527,7 @@ class TestTensorSample:
         dev.sample(obs)
 
         s1 = obs.eigvals
-        p = dev.marginal_prob(dev.probability(), wires=obs.wires.tolist())
+        p = dev.marginal_prob(dev.probability(), wires=obs.wires)
 
         # s1 should only contain 1 and -1
         assert np.allclose(s1 ** 2, 1, atol=tol, rtol=0)
@@ -1575,7 +1575,7 @@ class TestTensorSample:
         dev.sample(obs)
 
         s1 = obs.eigvals
-        p = dev.marginal_prob(dev.probability(), wires=obs.wires.tolist())
+        p = dev.marginal_prob(dev.probability(), wires=obs.wires)
 
         # s1 should only contain the eigenvalues of
         # the hermitian matrix tensor product Z

--- a/tests/qnodes/test_qnode_base.py
+++ b/tests/qnodes/test_qnode_base.py
@@ -343,7 +343,7 @@ class TestQNodeOperationQueue:
 
         assert qnode.ops[0].name == "PauliX"
         assert len(qnode.ops[0].wires) == 1
-        assert qnode.ops[0].wires[0] == Wires(0)
+        assert qnode.ops[0].wires[0] == 0  #Wires(0)
 
 
 class TestQNodeExceptions:
@@ -775,11 +775,11 @@ class TestQNodeArgs:
 
         node = BaseQNode(circuit, qubit_device_2_wires)
         c = node(np.pi, q=1)
-        assert node.ops[0].wires == Wires([1])
+        assert node.ops[0].wires == [1]  #Wires([1])
         assert c == pytest.approx(-1.0, abs=tol)
 
         c = node(np.pi)
-        assert node.ops[0].wires == Wires([default_q])
+        assert node.ops[0].wires == [default_q]  #Wires([default_q])
         assert c == pytest.approx(-1.0, abs=tol)
 
     def test_keywordargs_used(self, qubit_device_1_wire, tol):

--- a/tests/templates/test_embeddings.py
+++ b/tests/templates/test_embeddings.py
@@ -394,7 +394,7 @@ class TestIQPEmbedding:
 
         # compare all gate wires to expected ones
         for idx, gate in enumerate(rec.queue):
-            assert gate.wires == Wires(expected_queue_wires[idx])
+            assert gate.wires == expected_queue_wires[idx]  #Wires(expected_queue_wires[idx])
 
     @pytest.mark.parametrize('pattern', [[[0, 3], [1, 2], [2, 0]],
                                          [[2, 3], [0, 2], [1, 0]]])
@@ -408,7 +408,7 @@ class TestIQPEmbedding:
         for gate in rec.queue:
             # check wires of entanglers
             if len(gate.wires) == 2:
-                assert gate.wires == Wires(pattern[counter])
+                assert gate.wires == pattern[counter]  #Wires(pattern[counter])
                 counter += 1
 
     @pytest.mark.parametrize('features', [[1., 2.],

--- a/tests/templates/test_layers.py
+++ b/tests/templates/test_layers.py
@@ -191,7 +191,7 @@ class TestStronglyEntangling:
 
         assert len(rec.queue) == n_layers
         assert all([isinstance(q, qml.Rot) for q in rec.queue])
-        assert all([q._wires[0] == Wires(0) for q in rec.queue])
+        assert all([q._wires[0] == 0 for q in rec.queue]) #Wires(0) for q in rec.queue])
 
     def test_strong_ent_layers_uses_correct_weights(self, n_subsystems):
         """Test that StronglyEntanglingLayers uses the correct weights in the circuit."""
@@ -451,7 +451,7 @@ class TestRandomLayers:
                 seed=42,
             )
 
-        wires = [q._wires.tolist() for q in rec.queue]
+        wires = [q._wires for q in rec.queue]
         wires_flat = [item for w in wires for item in w]
         mean_wire = np.mean(wires_flat)
         assert np.isclose(mean_wire, (n_subsystems - 1) / 2, atol=0.05)

--- a/tests/templates/test_state_preparations.py
+++ b/tests/templates/test_state_preparations.py
@@ -315,12 +315,12 @@ class TestArbitraryStatePreparation:
         assert rec.queue[0].name == "PauliRot"
         assert rec.queue[0].params[0] == weights[0]
         assert rec.queue[0].params[1] == "X"
-        assert rec.queue[0].wires == Wires([0])
+        assert rec.queue[0].wires == [0]  #Wires([0])
 
         assert rec.queue[1].name == "PauliRot"
         assert rec.queue[1].params[0] == weights[1]
         assert rec.queue[1].params[1] == "Y"
-        assert rec.queue[1].wires == Wires([0])
+        assert rec.queue[1].wires == [0]  #Wires([0])
 
     def test_correct_gates_two_wires(self):
         """Test that the correct gates are applied on on two wires."""
@@ -332,32 +332,32 @@ class TestArbitraryStatePreparation:
         assert rec.queue[0].name == "PauliRot"
         assert rec.queue[0].params[0] == weights[0]
         assert rec.queue[0].params[1] == "XI"
-        assert rec.queue[0].wires == Wires([0, 1])
+        assert rec.queue[0].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[1].name == "PauliRot"
         assert rec.queue[1].params[0] == weights[1]
         assert rec.queue[1].params[1] == "YI"
-        assert rec.queue[1].wires == Wires([0, 1])
+        assert rec.queue[1].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[2].name == "PauliRot"
         assert rec.queue[2].params[0] == weights[2]
         assert rec.queue[2].params[1] == "IX"
-        assert rec.queue[2].wires == Wires([0, 1])
+        assert rec.queue[2].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[3].name == "PauliRot"
         assert rec.queue[3].params[0] == weights[3]
         assert rec.queue[3].params[1] == "IY"
-        assert rec.queue[3].wires == Wires([0, 1])
+        assert rec.queue[3].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[4].name == "PauliRot"
         assert rec.queue[4].params[0] == weights[4]
         assert rec.queue[4].params[1] == "XX"
-        assert rec.queue[4].wires == Wires([0, 1])
+        assert rec.queue[4].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[5].name == "PauliRot"
         assert rec.queue[5].params[0] == weights[5]
         assert rec.queue[5].params[1] == "XY"
-        assert rec.queue[5].wires == Wires([0, 1])
+        assert rec.queue[5].wires == [0,1]  #Wires([0, 1])
 
     def test_GHZ_generation(self, qubit_device_3_wires, tol):
         """Test that the template prepares a GHZ state."""

--- a/tests/templates/test_subroutines.py
+++ b/tests/templates/test_subroutines.py
@@ -240,12 +240,12 @@ class TestInterferometer:
             for idx, op in enumerate(rec_rect.queue[:3]):
                 assert isinstance(op, qml.Beamsplitter)
                 assert op.parameters == [theta[idx], phi[idx]]
-                assert op.wires == Wires(expected_bs_wires[idx])
+                assert op.wires == expected_bs_wires[idx]  #Wires(expected_bs_wires[idx])
 
             for idx, op in enumerate(rec.queue[3:]):
                 assert isinstance(op, qml.Rotation)
                 assert op.parameters == [varphi[idx]]
-                assert op.wires == Wires([idx])
+                assert op.wires == [idx]  #Wires([idx])
 
     def test_four_mode_rect(self, tol):
         """Test that a 4 mode interferometer using rectangular mesh gives the correct gates"""
@@ -266,12 +266,12 @@ class TestInterferometer:
         for idx, op in enumerate(rec.queue[:6]):
             assert isinstance(op, qml.Beamsplitter)
             assert op.parameters == [theta[idx], phi[idx]]
-            assert op.wires == Wires(expected_bs_wires[idx])
+            assert op.wires == expected_bs_wires[idx]  #Wires(expected_bs_wires[idx])
 
         for idx, op in enumerate(rec.queue[6:]):
             assert isinstance(op, qml.Rotation)
             assert op.parameters == [varphi[idx]]
-            assert op.wires == Wires([idx])
+            assert op.wires == [idx]  #Wires([idx])
 
     def test_four_mode_triangular(self, tol):
         """Test that a 4 mode interferometer using triangular mesh gives the correct gates"""
@@ -292,12 +292,12 @@ class TestInterferometer:
         for idx, op in enumerate(rec.queue[:6]):
             assert isinstance(op, qml.Beamsplitter)
             assert op.parameters == [theta[idx], phi[idx]]
-            assert op.wires == Wires(expected_bs_wires[idx])
+            assert op.wires == expected_bs_wires[idx]  #Wires(expected_bs_wires[idx])
 
         for idx, op in enumerate(rec.queue[6:]):
             assert isinstance(op, qml.Rotation)
             assert op.parameters == [varphi[idx]]
-            assert op.wires == Wires([idx])
+            assert op.wires == [idx]  #Wires([idx])
 
     def test_integration(self, tol):
         """test integration with PennyLane and gradient calculations"""
@@ -383,7 +383,7 @@ class TestSingleExcitationUnitary:
 
             exp_wires = gate[2]
             res_wires = rec.queue[idx]._wires
-            assert res_wires == Wires(exp_wires)
+            assert res_wires == exp_wires  #Wires(exp_wires)
 
             exp_weight = gate[3]
             res_weight = rec.queue[idx].parameters
@@ -452,7 +452,7 @@ class TestArbitraryUnitary:
         with qml.utils.OperationRecorder() as rec:
             ArbitraryUnitary(weights, wires=[0])
 
-        assert all(op.name == "PauliRot" and op.wires == Wires([0]) for op in rec.queue)
+        assert all(op.name == "PauliRot" and op.wires == [0] for op in rec.queue) # Wires([0]) for op in rec.queue)
 
         pauli_words = ["X", "Y", "Z"]
 
@@ -467,7 +467,7 @@ class TestArbitraryUnitary:
         with qml.utils.OperationRecorder() as rec:
             ArbitraryUnitary(weights, wires=[0, 1])
 
-        assert all(op.name == "PauliRot" and op.wires == Wires([0, 1]) for op in rec.queue)
+        assert all(op.name == "PauliRot" and op.wires == [0, 1] for op in rec.queue) # Wires([0, 1]) for op in rec.queue)
 
         pauli_words = ["XI", "YI", "ZI", "ZX", "IX", "XX", "YX", "YY", "ZY", "IY", "XY", "XZ", "YZ", "ZZ", "IZ"]
 
@@ -569,7 +569,7 @@ class TestDoubleExcitationUnitary:
 
             exp_wires = gate[2]
             res_wires = rec.queue[idx]._wires
-            assert res_wires == Wires(exp_wires)
+            assert res_wires == exp_wires #Wires(exp_wires)
 
             exp_weight = gate[3]
             res_weight = rec.queue[idx].parameters
@@ -711,7 +711,7 @@ class TestUCCSDUnitary:
 
             exp_wires = gate[2]
             res_wires = rec.queue[idx]._wires
-            assert res_wires == Wires(exp_wires)
+            assert res_wires == exp_wires #Wires(exp_wires)
 
             exp_weight = gate[3]
             res_weight = rec.queue[idx].parameters

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -132,7 +132,7 @@ class TestOperation:
         op = test_class(*pars, wires=ww)
         assert op.name == test_class.__name__
         assert op.params == pars
-        assert op._wires == Wires(ww)
+        assert op._wires == ww #Wires(ww)
 
         # too many parameters
         with pytest.raises(ValueError, match='wrong number of parameters'):
@@ -521,7 +521,7 @@ class TestObservableConstruction:
         cv_obs = qml.TensorN(wires=[0, 1])
 
         assert isinstance(cv_obs, qml.TensorN)
-        assert cv_obs.wires == Wires([0, 1])
+        assert cv_obs.wires == [0, 1]  #Wires([0, 1])
         assert cv_obs.ev_order is None
 
     def test_tensor_n_single_mode_wires_explicit(self):
@@ -530,7 +530,7 @@ class TestObservableConstruction:
         cv_obs = qml.TensorN(wires=[0])
 
         assert isinstance(cv_obs, qml.NumberOperator)
-        assert cv_obs.wires == Wires([0])
+        assert cv_obs.wires == list([0])
         assert cv_obs.ev_order == 2
 
     def test_tensor_n_single_mode_wires_implicit(self):
@@ -539,7 +539,7 @@ class TestObservableConstruction:
         cv_obs = qml.TensorN(1)
 
         assert isinstance(cv_obs, qml.NumberOperator)
-        assert cv_obs.wires == Wires([1])
+        assert cv_obs.wires == list([1])
         assert cv_obs.ev_order == 2
 
 
@@ -638,7 +638,7 @@ class TestTensor:
         X = qml.PauliX(0)
         Y = qml.Hermitian(p, wires=[1, 2])
         t = Tensor(X, Y)
-        assert t.wires == Wires([0, 1, 2])
+        assert t.wires == list([0, 1, 2])
 
     def test_params(self):
         """Test that the correct flattened list of parameters is returned"""
@@ -796,20 +796,20 @@ class TestTensor:
 
         # diagonalize the PauliX on wire 0 (H.X.H = Z)
         assert isinstance(res[0], qml.Hadamard)
-        assert res[0].wires == Wires([0])
+        assert res[0].wires == list([0])
 
         # diagonalize the PauliY on wire 1 (U.Y.U^\dagger = Z
         # where U = HSZ).
         assert isinstance(res[1], qml.PauliZ)
-        assert res[1].wires == Wires([1])
+        assert res[1].wires == list([1])
         assert isinstance(res[2], qml.S)
-        assert res[2].wires == Wires([1])
+        assert res[2].wires == list([1])
         assert isinstance(res[3], qml.Hadamard)
-        assert res[3].wires == Wires([1])
+        assert res[3].wires == list([1])
 
         # diagonalize the Hermitian observable on wires 5, 6
         assert isinstance(res[4], qml.QubitUnitary)
-        assert res[4].wires == Wires([5, 6])
+        assert res[4].wires == list([5, 6])
 
         O = O @ qml.Hadamard(4)
         res = O.diagonalizing_gates()
@@ -817,7 +817,7 @@ class TestTensor:
         # diagonalize the Hadamard observable on wire 4
         # (RY(-pi/4).H.RY(pi/4) = Z)
         assert isinstance(res[-1], qml.RY)
-        assert res[-1].wires == Wires([4])
+        assert res[-1].wires == list([4])
         assert np.allclose(res[-1].parameters, -np.pi/4, atol=tol, rtol=0)
 
     def test_diagonalizing_gates_numerically_diagonalizes(self, tol):
@@ -833,7 +833,7 @@ class TestTensor:
 
         # group the diagonalizing gates based on what wires they act on
         U_list = []
-        for _, g in itertools.groupby(diag_gates, lambda x: x.wires.tolist()):
+        for _, g in itertools.groupby(diag_gates, lambda x: x.wires):
             # extract the matrices of each diagonalizing gate
             mats = [i.matrix for i in g]
 
@@ -1019,27 +1019,27 @@ class TestDecomposition:
 
         assert rec.queue[0].name == "RZ"
         assert rec.queue[0].parameters == [np.pi/2]
-        assert rec.queue[0].wires == Wires([1])
+        assert rec.queue[0].wires == list([1])
 
         assert rec.queue[1].name == "RY"
         assert rec.queue[1].parameters == [phi/2]
-        assert rec.queue[1].wires == Wires([1])
+        assert rec.queue[1].wires == list([1])
 
         assert rec.queue[2].name == "CNOT"
         assert rec.queue[2].parameters == []
-        assert rec.queue[2].wires == Wires([0, 1])
+        assert rec.queue[2].wires == list([0, 1])
 
         assert rec.queue[3].name == "RY"
         assert rec.queue[3].parameters == [-phi/2]
-        assert rec.queue[3].wires == Wires([1])
+        assert rec.queue[3].wires == list([1])
 
         assert rec.queue[4].name == "CNOT"
         assert rec.queue[4].parameters == []
-        assert rec.queue[4].wires == Wires([0, 1])
+        assert rec.queue[4].wires == list([0, 1])
 
         assert rec.queue[5].name == "RZ"
         assert rec.queue[5].parameters == [-np.pi/2]
-        assert rec.queue[5].wires == Wires([1])
+        assert rec.queue[5].wires == list([1])
 
     @pytest.mark.parametrize("phi", [0.03236*i for i in range(5)])
     def test_crx_decomposition_correctness(self, phi, tol):
@@ -1066,19 +1066,19 @@ class TestDecomposition:
 
         assert rec.queue[0].name == "RY"
         assert rec.queue[0].parameters == [phi/2]
-        assert rec.queue[0].wires == Wires([1])
+        assert rec.queue[0].wires == list([1])
 
         assert rec.queue[1].name == "CNOT"
         assert rec.queue[1].parameters == []
-        assert rec.queue[1].wires == Wires(operation_wires)
+        assert rec.queue[1].wires == list(operation_wires)
 
         assert rec.queue[2].name == "RY"
         assert rec.queue[2].parameters == [-phi/2]
-        assert rec.queue[2].wires == Wires([1])
+        assert rec.queue[2].wires == list([1])
 
         assert rec.queue[3].name == "CNOT"
         assert rec.queue[3].parameters == []
-        assert rec.queue[3].wires == Wires(operation_wires)
+        assert rec.queue[3].wires == list(operation_wires)
 
     @pytest.mark.parametrize("phi", [0.03236*i for i in range(5)])
     def test_cry_decomposition_correctness(self, phi, tol):
@@ -1104,19 +1104,19 @@ class TestDecomposition:
 
         assert rec.queue[0].name == "PhaseShift"
         assert rec.queue[0].parameters == [phi/2]
-        assert rec.queue[0].wires == Wires([1])
+        assert rec.queue[0].wires == list([1])
 
         assert rec.queue[1].name == "CNOT"
         assert rec.queue[1].parameters == []
-        assert rec.queue[1].wires == Wires(operation_wires)
+        assert rec.queue[1].wires == list(operation_wires)
 
         assert rec.queue[2].name == "PhaseShift"
         assert rec.queue[2].parameters == [-phi/2]
-        assert rec.queue[2].wires == Wires([1])
+        assert rec.queue[2].wires == list([1])
 
         assert rec.queue[3].name == "CNOT"
         assert rec.queue[3].parameters == []
-        assert rec.queue[3].wires == Wires(operation_wires)
+        assert rec.queue[3].wires == list(operation_wires)
 
     @pytest.mark.parametrize("phi", [0.03236*i for i in range(5)])
     def test_crz_decomposition_correctness(self, phi, tol):

--- a/tests/test_qubit_device.py
+++ b/tests/test_qubit_device.py
@@ -149,13 +149,13 @@ class TestOperations:
 
         assert len(call_history) == 3
         assert isinstance(call_history[0], qml.PauliX)
-        assert call_history[0].wires == Wires([0])
+        assert call_history[0].wires == [0] #Wires([0])
 
         assert isinstance(call_history[1], qml.PauliY)
-        assert call_history[1].wires == Wires([1])
+        assert call_history[1].wires == [1]  #Wires([1])
 
         assert isinstance(call_history[2], qml.PauliZ)
-        assert call_history[2].wires == Wires([2])
+        assert call_history[2].wires == [2]  #Wires([2])
 
     def test_unsupported_operations_raise_error(self, mock_qubit_device_with_paulis_and_methods):
         """Tests that the operations are properly applied and queued"""
@@ -616,4 +616,4 @@ class TestActiveWires:
         ]
 
         res = mock_qubit_device.active_wires(queue)
-        assert res == Wires([0, 2, 5])
+        assert res == {0, 2, 5}  #Wires([0, 2, 5])


### PR DESCRIPTION
**Context:**

We are planning a PennyLane release for 22 June at relatively short notice. The current master - which is halfway into the wire refactor - breaks the ``QubitDevice`` based plugins. 

We considered the best way to solve this (releasing small changes to the plugins to make them compatible, try different hotfixes as temporary solutions,...) and decided that the quickest and safest way is to roll back the changes that made the operator attribute ``wires`` be a wires object. 
With this, everything is back to as it were for the plugins. The changes are relatively easy to pick up in the next PR #666 of the wires refactor, which rolled back some of the changes anyways. 

**Description of the Change:**

Convert ``Operation.wires`` to list and temporarily fix all the tests that have assert statements for wires. 