### PR TITLE
Make QubitDevice's estimate_probability independent of the number of shots

### DIFF
--- a/pennylane/_qubit_device.py
+++ b/pennylane/_qubit_device.py
@@ -410,7 +410,7 @@ class QubitDevice(Device):
         # count the basis state occurrences, and construct the probability vector
         basis_states, counts = np.unique(indices, return_counts=True)
         prob = np.zeros([2 ** len(wires)], dtype=np.float64)
-        prob[basis_states] = counts / self.shots
+        prob[basis_states] = counts / len(samples)
         return self._asarray(prob, dtype=self.R_DTYPE)
 
     def probability(self, wires=None):


### PR DESCRIPTION
Currently, the ``estimate_probability`` method of ``QubitDevice`` normalises probabilities by using the number of shots. There may be future pathological cases where the shots are changed, but the collected samples (in ``self._samples``) are not. For example, when we use the method directly:

```python
import pennylane as qml

dev = qml.device('default.qubit', wires=2, analytic=False)

@qml.qnode(dev)
def circuit():
    qml.RX(0.5, wires=0)
    qml.RX(0.5, wires=1)
    return qml.probs(wires=[0, 1])

circuit()
print(sum(dev.estimate_probability())) # 1.0
dev.shots = 10
print(sum(dev.estimate_probability())) # 100.0
```

This PR changes the method to use the length of the sample array instead.