### PR TITLE
Allow interface functions to convert QNodes with pre-existing interfaces

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,26 +2,26 @@
 
 <h3>New features since last release</h3>
 
-* Adds a device test suite, located at `pennylane/plugins/tests`, which can be used 
-  to run generic tests on core or external devices calling 
-  
-  >>> pytest pennylane/plugins/tests --device default.qubit --shots 1234 --analytic False                                                                                                                                                                                                                                                                    
-  
+* Adds a device test suite, located at `pennylane/plugins/tests`, which can be used
+  to run generic tests on core or external devices calling
+
+  >>> pytest pennylane/plugins/tests --device default.qubit --shots 1234 --analytic False
+
   The command line arguments are optional.
-   
-  * If `--device` is not given, the tests are run on the core devices that ship with PennyLane. 
-  
-  * If `--shots` is not given, a default of 10000 is used. The shots argument is ignored for devices running in 
+
+  * If `--device` is not given, the tests are run on the core devices that ship with PennyLane.
+
+  * If `--shots` is not given, a default of 10000 is used. The shots argument is ignored for devices running in
     analytic mode.
-  
+
   * If `--analytic` is not given, the device's default is used.
-  
-  Other arguments of the device, such as `qiskit.aer`'s compulsory `backend_options`, 
+
+  Other arguments of the device, such as `qiskit.aer`'s compulsory `backend_options`,
   can be defined in the `config.toml` file containing custom PennyLane configurations.
-                                                                                                                                                        
-  If the tests are run on external devices, the device and its dependencies must be 
-  installed locally. 
-  
+
+  If the tests are run on external devices, the device and its dependencies must be
+  installed locally.
+
 * Added the `decompose_hamiltonian` method to the `utils` module. The method can be used to
   decompose a Hamiltonian into a linear combination of Pauli operators.
   [(#671)](https://github.com/XanaduAI/pennylane/pull/671)
@@ -45,13 +45,19 @@
 
 <h3>Breaking changes</h3>
 
+<h3>Bug fixes</h3>
+
+* The PennyLane interface conversion functions can now convert QNodes with
+  pre-existing interfaces.
+  [(#707)](https://github.com/XanaduAI/pennylane/pull/707)
+
 <h3>Documentation</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-Antal Száva, Nicola Vitucci
+Josh Izaac, Antal Száva, Nicola Vitucci
 
 # Release 0.10.0 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,7 +5,9 @@
 * Adds a device test suite, located at `pennylane/plugins/tests`, which can be used
   to run generic tests on core or external devices calling
 
+  ```pycon
   >>> pytest pennylane/plugins/tests --device default.qubit --shots 1234 --analytic False
+  ```
 
   The command line arguments are optional.
 

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -36,7 +36,7 @@ def to_autograd(qnode):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode # pylint: disable=protected-access
+        qnode = qnode._qnode  # pylint: disable=protected-access
 
     class AutogradQNode(qnode.__class__):
         """QNode that works with Autograd."""
@@ -109,5 +109,5 @@ def to_autograd(qnode):
     autograd.extend.defvjp(AutogradQNode.evaluate, AutogradQNode.QNode_vjp, argnums=[1])
     converted_qnode = deepcopy(qnode)
     converted_qnode.__class__ = AutogradQNode
-    converted_qnode._qnode = qnode # pylint: disable=protected-access
+    converted_qnode._qnode = qnode  # pylint: disable=protected-access
     return converted_qnode

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -36,7 +36,7 @@ def to_autograd(qnode):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode
+        qnode = qnode._qnode # pylint: disable=protected-access
 
     class AutogradQNode(qnode.__class__):
         """QNode that works with Autograd."""
@@ -109,5 +109,5 @@ def to_autograd(qnode):
     autograd.extend.defvjp(AutogradQNode.evaluate, AutogradQNode.QNode_vjp, argnums=[1])
     converted_qnode = deepcopy(qnode)
     converted_qnode.__class__ = AutogradQNode
-    converted_qnode._qnode = qnode
+    converted_qnode._qnode = qnode # pylint: disable=protected-access
     return converted_qnode

--- a/pennylane/interfaces/autograd.py
+++ b/pennylane/interfaces/autograd.py
@@ -14,7 +14,6 @@
 """
 Differentiable quantum nodes with Autograd interface.
 """
-from copy import deepcopy
 import autograd.extend
 import autograd.builtins
 
@@ -107,7 +106,6 @@ def to_autograd(qnode):
 
     # define the vector-Jacobian product function for AutogradQNode.evaluate
     autograd.extend.defvjp(AutogradQNode.evaluate, AutogradQNode.QNode_vjp, argnums=[1])
-    converted_qnode = deepcopy(qnode)
-    converted_qnode.__class__ = AutogradQNode
-    converted_qnode._qnode = qnode  # pylint: disable=protected-access
-    return converted_qnode
+    qnode._qnode = qnode  # pylint: disable=protected-access
+    qnode.__class__ = AutogradQNode
+    return qnode

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -76,6 +76,13 @@ def to_tf(qnode, dtype=None):
     Returns:
         function: the QNode as a TensorFlow function
     """
+    qnode_interface = getattr(qnode, "interface", None)
+
+    if qnode_interface == "tf":
+        return qnode
+
+    if qnode_interface is not None:
+        qnode = qnode._qnode
 
     class TFQNode(partial):
         """TensorFlow QNode"""
@@ -112,6 +119,7 @@ def to_tf(qnode, dtype=None):
         func = qnode.func
         set_trainable_args = qnode.set_trainable_args
         get_trainable_args = qnode.get_trainable_args
+        _qnode = qnode
 
         # Bind QNode attributes. Note that attributes must be
         # bound as properties; by making use of closure, we ensure

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -82,7 +82,7 @@ def to_tf(qnode, dtype=None):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode
+        qnode = qnode._qnode # pylint: disable=protected-access
 
     class TFQNode(partial):
         """TensorFlow QNode"""

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -78,7 +78,7 @@ def to_tf(qnode, dtype=None):
     """
     qnode_interface = getattr(qnode, "interface", None)
 
-    if qnode_interface == "tf":
+    if qnode_interface == "tf" and dtype == qnode._dtype:
         return qnode
 
     if qnode_interface is not None:
@@ -120,6 +120,7 @@ def to_tf(qnode, dtype=None):
         set_trainable_args = qnode.set_trainable_args
         get_trainable_args = qnode.get_trainable_args
         _qnode = qnode
+        _dtype = dtype
 
         # Bind QNode attributes. Note that attributes must be
         # bound as properties; by making use of closure, we ensure

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -82,7 +82,7 @@ def to_tf(qnode, dtype=None):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode # pylint: disable=protected-access
+        qnode = qnode._qnode  # pylint: disable=protected-access
 
     class TFQNode(partial):
         """TensorFlow QNode"""

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -79,7 +79,7 @@ def to_tf(qnode, dtype=None):
     qnode_interface = getattr(qnode, "interface", None)
 
     if qnode_interface == "tf" and dtype == qnode._dtype:
-            return qnode
+        return qnode
 
     if qnode_interface is not None:
         qnode = qnode._qnode  # pylint: disable=protected-access

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -78,10 +78,13 @@ def to_tf(qnode, dtype=None):
     """
     qnode_interface = getattr(qnode, "interface", None)
 
-    if qnode_interface == "tf" and dtype == qnode._dtype:
-        return qnode
+    if qnode_interface == "tf":
+        if dtype == qnode._dtype:
+            return qnode
 
-    if qnode_interface is not None:
+        qnode = qnode._qnode
+
+    elif qnode_interface is not None:
         qnode = qnode._qnode  # pylint: disable=protected-access
 
     class TFQNode(partial):

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -78,7 +78,7 @@ def to_tf(qnode, dtype=None):
     """
     qnode_interface = getattr(qnode, "interface", None)
 
-    if qnode_interface == "tf" and dtype == qnode._dtype:
+    if qnode_interface == "tf" and dtype == qnode._dtype:  # pylint: disable=protected-access
         return qnode
 
     if qnode_interface is not None:

--- a/pennylane/interfaces/tf.py
+++ b/pennylane/interfaces/tf.py
@@ -79,10 +79,10 @@ def to_tf(qnode, dtype=None):
     qnode_interface = getattr(qnode, "interface", None)
 
     if qnode_interface == "tf":
-        if dtype == qnode._dtype:
+        if dtype == qnode._dtype:  # pylint: disable=protected-access
             return qnode
 
-        qnode = qnode._qnode
+        qnode = qnode._qnode  # pylint: disable=protected-access
 
     elif qnode_interface is not None:
         qnode = qnode._qnode  # pylint: disable=protected-access

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -149,7 +149,7 @@ def to_torch(qnode):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode
+        qnode = qnode._qnode # pylint: disable=protected-access
 
     class _TorchQNode(torch.autograd.Function):
         """The TorchQNode"""

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -149,7 +149,7 @@ def to_torch(qnode):
         return qnode
 
     if qnode_interface is not None:
-        qnode = qnode._qnode # pylint: disable=protected-access
+        qnode = qnode._qnode  # pylint: disable=protected-access
 
     class _TorchQNode(torch.autograd.Function):
         """The TorchQNode"""

--- a/pennylane/interfaces/torch.py
+++ b/pennylane/interfaces/torch.py
@@ -143,6 +143,13 @@ def to_torch(qnode):
     Returns:
         torch.autograd.Function: the QNode as a PyTorch autograd function
     """
+    qnode_interface = getattr(qnode, "interface", None)
+
+    if qnode_interface == "torch":
+        return qnode
+
+    if qnode_interface is not None:
+        qnode = qnode._qnode
 
     class _TorchQNode(torch.autograd.Function):
         """The TorchQNode"""
@@ -259,6 +266,7 @@ def to_torch(qnode):
         func = qnode.func
         set_trainable_args = qnode.set_trainable_args
         get_trainable_args = qnode.get_trainable_args
+        _qnode = qnode
 
         # Bind QNode attributes. Note that attributes must be
         # bound as properties; by making use of closure, we ensure

--- a/tests/interfaces/test_autograd.py
+++ b/tests/interfaces/test_autograd.py
@@ -1050,7 +1050,6 @@ class TestConversion:
         assert qnode.interface == interface
 
         converted_qnode = to_autograd(qnode)
-        assert converted_qnode is not qnode
 
         x = 0.4
         res = converted_qnode(x)

--- a/tests/interfaces/test_tf.py
+++ b/tests/interfaces/test_tf.py
@@ -1309,26 +1309,9 @@ class TestConversion:
         grad = tape.gradient(res, x)
         assert np.allclose(grad, -tf.sin(x), atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("interface", ["torch"])
-    def test_torch_conversion(self, qnode, tol):
-        """Tests that the to_tf() function correctly converts torch qnodes."""
-        converted_qnode = to_tf(qnode)
-        assert converted_qnode is not qnode
-        assert converted_qnode._qnode is qnode._qnode
-
-        x = tf.Variable(0.4)
-
-        with tf.GradientTape() as tape:
-            res = converted_qnode(x)
-
-        assert np.allclose(res, tf.cos(x), atol=tol, rtol=0)
-
-        grad = tape.gradient(res, x)
-        assert np.allclose(grad, -tf.sin(x), atol=tol, rtol=0)
-
-    @pytest.mark.parametrize("interface", [None, "autograd"])
-    def test_autograd_conversion(self, qnode, tol):
-        """Tests that the to_tf() function correctly converts both autograd qnodes
+    @pytest.mark.parametrize("interface", [None, "torch", "autograd"])
+    def test_other_conversion(self, qnode, tol):
+        """Tests that the to_tf() function correctly converts both torch and autograd qnodes
         and QNodes with no interface."""
         converted_qnode = to_tf(qnode)
         assert converted_qnode is not qnode

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -1253,25 +1253,10 @@ class TestConversion:
         assert np.allclose(res.detach().numpy(), np.cos(x_val), atol=tol, rtol=0)
         assert np.allclose(x.grad, -np.sin(x_val), atol=tol, rtol=0)
 
-    @pytest.mark.parametrize("interface", ["tf"])
-    def test_tf_conversion(self, qnode, tol):
-        """Tests that the to_torch() function correctly converts tf qnodes."""
-        converted_qnode = to_torch(qnode)
-        assert converted_qnode is not qnode
-        assert converted_qnode._qnode is qnode._qnode
-
-        x_val = 0.4
-        x = torch.tensor(x_val, requires_grad=True)
-        res = converted_qnode(x)
-        res.backward()
-
-        assert np.allclose(res.detach().numpy(), np.cos(x_val), atol=tol, rtol=0)
-        assert np.allclose(x.grad, -np.sin(x_val), atol=tol, rtol=0)
-
-    @pytest.mark.parametrize("interface", [None, "autograd"])
-    def test_autograd_conversion(self, qnode, tol):
-        """Tests that the to_torch() function correctly converts both autograd qnodes
-        and QNodes with no interface."""
+    @pytest.mark.parametrize("interface", [None, "autograd", "tf"])
+    def test_other_conversion(self, qnode, tol):
+        """Tests that the to_torch() function correctly converts both tf and autograd qnodes and
+        QNodes with no interface."""
         converted_qnode = to_torch(qnode)
         assert converted_qnode is not qnode
         assert converted_qnode._qnode is getattr(qnode, "_qnode", qnode)

--- a/tests/interfaces/test_torch.py
+++ b/tests/interfaces/test_torch.py
@@ -27,7 +27,7 @@ import pennylane as qml
 from pennylane.utils import _flatten, unflatten
 from pennylane.qnodes import QNode, QuantumFunctionError
 from pennylane._device import DeviceError
-from pennylane.interfaces.torch import unflatten_torch
+from pennylane.interfaces.torch import to_torch, unflatten_torch
 
 from gate_data import CNOT, Rotx, Roty, Rotz, I, Y, Z
 
@@ -1216,3 +1216,70 @@ class TestParameterHandlingIntegration:
 
         with pytest.raises(qml.QuantumFunctionError, match="cannot be modified"):
             circuit(x, y, z)
+
+
+class TestConversion:
+    """Integration tests to make sure that to_torch() correctly converts
+    QNodes with/without pre-existing interfaces"""
+
+    @pytest.fixture
+    def qnode(self, interface, tf_support):
+        """Returns a simple QNode corresponding to cos(x),
+        with interface as determined by the interface fixture"""
+        if interface == "tf" and not tf_support:
+            pytest.skip("Skipped, no tf support")
+
+        dev = qml.device("default.qubit", wires=1)
+
+        @qml.qnode(dev, interface=interface)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        return circuit
+
+    @pytest.mark.parametrize("interface", ["torch"])
+    def test_torch_conversion(self, qnode, tol):
+        """Tests that the to_torch() function ignores QNodes that already
+        have the torch interface."""
+        converted_qnode = to_torch(qnode)
+        assert converted_qnode is qnode
+
+        x_val = 0.4
+        x = torch.tensor(x_val, requires_grad=True)
+        res = converted_qnode(x)
+        res.backward()
+
+        assert np.allclose(res.detach().numpy(), np.cos(x_val), atol=tol, rtol=0)
+        assert np.allclose(x.grad, -np.sin(x_val), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("interface", ["tf"])
+    def test_tf_conversion(self, qnode, tol):
+        """Tests that the to_torch() function correctly converts tf qnodes."""
+        converted_qnode = to_torch(qnode)
+        assert converted_qnode is not qnode
+        assert converted_qnode._qnode is qnode._qnode
+
+        x_val = 0.4
+        x = torch.tensor(x_val, requires_grad=True)
+        res = converted_qnode(x)
+        res.backward()
+
+        assert np.allclose(res.detach().numpy(), np.cos(x_val), atol=tol, rtol=0)
+        assert np.allclose(x.grad, -np.sin(x_val), atol=tol, rtol=0)
+
+    @pytest.mark.parametrize("interface", [None, "autograd"])
+    def test_autograd_conversion(self, qnode, tol):
+        """Tests that the to_torch() function correctly converts both autograd qnodes
+        and QNodes with no interface."""
+        converted_qnode = to_torch(qnode)
+        assert converted_qnode is not qnode
+        assert converted_qnode._qnode is getattr(qnode, "_qnode", qnode)
+
+        x_val = 0.4
+        x = torch.tensor(x_val, requires_grad=True)
+        res = converted_qnode(x)
+        res.backward()
+
+        assert np.allclose(res.detach().numpy(), np.cos(x_val), atol=tol, rtol=0)
+        assert np.allclose(x.grad, -np.sin(x_val), atol=tol, rtol=0)


### PR DESCRIPTION
**Context:**

The PennyLane interface functions `to_torch(qnode)`, `to_tf(qnode)`, and `to_autograd(qnode)` currently all make the assumption that the input QNode either has no attached interface (i.e., it is a 'bare' `JacobianQNode`) or that it has an autograd interface.

This causes issues if the QNode to be converted has the same interface as the one to be applied (see PL-451, whereby `to_tf(to_tf(qnode))` causes the gradient to be zeroed), or already has a pre-existing interface.

**Description of the Change:**

* All interfaces now keep a reference to the original bare QNode under the `_qnode` attribute.

* The interface functions return the input QNode, without modification, if the input QNode interface matches the function.

* If the input QNode has a pre-existing interface, then the interface functions instead return `to_interface(qnode._qnode)`

**Benefits:**

The interface functions contain logic detailing how to handle QNodes with no interfaces and pre-existing interfaces. Higher level abstractions that depend on these functions (such as the `qml.qnn` module) can now use these functions without worrying about the interface of input QNodes.

**Possible Drawbacks:**

While writing tests for `to_autograd()`, I noticed that it has a side-effect; it mutates the input QNode _in addition_ to returning a new QNode. I attempted to modify `to_autograd()` to perform a deep copy to ensure this no longer happens. This worked for simple QNodes, but QNode with tensor observables would not copy correctly --- the output would always be the ground state.

**Related GitHub Issues:** PL-451
