### PR TITLE
Refactor implementation of the total spin observable S2

### DIFF
--- a/qchem/CHANGELOG.md
+++ b/qchem/CHANGELOG.md
@@ -41,6 +41,10 @@
   ```
 <h3>Improvements</h3>
 
+* The total spin observable S^2 can be built straightforwardly using the
+  function `spin2` as implemented in the `obs` module.
+  [(#714)](https://github.com/XanaduAI/pennylane/pull/714)
+
 <h3>Breaking changes</h3>
 
 <h3>Documentation</h3>

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -240,7 +240,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
     **Example**
 
     >>> table = np.array([[0.0, 0.0, 0.4], [1.0, 1.0, -0.5], [1.0, 0.0, 0.0]])
-    >>> observable(table, init_term=1 / 4, mapping="bravyi_kitaev")
+    >>> print(observable(table, init_term=1 / 4, mapping="bravyi_kitaev"))
     (0.2) [I0]
     + (-0.2) [Z0]
     + (0.25) [Z0 Z1]

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -35,7 +35,6 @@ def _spin2_matrix_elements(sz):
         \langle ~ (\alpha, s_{z_\alpha});~ (\beta, s_{z_\beta}) ~ \vert \hat{s}_1 &&
         \cdot \hat{s}_2 \vert ~ (\gamma, s_{z_\gamma}); ~ (\delta, s_{z_\gamma}) ~ \rangle =
         \delta_{\alpha,\delta} \delta_{\beta,\gamma} \\
-
         && \times \left( \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}+1}
         \delta_{s_{z_\beta}, s_{z_\gamma}-1} + \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}-1}
         \delta_{s_{z_\beta}, s_{z_\gamma}+1} + s_{z_\alpha} s_{z_\beta}
@@ -43,7 +42,7 @@ def _spin2_matrix_elements(sz):
 
     where :math:`\alpha` and :math:`s_{z_\alpha}` refer to the quantum numbers of the spatial
     function and the spin projection, respectively, of the single-particle state
-    :math:`\vert \bm{\alpha} \rangle`.
+    :math:`\vert \bm{\alpha} \rangle \equiv \vert \alpha, s_{z_\alpha} \rangle`.
 
     Args:
         sz (array[float]): spin-projection of the single-particle states
@@ -115,7 +114,6 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
 
         \langle \bm{\alpha}, \bm{\beta} \vert \hat{s}_1 \cdot \hat{s}_2
         \vert \bm{\gamma}, \bm{\delta} \rangle = && \delta_{\alpha,\delta} \delta_{\beta,\gamma} \\
-
         && \times \left( \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}+1}
         \delta_{s_{z_\beta}, s_{z_\gamma}-1} + \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}-1}
         \delta_{s_{z_\beta}, s_{z_\gamma}+1} + s_{z_\alpha} s_{z_\beta}
@@ -123,7 +121,8 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
 
     In the equations above :math:`N` is the number of electrons, :math:`\alpha` refer to the
     quantum numbers of the spatial wave function and :math:`s_{z_\alpha}` is
-    the spin projection of the single-particle state :math:`\vert \bm{\alpha} \rangle`.
+    the spin projection of the single-particle state
+    :math:`\vert \bm{\alpha} \rangle \equiv \vert \alpha, s_{z_\alpha} \rangle`.
     The operators :math:`\hat{c}^\dagger` and :math:`\hat{c}` are the particle creation
     and annihilation operators, respectively.
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -15,9 +15,7 @@
 values can be used to simulate molecular properties.
 """
 # pylint: disable=too-many-arguments, too-few-public-methods
-import os
 import numpy as np
-from openfermion.hamiltonians import MolecularData
 from openfermion.ops import FermionOperator
 from openfermion.transforms import bravyi_kitaev, jordan_wigner
 
@@ -107,7 +105,7 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
 
         \hat{S}^2 = \frac{3}{4}N + \sum_{ \bm{\alpha}, \bm{\beta}, \bm{\gamma}, \bm{\delta} }
         \langle \bm{\alpha}, \bm{\beta} \vert \hat{s}_1 \cdot \hat{s}_2
-        \vert \bm{\gamma}, \bm{\delta} \rangle ~ 
+        \vert \bm{\gamma}, \bm{\delta} \rangle ~
         \hat{c}_\bm{\alpha}^\dagger \hat{c}_\bm{\beta}^\dagger
         \hat{c}_\bm{\gamma} \hat{c}_\bm{\delta},
     

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -24,39 +24,41 @@ from openfermion.transforms import bravyi_kitaev, jordan_wigner
 from . import structure
 
 
-def _spin2_matrix_elements(sz, n_spin_orbs):
-    r"""Generates the table of matrix elements
-    :math:`\langle \alpha, \beta \vert \hat{s}_1 \cdot \hat{s}_2 \vert \gamma, \delta \rangle`
-    of the two-particle spin operator :math:`\hat{s}_1 \cdot \hat{s}_2`.
+def _spin2_matrix_elements(sz):
+    r"""Builds the table of matrix elements
+    :math:`\langle \bm{\alpha}, \bm{\beta} \vert \hat{s}_1 \cdot \hat{s}_2 \vert
+    \bm{\gamma}, \bm{\delta} \rangle` of the two-particle spin operator
+    :math:`\hat{s}_1 \cdot \hat{s}_2`.
 
     The matrix elements are evaluated using the expression,
 
     .. math::
 
-        \langle \alpha, \beta \vert \hat{s}_1 \cdot \hat{s}_2
-        \vert \gamma, \delta \rangle = \delta_{\alpha,\delta} \delta_{\beta,\gamma}
-        \left( \frac{1}{2} \delta_{m_\alpha, m_\delta+1} \delta_{m_\beta, m_\gamma-1}
-        + \frac{1}{2} \delta_{m_\alpha, m_\delta-1} \delta_{m_\beta, m_\gamma+1}
-        + m_\alpha m_\beta \delta_{m_\alpha, m_\delta} \delta_{m_\beta, m_\gamma} \right),
+        \langle ~ (\alpha, s_{z_\alpha});~ (\beta, s_{z_\beta}) ~ \vert \hat{s}_1 &&
+        \cdot \hat{s}_2 \vert ~ (\gamma, s_{z_\gamma}); ~ (\delta, s_{z_\gamma}) ~ \rangle =
+        \delta_{\alpha,\delta} \delta_{\beta,\gamma} \\
 
-    where :math:`\alpha` and :math:`m_\alpha` refer to the quantum numbers of the spatial
-    :math:`\varphi_\alpha({\bf r})` and spin :math:`\chi_{m_\alpha}(s_z)` wave functions,
-    respectively, of the single-particle state :math:`\vert \alpha \rangle`.
+        && \times \left( \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}+1}
+        \delta_{s_{z_\beta}, s_{z_\gamma}-1} + \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}-1}
+        \delta_{s_{z_\beta}, s_{z_\gamma}+1} + s_{z_\alpha} s_{z_\beta}
+        \delta_{s_{z_\alpha}, s_{z_\delta}} \delta_{s_{z_\beta}, s_{z_\gamma}} \right),
+
+    where :math:`\alpha` and :math:`s_{z_\alpha}` refer to the quantum numbers of the spatial
+    function and the spin projection, respectively, of the single-particle state
+    :math:`\vert \bm{\alpha} \rangle`.
 
     Args:
-        sz (array[float]): spin-projection quantum number of the spin-orbitals
-        n_spin_orbs (int): number of spin orbitals
+        sz (array[float]): spin-projection of the single-particle states
 
     Returns:
         array: NumPy array with the table of matrix elements. The first four columns
-        contain the indices :math:`\alpha`, :math:`\beta`, :math:`\gamma`, :math:`\delta`
-        and the fifth column stores the computed matrix element.
+        contain the indices :math:`\bm{\alpha}`, :math:`\bm{\beta}`, :math:`\bm{\gamma}`,
+        :math:`\bm{\delta}` and the fifth column stores the computed matrix element.
 
     **Example**
 
-    >>> n_spin_orbs = 2
     >>> sz = np.array([0.5, -0.5])
-    >>> print(_spin2_matrix_elements(sz, n_spin_orbs))
+    >>> print(_spin2_matrix_elements(sz))
     [[ 0.    0.    0.    0.    0.25]
      [ 0.    1.    1.    0.   -0.25]
      [ 1.    0.    0.    1.   -0.25]
@@ -65,12 +67,7 @@ def _spin2_matrix_elements(sz, n_spin_orbs):
      [ 1.    0.    1.    0.    0.5 ]]
     """
 
-    if sz.size != n_spin_orbs:
-        raise ValueError(
-            "Size of 'sz' must be equal to 'n_spin_orbs'; size got for 'sz' {}".format(sz.size)
-        )
-
-    n = np.arange(n_spin_orbs)
+    n = np.arange(sz.size)
 
     alpha = n.reshape(-1, 1, 1, 1)
     beta = n.reshape(1, -1, 1, 1)
@@ -101,98 +98,88 @@ def _spin2_matrix_elements(sz, n_spin_orbs):
     return np.vstack([diag, off_diag])
 
 
-def get_spin2_matrix_elements(mol_name, hf_data, n_active_electrons=None, n_active_orbitals=None):
-    r"""Reads the Hartree-Fock (HF) electronic structure data file, defines an active space and
-    generates the table of matrix elements required to build the total-spin
-    operator :math:`\hat{S}^2`.
+def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
+    r"""Computes the total spin operator :math:`\hat{S}^2`.
 
-    The second-quantized expression for the operator :math:`\hat{S}^2` reads,
+    The total spin operator :math:`\hat{S}^2` is given by
 
     .. math::
 
-        \hat{S}^2 = \frac{3}{4}N + \sum_{\alpha, \beta, \gamma, \delta}
-        \langle \alpha, \beta \vert \hat{s}_1 \cdot \hat{s}_2
-        \vert \gamma, \delta \rangle ~ \hat{c}_\alpha^\dagger \hat{c}_\beta^\dagger
-        \hat{c}_\gamma \hat{c}_\delta,
+        \hat{S}^2 = \frac{3}{4}N + \sum_{ \bm{\alpha}, \bm{\beta}, \bm{\gamma}, \bm{\delta} }
+        \langle \bm{\alpha}, \bm{\beta} \vert \hat{s}_1 \cdot \hat{s}_2
+        \vert \bm{\gamma}, \bm{\delta} \rangle ~ 
+        \hat{c}_\bm{\alpha}^\dagger \hat{c}_\bm{\beta}^\dagger
+        \hat{c}_\bm{\gamma} \hat{c}_\bm{\delta},
     
     where the two-particle matrix elements are computedas,
 
     .. math::
 
-        \langle \alpha, \beta \vert \hat{s}_1 \cdot \hat{s}_2
-        \vert \gamma, \delta \rangle = \delta_{\alpha,\delta} \delta_{\beta,\gamma}
-        \left( \frac{1}{2} \delta_{m_\alpha, m_\delta+1} \delta_{m_\beta, m_\gamma-1}
-        + \frac{1}{2} \delta_{m_\alpha, m_\delta-1} \delta_{m_\beta, m_\gamma+1}
-        + m_\alpha m_\beta \delta_{m_\alpha, m_\delta} \delta_{m_\beta, m_\gamma} \right).
+        \langle \bm{\alpha}, \bm{\beta} \vert \hat{s}_1 \cdot \hat{s}_2
+        \vert \bm{\gamma}, \bm{\delta} \rangle = && \delta_{\alpha,\delta} \delta_{\beta,\gamma} \\
 
-    In the equations above :math:`N` is the number of particles, :math:`m_\alpha` refers to
-    the quantum number of the spin wave function :math:`\chi_{m_\alpha}(s_z)` of the
-    spin-orbital :math:`\vert \alpha \rangle` and :math:`\hat{c}_\alpha^\dagger`
-    (:math:`\hat{c}_\alpha`) is the creation (annihilation) particle operator acting
-    on the :math:`\alpha`-th active orbital.
+        && \times \left( \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}+1}
+        \delta_{s_{z_\beta}, s_{z_\gamma}-1} + \frac{1}{2} \delta_{s_{z_\alpha}, s_{z_\delta}-1}
+        \delta_{s_{z_\beta}, s_{z_\gamma}+1} + s_{z_\alpha} s_{z_\beta}
+        \delta_{s_{z_\alpha}, s_{z_\delta}} \delta_{s_{z_\beta}, s_{z_\gamma}} \right).
+
+    In the equations above :math:`N` is the number of electrons, :math:`\alpha` refer to the
+    quantum numbers of the spatial wave function and :math:`s_{z_\alpha}` is
+    the spin projection of the single-particle state :math:`\vert \bm{\alpha} \rangle`.
+    The operators :math:`\hat{c}^\dagger` and :math:`\hat{c}` are the particle creation
+    and annihilation operators, respectively.
 
     Args:
-        mol_name (str): name of the molecule
-        hf_data (str): path to the directory with the HF electronic structure data
-        n_active_electrons (int): number of active electrons
-        n_active_orbitals (int): number of active orbitals
+        n_electrons (int): Number of electrons. If an active space is defined, 'n_electrons'
+            is the number of active electrons.
+        n_orbitals (int): Number of orbitals. If an active space is defined, 'n_orbitals'
+            is the number of active orbitals.
 
     Returns:
-        tuple: the table of the two-particle matrix elements and the single-particle
-        contribution :math:`\frac{3N}{4}`. The first four columns of the table contains the
-        indices :math:`\alpha`, :math:`\beta`, :math:`\gamma`, :math:`\delta` and the
-        fifth column the value of the matrix elements.
+        pennylane.Hamiltonian: the total spin observable :math:`\hat{S}^2`
 
     **Example**
 
-    >>> get_spin2_matrix_elements(
-        'h2',
-        './pyscf/sto-3g',
-        n_active_electrons=2,
-        n_active_orbitals=2)
-    [[ 0.    0.    0.    0.    0.25]
-     [ 0.    1.    1.    0.   -0.25]
-     [ 0.    2.    2.    0.    0.25]
-     [ 0.    3.    3.    0.   -0.25]
-     [ 1.    0.    0.    1.   -0.25]
-     [ 1.    1.    1.    1.    0.25]
-     [ 1.    2.    2.    1.   -0.25]
-     [ 1.    3.    3.    1.    0.25]
-     [ 2.    0.    0.    2.    0.25]
-     [ 2.    1.    1.    2.   -0.25]
-     [ 2.    2.    2.    2.    0.25]
-     [ 2.    3.    3.    2.   -0.25]
-     [ 3.    0.    0.    3.   -0.25]
-     [ 3.    1.    1.    3.    0.25]
-     [ 3.    2.    2.    3.   -0.25]
-     [ 3.    3.    3.    3.    0.25]
-     [ 0.    1.    0.    1.    0.5 ]
-     [ 0.    3.    2.    1.    0.5 ]
-     [ 1.    0.    1.    0.    0.5 ]
-     [ 1.    2.    3.    0.    0.5 ]
-     [ 2.    1.    0.    3.    0.5 ]
-     [ 2.    3.    2.    3.    0.5 ]
-     [ 3.    0.    1.    2.    0.5 ]
-     [ 3.    2.    3.    2.    0.5 ]] 1.5
+    >>> n_electrons = 2
+    >>> n_orbitals = 2
+    >>> S2 = spin2(n_electrons, n_orbitals, mapping="jordan_wigner")
+    >>> print(S2)
+    (0.75) [I0]
+    + (0.375) [Z1]
+    + (-0.375) [Z0 Z1]
+    + (0.125) [Z0 Z2]
+    + (0.375) [Z0]
+    + (-0.125) [Z0 Z3]
+    + (-0.125) [Z1 Z2]
+    + (0.125) [Z1 Z3]
+    + (0.375) [Z2]
+    + (0.375) [Z3]
+    + (-0.375) [Z2 Z3]
+    + (0.125) [Y0 X1 Y2 X3]
+    + (0.125) [Y0 Y1 X2 X3]
+    + (0.125) [Y0 Y1 Y2 Y3]
+    + (-0.125) [Y0 X1 X2 Y3]
+    + (-0.125) [X0 Y1 Y2 X3]
+    + (0.125) [X0 X1 X2 X3]
+    + (0.125) [X0 X1 Y2 Y3]
+    + (0.125) [X0 Y1 X2 Y3]
     """
 
-    active_indices = structure.active_space(
-        mol_name,
-        hf_data,
-        n_active_electrons=n_active_electrons,
-        n_active_orbitals=n_active_orbitals,
-    )[1]
+    if n_electrons <= 0:
+        raise ValueError(
+            "'n_electrons' must be greater than 0; got for 'n_electrons' {}".format(n_electrons)
+        )
 
-    if n_active_electrons is None:
-        hf_elect_struct = MolecularData(filename=os.path.join(hf_data.strip(), mol_name.strip()))
-        n_electrons = hf_elect_struct.n_electrons
-    else:
-        n_electrons = n_active_electrons
+    if n_orbitals <= 0:
+        raise ValueError(
+            "'n_orbitals' must be greater than 0; got for 'n_orbitals' {}".format(n_orbitals)
+        )
 
-    n_spin_orbs = 2 * len(active_indices)
-    sz = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
+    sz = np.where(np.arange(2 * n_orbitals) % 2 == 0, 0.5, -0.5)
 
-    return _spin2_matrix_elements(sz, n_spin_orbs), 3 / 4 * n_electrons
+    table = _spin2_matrix_elements(sz)
+
+    return observable(table, init_term=3 / 4 * n_electrons, mapping=mapping)
 
 
 def observable(me_table, init_term=0, mapping="jordan_wigner"):
@@ -369,7 +356,7 @@ def get_spinZ_matrix_elements(mol_name, hf_data, n_active_electrons=None, n_acti
 
 __all__ = [
     "_spin2_matrix_elements",
-    "get_spin2_matrix_elements",
+    "spin2",
     "observable",
     "get_spinZ_matrix_elements",
 ]

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -134,6 +134,8 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
             is the number of active electrons.
         n_orbitals (int): Number of orbitals. If an active space is defined, 'n_orbitals'
             is the number of active orbitals.
+        mapping (str): Specifies the transformation to map the fermionic operator to the
+            Pauli basis. Input values can be ``'jordan_wigner'`` or ``'bravyi_kitaev'``.
 
     Returns:
         pennylane.Hamiltonian: the total spin observable :math:`\hat{S}^2`
@@ -190,7 +192,7 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
     This function can be used to build second-quantized operators in the basis
     of single-particle states (e.g., HF states) and to transform them into
     PennyLane observables. In general, single- and two-particle operators can be
-    expanded in a truncated set of orbitals that define an active space,
+    expanded in a defined active space,
 
     .. math::
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -218,10 +218,10 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
 
     Args:
         me_table (array[float]): Numpy array with the table of matrix elements.
-            For a single-particle operator this array will have shape
+            For single-particle operators this array will have shape
             ``(me_table.shape[0], 3)`` with each row containing the indices
             :math:`\alpha`, :math:`\beta` and the matrix element :math:`\langle \alpha \vert
-            \hat{\mathcal{A}}\vert \beta \rangle`. For a two-particle operator this
+            \hat{\mathcal{A}}\vert \beta \rangle`. For two-particle operators this
             array will have shape ``(me_table.shape[0], 5)`` with each row containing
             the indices :math:`\alpha`, :math:`\beta`, :math:`\gamma`, :math:`\delta` and
             the matrix elements :math:`\langle \alpha, \beta \vert \hat{\mathcal{B}}

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -28,7 +28,7 @@ def _spin2_matrix_elements(sz):
     \bm{\gamma}, \bm{\delta} \rangle` of the two-particle spin operator
     :math:`\hat{s}_1 \cdot \hat{s}_2`.
 
-    The matrix elements are evaluated using the expression,
+    The matrix elements are evaluated using the expression
 
     .. math::
 
@@ -108,7 +108,7 @@ def spin2(n_electrons, n_orbitals, mapping="jordan_wigner"):
         \hat{c}_\bm{\alpha}^\dagger \hat{c}_\bm{\beta}^\dagger
         \hat{c}_\bm{\gamma} \hat{c}_\bm{\delta},
     
-    where the two-particle matrix elements are computedas,
+    where the two-particle matrix elements are computed as,
 
     .. math::
 

--- a/qchem/pennylane_qchem/qchem/obs.py
+++ b/qchem/pennylane_qchem/qchem/obs.py
@@ -239,28 +239,11 @@ def observable(me_table, init_term=0, mapping="jordan_wigner"):
 
     **Example**
 
-    >>> s2_matrix_elements, init_term = get_spin2_matrix_elements('h2', './pyscf/sto-3g')
-    >>> s2_obs = observable(s2_matrix_elements, init_term=init_term)
-    >>> print(s2_obs)
-    (0.75) [I0]
-    + (0.375) [Z1]
-    + (-0.375) [Z0 Z1]
-    + (0.125) [Z0 Z2]
-    + (0.375) [Z0]
-    + (-0.125) [Z0 Z3]
-    + (-0.125) [Z1 Z2]
-    + (0.125) [Z1 Z3]
-    + (0.375) [Z2]
-    + (0.375) [Z3]
-    + (-0.375) [Z2 Z3]
-    + (0.125) [Y0 X1 Y2 X3]
-    + (0.125) [Y0 Y1 X2 X3]
-    + (0.125) [Y0 Y1 Y2 Y3]
-    + (-0.125) [Y0 X1 X2 Y3]
-    + (-0.125) [X0 Y1 Y2 X3]
-    + (0.125) [X0 X1 X2 X3]
-    + (0.125) [X0 X1 Y2 Y3]
-    + (0.125) [X0 Y1 X2 Y3]
+    >>> table = np.array([[0.0, 0.0, 0.4], [1.0, 1.0, -0.5], [1.0, 0.0, 0.0]])
+    >>> observable(table, init_term=1 / 4, mapping="bravyi_kitaev")
+    (0.2) [I0]
+    + (-0.2) [Z0]
+    + (0.25) [Z0 Z1]
     """
 
     if mapping.strip().lower() not in ("jordan_wigner", "bravyi_kitaev"):

--- a/qchem/tests/test_s2_obs.py
+++ b/qchem/tests/test_s2_obs.py
@@ -7,85 +7,26 @@ from pennylane import qchem
 
 from openfermion.ops._qubit_operator import QubitOperator
 
-ref_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "test_ref_files")
 
+me_1 = np.array([[0.0, 0.0, 0.0, 0.0, 0.25],])
 
-@pytest.mark.parametrize(
-    ("n_spin_orbs", "s2_me_expected"),
-    [
-        (1, np.array([[0.0, 0.0, 0.0, 0.0, 0.25]])),
-        (
-            3,
-            np.array(
-                [
-                    [0.0, 0.0, 0.0, 0.0, 0.25],
-                    [0.0, 1.0, 1.0, 0.0, -0.25],
-                    [0.0, 2.0, 2.0, 0.0, 0.25],
-                    [1.0, 0.0, 0.0, 1.0, -0.25],
-                    [1.0, 1.0, 1.0, 1.0, 0.25],
-                    [1.0, 2.0, 2.0, 1.0, -0.25],
-                    [2.0, 0.0, 0.0, 2.0, 0.25],
-                    [2.0, 1.0, 1.0, 2.0, -0.25],
-                    [2.0, 2.0, 2.0, 2.0, 0.25],
-                    [0.0, 1.0, 0.0, 1.0, 0.5],
-                    [1.0, 0.0, 1.0, 0.0, 0.5],
-                ]
-            ),
-        ),
-    ],
-)
-def test_spin2_matrix_elements(n_spin_orbs, s2_me_expected, tol):
-    r"""Test the calculation of the matrix elements of the two-particle spin operator
-    :math:`\hat{s}_1 \cdot \hat{s}_2`"""
-
-    sz = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
-
-    s2_me_result = qchem._spin2_matrix_elements(sz, n_spin_orbs)
-
-    assert np.allclose(s2_me_result, s2_me_expected, **tol)
-
-
-def test_exception_spin2_me(message_match="Size of 'sz' must be equal to 'n_spin_orbs'"):
-    """Test that the 'spin2_matrix_elements' function throws an exception if the
-    size of 'sz' is not equal to 'n_spin_orbs'."""
-
-    n_spin_orbs = 4
-    sz = np.where(np.arange(n_spin_orbs + 1) % 2 == 0, 0.5, -0.5)
-
-    with pytest.raises(ValueError, match=message_match):
-        qchem._spin2_matrix_elements(sz, n_spin_orbs)
-
-
-me = np.array(
+me_3 = np.array(
     [
         [0.0, 0.0, 0.0, 0.0, 0.25],
         [0.0, 1.0, 1.0, 0.0, -0.25],
         [0.0, 2.0, 2.0, 0.0, 0.25],
-        [0.0, 3.0, 3.0, 0.0, -0.25],
         [1.0, 0.0, 0.0, 1.0, -0.25],
         [1.0, 1.0, 1.0, 1.0, 0.25],
         [1.0, 2.0, 2.0, 1.0, -0.25],
-        [1.0, 3.0, 3.0, 1.0, 0.25],
         [2.0, 0.0, 0.0, 2.0, 0.25],
         [2.0, 1.0, 1.0, 2.0, -0.25],
         [2.0, 2.0, 2.0, 2.0, 0.25],
-        [2.0, 3.0, 3.0, 2.0, -0.25],
-        [3.0, 0.0, 0.0, 3.0, -0.25],
-        [3.0, 1.0, 1.0, 3.0, 0.25],
-        [3.0, 2.0, 2.0, 3.0, -0.25],
-        [3.0, 3.0, 3.0, 3.0, 0.25],
         [0.0, 1.0, 0.0, 1.0, 0.5],
-        [0.0, 3.0, 2.0, 1.0, 0.5],
         [1.0, 0.0, 1.0, 0.0, 0.5],
-        [1.0, 2.0, 3.0, 0.0, 0.5],
-        [2.0, 1.0, 0.0, 3.0, 0.5],
-        [2.0, 3.0, 2.0, 3.0, 0.5],
-        [3.0, 0.0, 1.0, 2.0, 0.5],
-        [3.0, 2.0, 3.0, 2.0, 0.5],
     ]
 )
 
-me_lih = np.array(
+me_6 = np.array(
     [
         [0.0, 0.0, 0.0, 0.0, 0.25],
         [0.0, 1.0, 1.0, 0.0, -0.25],
@@ -146,27 +87,20 @@ me_lih = np.array(
 
 
 @pytest.mark.parametrize(
-    ("mol_name", "n_act_elect", "n_act_orb", "s2_me_exp", "init_term_exp"),
-    [
-        ("h2_pyscf", None, None, me, 1.5),
-        ("h2_pyscf", 2, None, me, 1.5),
-        ("lih", 2, 2, me, 1.5),
-        ("lih", None, 3, me_lih, 3.0),
-    ],
+    ("n_spin_orbs", "s2_me_expected"), [(1, me_1), (3, me_3), (6, me_6)],
 )
-def test_get_spin2_matrix_elements(mol_name, n_act_elect, n_act_orb, s2_me_exp, init_term_exp, tol):
-    r"""Test that the table of matrix elements and the term use to initialize the
-    FermionOperator are computed correctly for different active spaces."""
+def test_spin2_matrix_elements(n_spin_orbs, s2_me_expected, tol):
+    r"""Test the calculation of the matrix elements of the two-particle spin operator
+    :math:`\hat{s}_1 \cdot \hat{s}_2` implemented by the function `'_spin2_matrix_elements'` """
 
-    s2_me_res, init_term_res = qchem.get_spin2_matrix_elements(
-        mol_name, ref_dir, n_active_electrons=n_act_elect, n_active_orbitals=n_act_orb
-    )
+    sz = np.where(np.arange(n_spin_orbs) % 2 == 0, 0.5, -0.5)
 
-    assert np.allclose(s2_me_res, s2_me_exp, **tol)
-    assert init_term_res == init_term_exp
+    s2_me_result = qchem._spin2_matrix_elements(sz)
+
+    assert np.allclose(s2_me_result, s2_me_expected, **tol)
 
 
-terms_lih_jw = {
+terms_jw = {
     (): (0.75 + 0j),
     ((1, "Z"),): (0.375 + 0j),
     ((0, "Z"), (1, "Z")): (-0.375 + 0j),
@@ -188,7 +122,7 @@ terms_lih_jw = {
     ((0, "X"), (1, "Y"), (2, "X"), (3, "Y")): (0.125 + 0j),
 }
 
-terms_lih_anion_bk = {
+terms_bk = {
     (): (1.125 + 0j),
     ((0, "Z"), (1, "Z")): (0.375 + 0j),
     ((1, "Z"),): (-0.375 + 0j),
@@ -239,27 +173,38 @@ terms_lih_anion_bk = {
 
 
 @pytest.mark.parametrize(
-    ("mol_name", "n_act_elect", "n_act_orb", "mapping", "terms_exp"),
-    [
-        ("lih", 2, 2, "JORDAN_wigner", terms_lih_jw),
-        ("lih_anion", 3, 3, "bravyi_KITAEV", terms_lih_anion_bk),
-    ],
+    ("n_electrons", "n_orbitals", "mapping", "terms_exp"),
+    [(2, 2, "JORDAN_wigner", terms_jw), (3, 3, "bravyi_KITAEV", terms_bk),],
 )
-def test_build_s2_observable(mol_name, n_act_elect, n_act_orb, mapping, terms_exp, monkeypatch):
-    r"""Tests the correctness of the built total-spin observable.
+def test_spin2(n_electrons, n_orbitals, mapping, terms_exp, monkeypatch):
+    r"""Tests the correctness of the total spin observable :math:`\hat{S}^2`
+    built by the function `'spin2'`.
 
     The parametrized inputs are `.terms` attribute of the total spin `QubitOperator.
     The equality checking is implemented in the `qchem` module itself as it could be
     something useful to the users as well.
     """
 
-    s2_me_table, init_term = qchem.get_spin2_matrix_elements(
-        mol_name, ref_dir, n_active_electrons=n_act_elect, n_active_orbitals=n_act_orb
-    )
+    S2 = qchem.spin2(n_electrons, n_orbitals, mapping=mapping)
 
-    s2_obs = qchem.observable(s2_me_table, init_term=init_term, mapping=mapping)
+    S2_qubit_op = QubitOperator()
+    monkeypatch.setattr(S2_qubit_op, "terms", terms_exp)
 
-    s2_qubit_op = QubitOperator()
-    monkeypatch.setattr(s2_qubit_op, "terms", terms_exp)
+    assert qchem._qubit_operators_equivalent(S2_qubit_op, S2)
 
-    assert qchem._qubit_operators_equivalent(s2_qubit_op, s2_obs)
+
+@pytest.mark.parametrize(
+    ("n_electrons", "n_orbitals", "msg_match"),
+    [
+        (-2, 2, "'n_electrons' must be greater than 0"),
+        (0, 2, "'n_electrons' must be greater than 0"),
+        (3, -3, "'n_orbitals' must be greater than 0"),
+        (3, 0, "'n_orbitals' must be greater than 0"),
+    ],
+)
+def test_exception_spin2(n_electrons, n_orbitals, msg_match):
+    """Test that the function `'spin2'` throws an exception if the
+    number of electrons or the number of orbitals is less than zero."""
+
+    with pytest.raises(ValueError, match=msg_match):
+        qchem.spin2(n_electrons, n_orbitals)


### PR DESCRIPTION
**Context:**
This is part of the refactoring of the obs module used to build many-body observables.

**Description of the Change:**
The total spin operator S^2 is constructed by calling the function `spin2` as implemented in the obs module.

**Benefits:**
The function to construct the observable is simpler and does not depend on any external-to-pennylane data structure. It returns the observable.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None