### PR TITLE
Refactor implementation of the Sz observable

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -41,6 +41,10 @@
   ```
 <h3>Improvements</h3>
 
+* The total-spin projection observable can be built straightforwardly using the
+  function ``spin_z`` as implemented in the ``obs`` module.
+  [(#)]()
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>
@@ -64,12 +68,6 @@ Juan Miguel Arrazola, Alain Delgado, Josh Izaac, Soran Jahangiri, Maria Schuld
   [(#629)](https://github.com/XanaduAI/pennylane/pull/629)
 
 <h3>Improvements</h3>
-
-* The function ``convert_hamiltonian`` has been renamed to ``convert_observable``
-  since it can be used to convert any OpenFermion QubitOperator to a PennyLane
-  Observable. ``convert_observable`` will be used in the ``obs`` module to build
-  observables linked to molecular properties.
-  [(#677)](https://github.com/XanaduAI/pennylane/pull/677)
 
 <h3>Breaking changes</h3>
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -43,7 +43,7 @@
 
 * The total-spin projection observable can be built straightforwardly using the
   function ``spin_z`` as implemented in the ``obs`` module.
-  [(#)]()
+  [(#711)](https://github.com/XanaduAI/pennylane/pull/711)
 
 <h3>Breaking changes</h3>
 

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -42,7 +42,7 @@
 <h3>Improvements</h3>
 
 * The total-spin projection observable can be built straightforwardly using the
-  function ``spin_z`` as implemented in the ``obs`` module.
+  function `spin_z` as implemented in the `obs` module.
   [(#711)](https://github.com/XanaduAI/pennylane/pull/711)
 
 <h3>Breaking changes</h3>

--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -69,6 +69,12 @@ Juan Miguel Arrazola, Alain Delgado, Josh Izaac, Soran Jahangiri, Maria Schuld
 
 <h3>Improvements</h3>
 
+* The function ``convert_hamiltonian`` has been renamed to ``convert_observable``
+  since it can be used to convert any OpenFermion QubitOperator to a PennyLane
+  Observable. ``convert_observable`` will be used in the ``obs`` module to build
+  observables linked to molecular properties.
+  [(#677)](https://github.com/XanaduAI/pennylane/pull/677)
+
 <h3>Breaking changes</h3>
 
 * Removes support for Python 3.5.

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -376,9 +376,9 @@ def particle_number(n_orbitals, mapping="jordan_wigner"):
 
 
 __all__ = [
-    "_spin2_matrix_elements",
-    "spin2",
     "observable",
-    "spin_z",
     "particle_number",
+    "spin_z",
+    "spin2",
+    "_spin2_matrix_elements",
 ]

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -313,7 +313,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
 
 def spin_z(n_orbitals, mapping="jordan_wigner"):
     r"""Computes the total spin projection operator :math:`\hat{S}_z` in the Pauli basis.
-    
+
     The second-quantized operator :math:`\hat{S}_z` reads,
 
     .. math::
@@ -324,11 +324,11 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
         \langle \alpha \vert \hat{s}_z \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
 
     where :math:`m_\alpha = \pm 1/2` denotes the spin-projection quantum number of
-    the single-particle state :math:`\vert \alpha \rangle` and :math:`\hat{c}^\dagger`
+    the single-particle states :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger`
     and :math:`\hat{c}` are the particle creation and annihilation operators, respectively.
 
     Args:
-        n_orbitals (str): number of orbitals. If an active space is defined 'n_orbitals'
+        n_orbitals (str): Number of orbitals. If an active space is defined, 'n_orbitals'
             is the number of active orbitals.
         mapping (str): Specifies the transformation to map the fermionic operator to the
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
@@ -339,23 +339,23 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     **Example**
 
     >>> n_orbitals = 2
-    >>> Sz_obs = spin_z(n_orbitals, mapping="jordan_wigner")
-    >>> print(Sz_obs)
+    >>> Sz = spin_z(n_orbitals, mapping="jordan_wigner")
+    >>> print(Sz)
     (-0.25) [Z0]
     + (0.25) [Z1]
     + (-0.25) [Z2]
     + (0.25) [Z3]
     """
 
-    n_spin_orbs = 2*n_orbitals
-    sz = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
+    n_spin_orbs = 2 * n_orbitals
+    sz_orb = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
 
     # build table with matrix elements
-    table_me = np.zeros((n_spin_orbs, 3))
+    table = np.zeros((n_spin_orbs, 3))
     for alpha in range(n_spin_orbs):
-        table_me[alpha] = np.array([alpha, alpha, sz[alpha]])
+        table[alpha] = np.array([alpha, alpha, sz_orb[alpha]])
 
-    return observable(table_me, mapping=mapping)
+    return observable(table, mapping=mapping)
 
 
 __all__ = [

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -319,13 +319,13 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     .. math::
 
         \hat{S}_z = \sum_{\alpha, \beta} \langle \alpha \vert \hat{s}_z \vert \beta \rangle
-        ~ \hat{c}_\alpha^\dagger\hat{c}_\beta,
+        ~ \hat{c}_\alpha^\dagger \hat{c}_\beta,
 
         \langle \alpha \vert \hat{s}_z \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
 
-    where :math:`m_\alpha = \pm 1/2` refers to the spin quantum number of the single-particle
-    state :math:`\vert \alpha \rangle` and :math:`\hat{c}^\dagger` and :math:`\hat{c}` denote
-    are the particle creation and annihilation operators.
+    where :math:`m_\alpha = \pm 1/2` denotes the spin-projection quantum number of
+    the single-particle state :math:`\vert \alpha \rangle` and :math:`\hat{c}^\dagger`
+    and :math:`\hat{c}` are the particle creation and annihilation operators, respectively.
 
     Args:
         n_orbitals (str): number of orbitals. If an active space is defined 'n_orbitals'
@@ -339,7 +339,7 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     **Example**
 
     >>> n_orbitals = 2
-    >>> Sz_obs = spin_z(n_orbitals, mapping='jordan_wigner')
+    >>> Sz_obs = spin_z(n_orbitals, mapping="jordan_wigner")
     >>> print(Sz_obs)
     (-0.25) [Z0]
     + (0.25) [Z1]

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -334,7 +334,7 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
 
     Returns:
-        pennylane.Hamiltonian: the fermionic-to-qubit transformed :math:`\hat{S}_z` observable
+        pennylane.Hamiltonian: the spin projection :math:`\hat{S}_z` observable
 
     **Example**
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -314,7 +314,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
 def spin_z(n_orbitals, mapping="jordan_wigner"):
     r"""Computes the total spin projection operator :math:`\hat{S}_z` in the Pauli basis.
 
-    The second-quantized operator :math:`\hat{S}_z` reads,
+    The total spin operator :math:`\hat{S}_z` is given by
 
     .. math::
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -320,11 +320,11 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
 
         \hat{S}_z = \sum_{\alpha, \beta} \langle \alpha \vert \hat{s}_z \vert \beta \rangle
         ~ \hat{c}_\alpha^\dagger \hat{c}_\beta, ~~ \langle \alpha \vert \hat{s}_z
-        \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
+        \vert \beta \rangle = s_z_\alpha \delta_{\alpha,\beta},
 
-    where :math:`m_\alpha = \pm 1/2` denotes the spin-projection quantum number of
-    the single-particle state :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger`
-    and :math:`\hat{c}` are the particle creation and annihilation operators, respectively.
+    where :math:`s_z_\alpha = \pm 1/2` is the spin-projection of the single-particle state
+    :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger` and :math:`\hat{c}`
+    are the particle creation and annihilation operators, respectively.
 
     Args:
         n_orbitals (str): Number of orbitals. If an active space is defined, 'n_orbitals'

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -324,7 +324,7 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
         \langle \alpha \vert \hat{s}_z \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
 
     where :math:`m_\alpha = \pm 1/2` denotes the spin-projection quantum number of
-    the single-particle states :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger`
+    the single-particle state :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger`
     and :math:`\hat{c}` are the particle creation and annihilation operators, respectively.
 
     Args:

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -320,9 +320,9 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
 
         \hat{S}_z = \sum_{\alpha, \beta} \langle \alpha \vert \hat{s}_z \vert \beta \rangle
         ~ \hat{c}_\alpha^\dagger \hat{c}_\beta, ~~ \langle \alpha \vert \hat{s}_z
-        \vert \beta \rangle = s_z_\alpha \delta_{\alpha,\beta},
+        \vert \beta \rangle = s_{z_\alpha} \delta_{\alpha,\beta},
 
-    where :math:`s_z_\alpha = \pm 1/2` is the spin-projection of the single-particle state
+    where :math:`s_{z_\alpha} = \pm 1/2` is the spin-projection of the single-particle state
     :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger` and :math:`\hat{c}`
     are the particle creation and annihilation operators, respectively.
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -319,9 +319,8 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     .. math::
 
         \hat{S}_z = \sum_{\alpha, \beta} \langle \alpha \vert \hat{s}_z \vert \beta \rangle
-        ~ \hat{c}_\alpha^\dagger \hat{c}_\beta,
-
-        \langle \alpha \vert \hat{s}_z \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
+        ~ \hat{c}_\alpha^\dagger \hat{c}_\beta, ~~ \langle \alpha \vert \hat{s}_z
+        \vert \beta \rangle = m_\alpha \delta_{\alpha,\beta},
 
     where :math:`m_\alpha = \pm 1/2` denotes the spin-projection quantum number of
     the single-particle state :math:`\vert \alpha \rangle`. The operators :math:`\hat{c}^\dagger`
@@ -334,7 +333,7 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
 
     Returns:
-        pennylane.Hamiltonian: the spin projection :math:`\hat{S}_z` observable
+        pennylane.Hamiltonian: the total spin projection :math:`\hat{S}_z` observable
 
     **Example**
 
@@ -348,12 +347,9 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     """
 
     n_spin_orbs = 2 * n_orbitals
+    r = np.arange(n_spin_orbs)
     sz_orb = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
-
-    # build table with matrix elements
-    table = np.zeros((n_spin_orbs, 3))
-    for alpha in range(n_spin_orbs):
-        table[alpha] = np.array([alpha, alpha, sz_orb[alpha]])
+    table = np.vstack([r, r, sz_orb]).T
 
     return observable(table, mapping=mapping)
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -333,7 +333,7 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
             Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
 
     Returns:
-        pennylane.Hamiltonian: the total spin projection :math:`\hat{S}_z` observable
+        pennylane.Hamiltonian: the total spin projection observable :math:`\hat{S}_z`
 
     **Example**
 
@@ -345,6 +345,11 @@ def spin_z(n_orbitals, mapping="jordan_wigner"):
     + (-0.25) [Z2]
     + (0.25) [Z3]
     """
+
+    if n_orbitals <= 0:
+        raise ValueError(
+            "'n_orbitals' must be greater than 0; got for 'n_orbitals' {}".format(n_orbitals)
+        )
 
     n_spin_orbs = 2 * n_orbitals
     r = np.arange(n_spin_orbs)

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -314,7 +314,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
 def spin_z(n_orbitals, mapping="jordan_wigner"):
     r"""Computes the total spin projection operator :math:`\hat{S}_z` in the Pauli basis.
 
-    The total spin operator :math:`\hat{S}_z` is given by
+    The total spin projection operator :math:`\hat{S}_z` is given by
 
     .. math::
 

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -44,3 +44,15 @@ def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
     monkeypatch.setattr(Sz_qubit_op, "terms", terms_exp)
 
     assert qchem._qubit_operators_equivalent(Sz_qubit_op, Sz)
+
+
+@pytest.mark.parametrize(
+    ("n_orbitals", "msg_match"),
+    [(-3, "'n_orbitals' must be greater than 0"), (0, "'n_orbitals' must be greater than 0"),],
+)
+def test_exception_spin_z(n_orbitals, msg_match):
+    """Test that the function `'spin_z'` throws an exception if the
+    number of orbitals is less than zero."""
+
+    with pytest.raises(ValueError, match=msg_match):
+        qchem.spin_z(n_orbitals)

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -7,51 +7,15 @@ from pennylane import qchem
 
 from openfermion.ops._qubit_operator import QubitOperator
 
-ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 
-me = np.array([[0.0, 0.0, 0.5], [1.0, 1.0, -0.5], [2.0, 2.0, 0.5], [3.0, 3.0, -0.5]])
-
-me_lih = np.array(
-    [
-        [0.0, 0.0, 0.5],
-        [1.0, 1.0, -0.5],
-        [2.0, 2.0, 0.5],
-        [3.0, 3.0, -0.5],
-        [4.0, 4.0, 0.5],
-        [5.0, 5.0, -0.5],
-    ]
-)
-
-
-@pytest.mark.parametrize(
-    ("mol_name", "n_act_elect", "n_act_orb", "sz_me_exp"),
-    [
-        ("h2_pyscf", None, None, me),
-        ("h2_pyscf", 2, None, me),
-        ("lih", 2, 2, me),
-        ("lih", None, 3, me_lih),
-    ],
-)
-def test_get_spinZ_matrix_elements(mol_name, n_act_elect, n_act_orb, sz_me_exp, tol):
-    r"""Test that the table of matrix elements
-    :math:`\langle \alpha \vert \hat{s}_z \vert \beta \rangle` are computed correctly
-    for different choices of the active space."""
-
-    sz_me_res = qchem.get_spinZ_matrix_elements(
-        mol_name, ref_dir, n_active_electrons=n_act_elect, n_active_orbitals=n_act_orb
-    )
-
-    assert np.allclose(sz_me_res, sz_me_exp, **tol)
-
-
-terms_lih_jw = {
+terms_1_jw = {
     ((0, "Z"),): (-0.25 + 0j),
     ((1, "Z"),): (0.25 + 0j),
     ((2, "Z"),): (-0.25 + 0j),
     ((3, "Z"),): (0.25 + 0j),
 }
 
-terms_lih_anion_bk = {
+terms_2_bk = {
     ((0, "Z"),): (-0.25 + 0j),
     ((0, "Z"), (1, "Z")): (0.25 + 0j),
     ((2, "Z"),): (-0.25 + 0j),
@@ -62,27 +26,24 @@ terms_lih_anion_bk = {
 
 
 @pytest.mark.parametrize(
-    ("mol_name", "n_act_elect", "n_act_orb", "mapping", "terms_exp"),
+    ("n_orbitals", "mapping", "terms_exp"),
     [
-        ("lih", 2, 2, "JORDAN_wigner", terms_lih_jw),
-        ("lih_anion", 3, 3, "bravyi_KITAEV", terms_lih_anion_bk),
+        (2 , "JORDAN_wigner", terms_1_jw),
+        (3 , "bravyi_KITAEV", terms_2_bk),
     ],
 )
-def test_build_sz_observable(mol_name, n_act_elect, n_act_orb, mapping, terms_exp, monkeypatch):
-    r"""Tests the correctness of the built total-spin projection observable :math:`\hat{S}_z`.
+def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
+    r"""Tests the correctness of the :math:`\hat{S}_z` observable built by the
+    `'spin_z'` function.
 
-    The parametrized inputs are `.terms` attribute of the total spin `QubitOperator.
-    The equality checking is implemented in the `qchem` module itself as it could be
-    something useful to the users as well.
+    The parametrized inputs are `.terms` attribute of the `QubitOperator. The equality
+    checking is implemented in the `qchem` module itself as it could be something
+    useful to the users as well.
     """
 
-    sz_me_table = qchem.get_spinZ_matrix_elements(
-        mol_name, ref_dir, n_active_electrons=n_act_elect, n_active_orbitals=n_act_orb
-    )
+    Sz_obs = qchem.spin_z(n_orbitals, mapping=mapping)
 
-    sz_obs = qchem.observable(sz_me_table, mapping=mapping)
+    Sz_qubit_op = QubitOperator()
+    monkeypatch.setattr(Sz_qubit_op, "terms", terms_exp)
 
-    sz_qubit_op = QubitOperator()
-    monkeypatch.setattr(sz_qubit_op, "terms", terms_exp)
-
-    assert qchem._qubit_operators_equivalent(sz_qubit_op, sz_obs)
+    assert qchem._qubit_operators_equivalent(Sz_qubit_op, Sz_obs)

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -31,7 +31,7 @@ terms_2_bk = {
 )
 def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
     r"""Tests the correctness of the :math:`\hat{S}_z` observable built by the
-    `'spin_z'` function.
+    function `'spin_z'`.
 
     The parametrized inputs are `.terms` attribute of the `QubitOperator. The equality
     checking is implemented in the `qchem` module itself as it could be something

--- a/qchem/tests/test_sz_obs.py
+++ b/qchem/tests/test_sz_obs.py
@@ -27,10 +27,7 @@ terms_2_bk = {
 
 @pytest.mark.parametrize(
     ("n_orbitals", "mapping", "terms_exp"),
-    [
-        (2 , "JORDAN_wigner", terms_1_jw),
-        (3 , "bravyi_KITAEV", terms_2_bk),
-    ],
+    [(2, "JORDAN_wigner", terms_1_jw), (3, "bravyi_KITAEV", terms_2_bk),],
 )
 def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
     r"""Tests the correctness of the :math:`\hat{S}_z` observable built by the
@@ -41,9 +38,9 @@ def test_spin_z(n_orbitals, mapping, terms_exp, monkeypatch):
     useful to the users as well.
     """
 
-    Sz_obs = qchem.spin_z(n_orbitals, mapping=mapping)
+    Sz = qchem.spin_z(n_orbitals, mapping=mapping)
 
     Sz_qubit_op = QubitOperator()
     monkeypatch.setattr(Sz_qubit_op, "terms", terms_exp)
 
-    assert qchem._qubit_operators_equivalent(Sz_qubit_op, Sz_obs)
+    assert qchem._qubit_operators_equivalent(Sz_qubit_op, Sz)


### PR DESCRIPTION
**Context:**
This is part of the refactoring of the ``obs`` module containing the functionalities to build many-body observables.

**Description of the Change:**
The total-spin projection operator ``Sz`` is constructed by calling the function ``spin_z`` as implemented in the ``obs`` module. 

**Benefits:**
The function to construct the observable is simpler. It does not depend on any external-to-pennylane data structure and returns directly the observable. 

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.