### PR TITLE
Reverting changes to wires of Tensor

### DIFF
--- a/pennylane/circuit_drawer/circuit_drawer.py
+++ b/pennylane/circuit_drawer/circuit_drawer.py
@@ -229,7 +229,11 @@ class CircuitDrawer:
                 if op is None:
                     continue
 
-                wires = op.wires
+                if isinstance(op, qml.operation.Tensor):
+                    # pylint: disable=protected-access
+                    wires = list(qml.utils._flatten(op.wires))
+                else:
+                    wires = op.wires
 
                 if len(wires) > 1:
                     internal_wires = self.circuit_wires_to_internal_wires(wires)

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -155,9 +155,11 @@ class CircuitGraph:
         self.num_wires = 0
         """int: number of wires the circuit contains"""
         for k, op in enumerate(ops):
-            self.num_wires = max(self.num_wires, max(op.wires) + 1)
+            self.num_wires = max(self.num_wires, max(list(_flatten(op.wires))) + 1)
             op.queue_idx = k  # store the queue index in the Operator
-            for w in set(op.wires):
+            for w in set(
+                _flatten(op.wires)
+            ):  # flatten the nested wires lists of Tensor observables
                 # Add op to the grid, to the end of wire w
                 self._grid.setdefault(w, []).append(op)
 

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -112,7 +112,7 @@ from numpy.linalg import multi_dot
 
 import pennylane as qml
 
-from .utils import pauli_eigs
+from .utils import _flatten, pauli_eigs
 from .variable import Variable
 
 # =============================================================================
@@ -978,7 +978,7 @@ class Tensor(Observable):
         Returns:
             int: number of wires
         """
-        return len(self.wires)
+        return len(list(_flatten(self.wires)))
 
     @property
     def wires(self):
@@ -987,7 +987,7 @@ class Tensor(Observable):
         Returns:
             list[int]: wires addressed by the observables in the tensor product
         """
-        return [w for o in self.obs for w in o.wires]
+        return [o.wires for o in self.obs]
 
     @property
     def params(self):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -366,7 +366,7 @@ class BaseQNode(qml.QueuingContext):
                 )
 
         # Make sure only existing wires are used.
-        for w in operator.wires:
+        for w in _flatten(operator.wires):
             if w < 0 or w >= self.num_wires:
                 raise QuantumFunctionError(
                     "Operation {} applied to invalid wire {} "
@@ -691,7 +691,7 @@ class BaseQNode(qml.QueuingContext):
             )
 
         # check that no wires are measured more than once
-        m_wires = list(w for ob in res for w in ob.wires)
+        m_wires = list(w for ob in res for w in _flatten(ob.wires))
         if len(m_wires) != len(set(m_wires)):
             raise QuantumFunctionError(
                 "Each wire in the quantum circuit can only be measured once."

--- a/tests/circuit_graph/test_circuit_graph_hash.py
+++ b/tests/circuit_graph/test_circuit_graph_hash.py
@@ -172,7 +172,7 @@ class TestCircuitGraphHash:
                         (
                          [],
                          [observable3],
-                        '|||[\'PauliZ\', \'PauliZ\'][0, 1]'
+                        '|||[\'PauliZ\', \'PauliZ\'][[0], [1]]'
                         )
 
                      ]

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -638,7 +638,7 @@ class TestTensor:
         X = qml.PauliX(0)
         Y = qml.Hermitian(p, wires=[1, 2])
         t = Tensor(X, Y)
-        assert t.wires == list([0, 1, 2])
+        assert t.wires == [[0], [1, 2]]
 
     def test_params(self):
         """Test that the correct flattened list of parameters is returned"""


### PR DESCRIPTION
**Context:**
The newly introduced Wires class is temporarily reverted #684 

One part that needs complementing is related to the Forest plugin that assumes a nested wires list for the `Tensor` operation class.

Otherwise, errors arise when running the test suite:
```python
../pennylane/pennylane/_qubit_device.py:165: in execute
    results = self.statistics(circuit.observables)
../pennylane/pennylane/_qubit_device.py:253: in statistics
    results.append(self.expval(obs))
pennylane_forest/qpu.py:186: in expval
    qubit = wire[0]
E   TypeError: 'int' object is not subscriptable
```

**Description of the Change:**
Reverting the logic for the Tensor class.

**Benefits:**
The Forest plugin will be able to handle the wires of `Tensor` again.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A