### PR TITLE
Renaming Operator.params to Operator.data

### DIFF
--- a/pennylane/beta/plugins/default_tensor_tf.py
+++ b/pennylane/beta/plugins/default_tensor_tf.py
@@ -192,7 +192,7 @@ class DefaultTensorTF(DefaultTensor):
             # Copy the operation parameters to the op_params dictionary.
             # Note that these are the unwrapped parameters, so PennyLane
             # free parameters will be represented as Variable instances.
-            self.op_params[operation] = operation.params[:]
+            self.op_params[operation] = operation.data[:]
 
         # Loop through the free parameter reference dictionary
         for _, par_dep_list in self.parameters.items():
@@ -208,8 +208,8 @@ class DefaultTensorTF(DefaultTensor):
             # For the above parameter dependency, get the corresponding
             # operation parameter variable, and get the numeric value.
             # Convert the resulting value to a TensorFlow tensor.
-            val = first.op.params[first.par_idx].val
-            mult = first.op.params[first.par_idx].mult
+            val = first.op.data[first.par_idx].val
+            mult = first.op.data[first.par_idx].mult
             v = tf.Variable(val / mult, dtype=self.R_DTYPE)
 
             # Mark the variable to be watched by the gradient tape,
@@ -221,7 +221,7 @@ class DefaultTensorTF(DefaultTensor):
                 # with the corresponding tf.Variable parameter.
                 # Note that the free parameter might be scaled by the
                 # variable.mult scaling factor.
-                mult = p.op.params[p.par_idx].mult
+                mult = p.op.data[p.par_idx].mult
                 self.op_params[p.op][p.par_idx] = v * mult
 
         # check that no Variables remain in the op_params dictionary

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -133,7 +133,7 @@ class RepresentationResolver:
         Returns:
             str: The formatted operation
         """
-        mat = operation.params[0]
+        mat = operation.data[0]
         idx = RepresentationResolver.index_of_array_or_append(mat, cache)
 
         return "{}{}".format(symbol, idx)
@@ -297,7 +297,7 @@ class RepresentationResolver:
         Returns:
             str: A string representing the polynomial
         """
-        coefficients = operation.params[0]
+        coefficients = operation.data[0]
         order = len(coefficients.shape)
 
         if order == 1:
@@ -343,8 +343,8 @@ class RepresentationResolver:
 
         elif base_name == "PauliRot":
             representation = "R{0}({1})".format(
-                op.params[1][op.wires.index(wire)],
-                self.single_parameter_representation(op.params[0]),
+                op.data[1][op.wires.index(wire)],
+                self.single_parameter_representation(op.data[0]),
             )
 
         elif base_name == "QubitUnitary":
@@ -358,12 +358,12 @@ class RepresentationResolver:
             )
 
         elif base_name == "QuadOperator":
-            par_rep = self.single_parameter_representation(op.params[0])
+            par_rep = self.single_parameter_representation(op.data[0])
 
             representation = "cos({0})x+sin({0})p".format(par_rep)
 
         elif base_name == "FockStateProjector":
-            n_str = ",".join([str(n) for n in op.params[0]])
+            n_str = ",".join([str(n) for n in op.data[0]])
 
             representation = (
                 self.charset.PIPE + n_str + self.charset.CROSSED_LINES + n_str + self.charset.PIPE
@@ -373,11 +373,11 @@ class RepresentationResolver:
             representation = self._format_polyxp(op)
 
         elif base_name == "FockState":
-            representation = self.charset.PIPE + str(op.params[0]) + self.charset.RANGLE
+            representation = self.charset.PIPE + str(op.data[0]) + self.charset.RANGLE
 
         elif base_name in {"BasisState", "FockStateVector"}:
             representation = (
-                self.charset.PIPE + str(op.params[0][op.wires.index(wire)]) + self.charset.RANGLE
+                self.charset.PIPE + str(op.data[0][op.wires.index(wire)]) + self.charset.RANGLE
             )
 
         # Operations that only have matrix arguments
@@ -389,12 +389,12 @@ class RepresentationResolver:
             "Interferometer",
         }:
             representation = name + RepresentationResolver._format_matrix_arguments(
-                op.params, "M", self.matrix_cache
+                op.data, "M", self.matrix_cache
             )
 
         else:
             representation = "{}({})".format(
-                name, ", ".join([self.single_parameter_representation(par) for par in op.params])
+                name, ", ".join([self.single_parameter_representation(par) for par in op.data])
             )
 
         if getattr(op, "inverse", False):

--- a/pennylane/circuit_drawer/representation_resolver.py
+++ b/pennylane/circuit_drawer/representation_resolver.py
@@ -343,8 +343,7 @@ class RepresentationResolver:
 
         elif base_name == "PauliRot":
             representation = "R{0}({1})".format(
-                op.data[1][op.wires.index(wire)],
-                self.single_parameter_representation(op.data[0]),
+                op.data[1][op.wires.index(wire)], self.single_parameter_representation(op.data[0]),
             )
 
         elif base_name == "QubitUnitary":

--- a/pennylane/circuit_graph.py
+++ b/pennylane/circuit_graph.py
@@ -210,7 +210,7 @@ class CircuitGraph:
         for op in self.operations_in_order:
             serialization_string += op.name
 
-            for param in op.params:
+            for param in op.data:
                 if isinstance(param, Variable):
                     serialization_string += delimiter
                     serialization_string += variable_delimiter
@@ -230,7 +230,7 @@ class CircuitGraph:
 
         for obs in self.observables_in_order:
             serialization_string += str(obs.name)
-            for param in obs.params:
+            for param in obs.data:
                 serialization_string += delimiter
                 serialization_string += str(param)
                 serialization_string += delimiter

--- a/pennylane/operation.py
+++ b/pennylane/operation.py
@@ -389,18 +389,18 @@ class Operator(abc.ABC):
         if self.do_check_domain:
             for p in params:
                 self.check_domain(p)
-        self.params = list(params)  #: list[Any]: parameters of the operator
+        self.data = list(params)  #: list[Any]: parameters of the operator
 
         if do_queue:
             self.queue()
 
     def __str__(self):
         """Operator name and some information."""
-        return "{}: {} params, wires {}".format(self.name, len(self.params), self.wires)
+        return "{}: {} params, wires {}".format(self.name, len(self.data), self.wires)
 
     def __repr__(self):
         """Constructor-call-like representation."""
-        # FIXME using self.parameters here instead of self.params is dangerous, it assumes the params can be evaluated
+        # FIXME using self.parameters here instead of self.data is dangerous, it assumes the data can be evaluated
         # which is only true if something suitable happens to remain in VariableRef.positional_arg_values etc. after
         # the last evaluation.
         if self.parameters:
@@ -502,7 +502,7 @@ class Operator(abc.ABC):
                 p = self.check_domain(p.val)
             return p
 
-        return [evaluate(p) for p in self.params]
+        return [evaluate(p) for p in self.data]
 
     def queue(self):
         """Append the operator to the Operator queue."""
@@ -591,7 +591,7 @@ class Operation(Operator):
         multiplier, shift = (0.5, np.pi / 2) if recipe is None else recipe
 
         # internal multiplier in the Variable
-        var_mult = self.params[idx].mult
+        var_mult = self.data[idx].mult
 
         multiplier *= var_mult
         if var_mult != 0:
@@ -955,7 +955,7 @@ class Tensor(Observable):
     def __str__(self):
         """Print the tensor product and some information."""
         return "Tensor product {}: {} params, wires {}".format(
-            [i.name for i in self.obs], len(self.params), self.wires
+            [i.name for i in self.obs], len(self.data), self.wires
         )
 
     def __repr__(self):
@@ -990,13 +990,13 @@ class Tensor(Observable):
         return [w for o in self.obs for w in o.wires]
 
     @property
-    def params(self):
+    def data(self):
         """Raw parameters of all constituent observables in the tensor product.
 
         Returns:
             list[Any]: flattened list containing all dependent parameters
         """
-        return [p for sublist in [o.params for o in self.obs] for p in sublist]
+        return [p for sublist in [o.data for o in self.obs] for p in sublist]
 
     @property
     def num_params(self):
@@ -1005,7 +1005,7 @@ class Tensor(Observable):
         Returns:
             list[Any]: flattened list containing all dependent parameters
         """
-        return len(self.params)
+        return len(self.data)
 
     @property
     def parameters(self):

--- a/pennylane/qnodes/base.py
+++ b/pennylane/qnodes/base.py
@@ -97,7 +97,7 @@ def _decompose_queue(ops, device):
         if device.supports_operation(op.name):
             new_ops.append(op)
         else:
-            decomposed_ops = op.decomposition(*op.params, wires=op.wires)
+            decomposed_ops = op.decomposition(*op.data, wires=op.wires)
             if op.inverse:
                 decomposed_ops = qml.inv(decomposed_ops)
 
@@ -584,7 +584,7 @@ class BaseQNode(qml.QueuingContext):
         # map each free variable to the operators which depend on it
         self.variable_deps = {k: [] for k in range(self.num_variables)}
         for op in self.ops:
-            for j, p in enumerate(_flatten(op.params)):
+            for j, p in enumerate(_flatten(op.data)):
                 if isinstance(p, Variable):
                     if not p.is_kwarg:  # ignore auxiliary arguments
                         self.variable_deps[p.idx].append(ParameterDependency(op, j))

--- a/pennylane/qnodes/cv.py
+++ b/pennylane/qnodes/cv.py
@@ -172,13 +172,13 @@ class CVQNode(JacobianQNode):
 
             # We temporarily edit the Operator such that parameter p_idx is replaced by a new one,
             # which we can modify without affecting other Operators depending on the original.
-            orig = op.params[p_idx]
+            orig = op.data[p_idx]
             assert orig.idx == idx
 
             # reference to a new, temporary parameter with index n, otherwise identical with orig
             temp_var = copy.copy(orig)
             temp_var.idx = n
-            op.params[p_idx] = temp_var
+            op.data[p_idx] = temp_var
 
             multiplier, shift = op.get_parameter_shift(p_idx)
 
@@ -234,7 +234,7 @@ class CVQNode(JacobianQNode):
                 pd[inds] += res
 
             # restore the original parameter
-            op.params[p_idx] = orig
+            op.data[p_idx] = orig
 
         return pd
 

--- a/pennylane/qnodes/qubit.py
+++ b/pennylane/qnodes/qubit.py
@@ -120,13 +120,13 @@ class QubitQNode(JacobianQNode):
 
             # We temporarily edit the Operator such that parameter p_idx is replaced by a new one,
             # which we can modify without affecting other Operators depending on the original.
-            orig = op.params[p_idx]
+            orig = op.data[p_idx]
             assert orig.idx == idx
 
             # reference to a new, temporary parameter with index n, otherwise identical with orig
             temp_var = copy.copy(orig)
             temp_var.idx = n
-            op.params[p_idx] = temp_var
+            op.data[p_idx] = temp_var
 
             multiplier, shift = op.get_parameter_shift(p_idx)
 
@@ -140,7 +140,7 @@ class QubitQNode(JacobianQNode):
             pd += (y2 - y1) * multiplier
 
             # restore the original parameter
-            op.params[p_idx] = orig
+            op.data[p_idx] = orig
 
         return pd
 
@@ -174,7 +174,7 @@ class QubitQNode(JacobianQNode):
                 # are not guaranteed to be involutory, need to take them into
                 # account separately to calculate d<A^2>/dp
 
-                A = e.params[0]  # Hermitian matrix
+                A = e.data[0]  # Hermitian matrix
                 # if not np.allclose(A @ A, np.identity(A.shape[0])):
                 new = qml.expval(qml.Hermitian(A @ A, w, do_queue=False))
             else:

--- a/pennylane/qnodes/rev.py
+++ b/pennylane/qnodes/rev.py
@@ -139,7 +139,7 @@ class ReversibleQNode(QubitQNode):
             )
 
             # post-process to get partial derivative contribution from this op
-            multiplier *= op.params[p_idx].mult  # possible scalar multiplier
+            multiplier *= op.data[p_idx].mult  # possible scalar multiplier
             pd += 2 * multiplier * self.device._imag(matrix_elems)
 
         # reset state back to pre-measurement value

--- a/tests/ops/test_qubit_ops.py
+++ b/tests/ops/test_qubit_ops.py
@@ -196,7 +196,7 @@ class TestObservables:
         assert np.allclose(qml.Hermitian._eigs[key]["eigval"], eigvals, atol=tol, rtol=0)
         assert np.allclose(qml.Hermitian._eigs[key]["eigvec"], eigvecs, atol=tol, rtol=0)
 
-        assert np.allclose(qubit_unitary[0].params, eigvecs.conj().T, atol=tol, rtol=0)
+        assert np.allclose(qubit_unitary[0].data, eigvecs.conj().T, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
 
     @pytest.mark.parametrize("obs1", EIGVALS_TEST_DATA)
@@ -221,7 +221,7 @@ class TestObservables:
             qml.Hermitian._eigs[key]["eigvec"], observable_1_eigvecs, atol=tol, rtol=0
         )
 
-        assert np.allclose(qubit_unitary[0].params, observable_1_eigvecs.conj().T, atol=tol, rtol=0)
+        assert np.allclose(qubit_unitary[0].data, observable_1_eigvecs.conj().T, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
 
         observable_2 = obs2[0]
@@ -239,7 +239,7 @@ class TestObservables:
         )
 
         assert np.allclose(
-            qubit_unitary_2[0].params, observable_2_eigvecs.conj().T, atol=tol, rtol=0
+            qubit_unitary_2[0].data, observable_2_eigvecs.conj().T, atol=tol, rtol=0
         )
         assert len(qml.Hermitian._eigs) == 2
 
@@ -254,7 +254,7 @@ class TestObservables:
         assert np.allclose(qml.Hermitian._eigs[key]["eigval"], eigvals, atol=tol, rtol=0)
         assert np.allclose(qml.Hermitian._eigs[key]["eigvec"], eigvecs, atol=tol, rtol=0)
 
-        assert np.allclose(qubit_unitary[0].params, eigvecs.conj().T, atol=tol, rtol=0)
+        assert np.allclose(qubit_unitary[0].data, eigvecs.conj().T, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
 
         qubit_unitary = qml.Hermitian(observable, wires=[0]).diagonalizing_gates()
@@ -263,7 +263,7 @@ class TestObservables:
         assert np.allclose(qml.Hermitian._eigs[key]["eigval"], eigvals, atol=tol, rtol=0)
         assert np.allclose(qml.Hermitian._eigs[key]["eigvec"], eigvecs, atol=tol, rtol=0)
 
-        assert np.allclose(qubit_unitary[0].params, eigvecs.conj().T, atol=tol, rtol=0)
+        assert np.allclose(qubit_unitary[0].data, eigvecs.conj().T, atol=tol, rtol=0)
         assert len(qml.Hermitian._eigs) == 1
 
     @pytest.mark.parametrize("observable, eigvals, eigvecs", EIGVALS_TEST_DATA)
@@ -338,15 +338,15 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
-        
+        assert res[0].data[0] == np.pi / 2
+
         assert res[1].name == "RX"
         assert res[1].wires == [0]  #qml.wires.Wires([0])
-        assert res[1].params[0] == np.pi
-        
+        assert res[1].data[0] == np.pi
+
         assert res[2].name == "PhaseShift"
         assert res[2].wires == [0]  #qml.wires.Wires([0])
-        assert res[2].params[0] == np.pi / 2
+        assert res[2].data[0] == np.pi / 2
 
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
@@ -360,16 +360,16 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
-        
+        assert res[0].data[0] == np.pi / 2
+
         assert res[1].name == "RY"
         assert res[1].wires == [0]  #qml.wires.Wires([0])
-        assert res[1].params[0] == np.pi
-        
+        assert res[1].data[0] == np.pi
+
         assert res[2].name == "PhaseShift"
         assert res[2].wires == [0]  #qml.wires.Wires([0])
-        assert res[2].params[0] == np.pi / 2
-        
+        assert res[2].data[0] == np.pi / 2
+
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
@@ -382,8 +382,8 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi
-        
+        assert res[0].data[0] == np.pi
+
         decomposed_matrix = res[0].matrix
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
@@ -396,8 +396,8 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
-        
+        assert res[0].data[0] == np.pi / 2
+
         decomposed_matrix = res[0].matrix
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
@@ -410,8 +410,8 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 4
-        
+        assert res[0].data[0] == np.pi / 4
+
         decomposed_matrix = res[0].matrix
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
@@ -424,16 +424,16 @@ class TestOperations:
 
         assert res[0].name == "PhaseShift"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
+        assert res[0].data[0] == np.pi / 2
 
         assert res[1].name == "RX"
         assert res[1].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
-        
+        assert res[0].data[0] == np.pi / 2
+
         assert res[2].name == "PhaseShift"
         assert res[2].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == np.pi / 2
-        
+        assert res[0].data[0] == np.pi / 2
+
         decomposed_matrix = np.linalg.multi_dot([i.matrix for i in reversed(res)])
         assert np.allclose(decomposed_matrix, op.matrix, atol=tol, rtol=0)
 
@@ -447,8 +447,8 @@ class TestOperations:
 
         assert res[0].name == "RZ"
         assert res[0].wires == [0]  #qml.wires.Wires([0])
-        assert res[0].params[0] == 0.3
-        
+        assert res[0].data[0] == 0.3
+
         decomposed_matrix = res[0].matrix
         global_phase = (decomposed_matrix[op.matrix != 0] / op.matrix[op.matrix != 0])[0]
 
@@ -811,7 +811,7 @@ class TestPauliRot:
 
         assert decomp_ops[0].name == "MultiRZ"
         assert decomp_ops[0].wires == [0,1]  #Wires([0, 1])
-        assert decomp_ops[0].params[0] == theta
+        assert decomp_ops[0].data[0] == theta
 
     def test_PauliRot_decomposition_XY(self):
         """Test that the decomposition for a XY rotation is correct."""
@@ -827,18 +827,18 @@ class TestPauliRot:
 
         assert decomp_ops[1].name == "RX"
         assert decomp_ops[1].wires == [1]  #Wires([1])
-        assert decomp_ops[1].params[0] == np.pi / 2
+        assert decomp_ops[1].data[0] == np.pi / 2
 
         assert decomp_ops[2].name == "MultiRZ"
         assert decomp_ops[2].wires == [0,1]  #Wires([0, 1])
-        assert decomp_ops[2].params[0] == theta
+        assert decomp_ops[2].data[0] == theta
 
         assert decomp_ops[3].name == "Hadamard"
         assert decomp_ops[3].wires == [0]  #Wires([0])
 
         assert decomp_ops[4].name == "RX"
         assert decomp_ops[4].wires == [1]  #Wires([1])
-        assert decomp_ops[4].params[0] == -np.pi / 2
+        assert decomp_ops[4].data[0] == -np.pi / 2
 
     def test_PauliRot_decomposition_XIYZ(self):
         """Test that the decomposition for a XIYZ rotation is correct."""
@@ -854,18 +854,18 @@ class TestPauliRot:
 
         assert decomp_ops[1].name == "RX"
         assert decomp_ops[1].wires == [2]  #Wires([2])
-        assert decomp_ops[1].params[0] == np.pi / 2
+        assert decomp_ops[1].data[0] == np.pi / 2
 
         assert decomp_ops[2].name == "MultiRZ"
         assert decomp_ops[2].wires == [0, 2, 3]  #Wires([0, 2, 3])
-        assert decomp_ops[2].params[0] == theta
+        assert decomp_ops[2].data[0] == theta
 
         assert decomp_ops[3].name == "Hadamard"
         assert decomp_ops[3].wires == [0]  #Wires([0])
 
         assert decomp_ops[4].name == "RX"
         assert decomp_ops[4].wires == [2]  #Wires([2])
-        assert decomp_ops[4].params[0] == -np.pi / 2
+        assert decomp_ops[4].data[0] == -np.pi / 2
 
     @pytest.mark.parametrize("angle", np.linspace(0, 2 * np.pi, 7))
     def test_differentiability(self, angle):
@@ -975,7 +975,7 @@ class TestMultiRZ:
 
         assert decomp_ops[1].name == "RZ"
         assert decomp_ops[1].wires == [0]  #Wires([0])
-        assert decomp_ops[1].params[0] == theta
+        assert decomp_ops[1].data[0] == theta
 
         assert decomp_ops[2].name == "CNOT"
         assert decomp_ops[2].wires == [1, 0]  #Wires([1, 0])
@@ -995,7 +995,7 @@ class TestMultiRZ:
 
         assert decomp_ops[2].name == "RZ"
         assert decomp_ops[2].wires == [0]  #Wires([0])
-        assert decomp_ops[2].params[0] == theta
+        assert decomp_ops[2].data[0] == theta
 
         assert decomp_ops[3].name == "CNOT"
         assert decomp_ops[3].wires == [2, 0]  #Wires([2, 0])
@@ -1058,4 +1058,4 @@ class TestDiagonalQubitUnitary:
 
         assert decomp[0].name == "QubitUnitary"
         assert decomp[0].wires == [0, 1, 2]  #Wires([0, 1, 2])
-        assert np.allclose(decomp[0].params[0], np.diag(D))
+        assert np.allclose(decomp[0].data[0], np.diag(D))

--- a/tests/qnodes/test_qnode_metric_tensor.py
+++ b/tests/qnodes/test_qnode_metric_tensor.py
@@ -91,7 +91,7 @@ class TestMetricTensor:
         assert isinstance(res[(2,)]["queue"][1], qml.RY)
         assert isinstance(res[(2,)]["queue"][2], qml.CNOT)
         assert isinstance(res[(2,)]["observable"][0], qml.Hermitian)
-        assert np.all(res[(2,)]["observable"][0].params[0] == qml.PhaseShift.generator[0])
+        assert np.all(res[(2,)]["observable"][0].data[0] == qml.PhaseShift.generator[0])
 
     def test_construct_subcircuit_layers(self):
         """Test correct subcircuits constructed

--- a/tests/templates/test_decorator.py
+++ b/tests/templates/test_decorator.py
@@ -61,7 +61,7 @@ class TestDecorator:
         for res_op, exp_op in zip(res, expected):
             assert res_op.name == exp_op.name
             assert res_op.wires == exp_op.wires
-            assert res_op.params == exp_op.params
+            assert res_op.data == exp_op.data
 
     def test_decorated_dummy_template(self):
         """Test the decorator for an already decorated template."""
@@ -72,7 +72,7 @@ class TestDecorator:
         for res_op, exp_op in zip(res, expected):
             assert res_op.name == exp_op.name
             assert res_op.wires == exp_op.wires
-            assert res_op.params == exp_op.params
+            assert res_op.data == exp_op.data
 
     def test_decorated_decorated_dummy_template(self):
         """Test the decorator for decorating an already decorated template."""
@@ -87,4 +87,4 @@ class TestDecorator:
         for res_op, exp_op in zip(res, expected):
             assert res_op.name == exp_op.name
             assert res_op.wires == exp_op.wires
-            assert res_op.params == exp_op.params
+            assert res_op.data == exp_op.data

--- a/tests/templates/test_state_preparations.py
+++ b/tests/templates/test_state_preparations.py
@@ -313,13 +313,13 @@ class TestArbitraryStatePreparation:
             ArbitraryStatePreparation(weights, wires=[0])
 
         assert rec.queue[0].name == "PauliRot"
-        assert rec.queue[0].params[0] == weights[0]
-        assert rec.queue[0].params[1] == "X"
+        assert rec.queue[0].data[0] == weights[0]
+        assert rec.queue[0].data[1] == "X"
         assert rec.queue[0].wires == [0]  #Wires([0])
 
         assert rec.queue[1].name == "PauliRot"
-        assert rec.queue[1].params[0] == weights[1]
-        assert rec.queue[1].params[1] == "Y"
+        assert rec.queue[1].data[0] == weights[1]
+        assert rec.queue[1].data[1] == "Y"
         assert rec.queue[1].wires == [0]  #Wires([0])
 
     def test_correct_gates_two_wires(self):
@@ -330,33 +330,33 @@ class TestArbitraryStatePreparation:
             ArbitraryStatePreparation(weights, wires=[0, 1])
 
         assert rec.queue[0].name == "PauliRot"
-        assert rec.queue[0].params[0] == weights[0]
-        assert rec.queue[0].params[1] == "XI"
+        assert rec.queue[0].data[0] == weights[0]
+        assert rec.queue[0].data[1] == "XI"
         assert rec.queue[0].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[1].name == "PauliRot"
-        assert rec.queue[1].params[0] == weights[1]
-        assert rec.queue[1].params[1] == "YI"
+        assert rec.queue[1].data[0] == weights[1]
+        assert rec.queue[1].data[1] == "YI"
         assert rec.queue[1].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[2].name == "PauliRot"
-        assert rec.queue[2].params[0] == weights[2]
-        assert rec.queue[2].params[1] == "IX"
+        assert rec.queue[2].data[0] == weights[2]
+        assert rec.queue[2].data[1] == "IX"
         assert rec.queue[2].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[3].name == "PauliRot"
-        assert rec.queue[3].params[0] == weights[3]
-        assert rec.queue[3].params[1] == "IY"
+        assert rec.queue[3].data[0] == weights[3]
+        assert rec.queue[3].data[1] == "IY"
         assert rec.queue[3].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[4].name == "PauliRot"
-        assert rec.queue[4].params[0] == weights[4]
-        assert rec.queue[4].params[1] == "XX"
+        assert rec.queue[4].data[0] == weights[4]
+        assert rec.queue[4].data[1] == "XX"
         assert rec.queue[4].wires == [0,1]  #Wires([0, 1])
 
         assert rec.queue[5].name == "PauliRot"
-        assert rec.queue[5].params[0] == weights[5]
-        assert rec.queue[5].params[1] == "XY"
+        assert rec.queue[5].data[0] == weights[5]
+        assert rec.queue[5].data[1] == "XY"
         assert rec.queue[5].wires == [0,1]  #Wires([0, 1])
 
     def test_GHZ_generation(self, qubit_device_3_wires, tol):

--- a/tests/templates/test_subroutines.py
+++ b/tests/templates/test_subroutines.py
@@ -363,7 +363,7 @@ class TestSingleExcitationUnitary:
     )
     def test_single_ex_unitary_operations(self, ph, ref_gates):
         """Test the correctness of the SingleExcitationUnitary template including the gate count
-        and order, the wires each operation acts on and the correct use of parameters 
+        and order, the wires each operation acts on and the correct use of parameters
         in the circuit."""
 
         sqg = 10
@@ -398,7 +398,7 @@ class TestSingleExcitationUnitary:
         ]
     )
     def test_single_excitation_unitary_exceptions(self, weight, ph, msg_match):
-        """Test that SingleExcitationUnitary throws an exception if ``weight`` or 
+        """Test that SingleExcitationUnitary throws an exception if ``weight`` or
         ``ph`` parameter has illegal shapes, types or values."""
         dev = qml.device("default.qubit", wires=5)
 
@@ -457,8 +457,8 @@ class TestArbitraryUnitary:
         pauli_words = ["X", "Y", "Z"]
 
         for i, op in enumerate(rec.queue):
-            assert op.params[0] == weights[i]
-            assert op.params[1] == pauli_words[i]
+            assert op.data[0] == weights[i]
+            assert op.data[1] == pauli_words[i]
 
     def test_correct_gates_two_wires(self):
         """Test that the correct gates are applied on two wires."""
@@ -472,8 +472,8 @@ class TestArbitraryUnitary:
         pauli_words = ["XI", "YI", "ZI", "ZX", "IX", "XX", "YX", "YY", "ZY", "IY", "XY", "XZ", "YZ", "ZZ", "IZ"]
 
         for i, op in enumerate(rec.queue):
-            assert op.params[0] == weights[i]
-            assert op.params[1] == pauli_words[i]
+            assert op.data[0] == weights[i]
+            assert op.data[1] == pauli_words[i]
 
 
 class TestDoubleExcitationUnitary:
@@ -549,7 +549,7 @@ class TestDoubleExcitationUnitary:
     )
     def test_double_ex_unitary_operations(self, wires1, wires2, ref_gates):
         """Test the correctness of the DoubleExcitationUnitary template including the gate count
-        and order, the wires each operation acts on and the correct use of parameters 
+        and order, the wires each operation acts on and the correct use of parameters
         in the circuit."""
 
         sqg = 72
@@ -585,7 +585,7 @@ class TestDoubleExcitationUnitary:
         ]
     )
     def test_double_excitation_unitary_exceptions(self, weight, wires1, wires2, msg_match):
-        """Test that DoubleExcitationUnitary throws an exception if ``weight`` or 
+        """Test that DoubleExcitationUnitary throws an exception if ``weight`` or
         ``pphh`` parameter has illegal shapes, types or values."""
         dev = qml.device("default.qubit", wires=10)
 
@@ -681,7 +681,7 @@ class TestUCCSDUnitary:
     )
     def test_uccsd_operations(self, ph, pphh, weights, ref_gates):
         """Test the correctness of the UCCSD template including the gate count
-        and order, the wires the operation acts on and the correct use of parameters 
+        and order, the wires the operation acts on and the correct use of parameters
         in the circuit."""
 
         sqg = 10 * len(ph) + 72 * len(pphh)

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -90,9 +90,9 @@ class TestOperation:
             for k in range(test_class.num_params):
                 D = op.heisenberg_pd(k)  # using the recipe
                 # using finite difference
-                op.params[k] += h
+                op.data[k] += h
                 Up = op.heisenberg_tr(0)
-                op.params = par
+                op.data = par
                 G = (Up-U) / h
                 assert D == pytest.approx(G, abs=tol)
 
@@ -131,7 +131,7 @@ class TestOperation:
         # valid call
         op = test_class(*pars, wires=ww)
         assert op.name == test_class.__name__
-        assert op.params == pars
+        assert op.data == pars
         assert op._wires == ww #Wires(ww)
 
         # too many parameters
@@ -646,7 +646,7 @@ class TestTensor:
         X = qml.PauliX(0)
         Y = qml.Hermitian(p, wires=[1, 2])
         t = Tensor(X, Y)
-        assert t.params == [p]
+        assert t.data == [p]
 
     def test_num_params(self):
         """Test that the correct number of parameters is returned"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -585,7 +585,7 @@ class TestInv:
         for inv_op, exp_op in zip(inv_ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_template_inversion_without_context(self):
         """Test that a template is properly inverted."""
@@ -596,7 +596,7 @@ class TestInv:
         for inv_op, exp_op in zip(inv_ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_double_inversion(self):
         """Test that inverting twice changes nothing."""
@@ -607,7 +607,7 @@ class TestInv:
         for inv_inv_op, exp_op in zip(inv_inv_ops, op_queue):
             assert inv_inv_op.name == exp_op.name
             assert inv_inv_op.wires == exp_op.wires
-            assert inv_inv_op.params == exp_op.params
+            assert inv_inv_op.data == exp_op.data
 
     def test_template_double_inversion(self):
         """Test that inverting twice changes nothing for a template."""
@@ -616,7 +616,7 @@ class TestInv:
         for inv_inv_op, exp_op in zip(inv_inv_ops, dummy_template([0, 1, 2])):
             assert inv_inv_op.name == exp_op.name
             assert inv_inv_op.wires == exp_op.wires
-            assert inv_inv_op.params == exp_op.params
+            assert inv_inv_op.data == exp_op.data
 
     def test_inversion_with_context(self):
         """Test that a sequence of operations is properly inverted when a context is present."""
@@ -640,7 +640,7 @@ class TestInv:
         for inv_op, exp_op in zip(rec.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_non_queued_inversion_with_context(self):
         """Test that a sequence of operations is properly inverted when a context is present.
@@ -667,7 +667,7 @@ class TestInv:
         for inv_op, exp_op in zip(rec.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_mixed_inversion_with_context(self):
         """Test that a sequence of operations is properly inverted when a context is present.
@@ -696,7 +696,7 @@ class TestInv:
         for inv_op, exp_op in zip(rec.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_mixed_inversion_with_nested_context(self):
         """Test that a sequence of operations is properly inverted when a nested context is present.
@@ -726,12 +726,12 @@ class TestInv:
         for inv_op, exp_op in zip(rec1.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
         for inv_op, exp_op in zip(rec2.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_template_inversion_with_context(self):
         """Test that a template is properly inverted when a context is present."""
@@ -753,7 +753,7 @@ class TestInv:
         for inv_op, exp_op in zip(rec.queue, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_inversion_with_qnode(self):
         """Test that a sequence of operations is properly inverted when inside a QNode."""
@@ -784,7 +784,7 @@ class TestInv:
         for inv_op, exp_op in zip(qfunc.ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_non_queued_inversion_with_qnode(self):
         """Test that a sequence of operations is properly inverted inside a QNode.
@@ -818,7 +818,7 @@ class TestInv:
         for inv_op, exp_op in zip(qfunc.ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_mixed_inversion_with_qnode(self):
         """Test that a sequence of operations is properly inverted inside a QNode.
@@ -853,7 +853,7 @@ class TestInv:
         for inv_op, exp_op in zip(qfunc.ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_template_inversion_with_qnode(self):
         """Test that a template is properly inverted when inside a QNode."""
@@ -882,7 +882,7 @@ class TestInv:
         for inv_op, exp_op in zip(qfunc.ops, inv_queue):
             assert inv_op.name == exp_op.name
             assert inv_op.wires == exp_op.wires
-            assert inv_op.params == exp_op.params
+            assert inv_op.data == exp_op.data
 
     def test_argument_wrapping(self):
         """Test that a single operation can be given to inv and is properly inverted."""
@@ -893,7 +893,7 @@ class TestInv:
 
         assert inv_ops[0].name == exp_op.name
         assert inv_ops[0].wires == exp_op.wires
-        assert inv_ops[0].params == exp_op.params
+        assert inv_ops[0].data == exp_op.data
 
     @pytest.mark.parametrize("arg", [2.3, object()])
     def test_argument_type_error(self, arg):


### PR DESCRIPTION
**Context:**
In the `Operator` class (including the inheriting classes `Operation`, `Observable` and `Tensor`), `.params` is used for the unevaluated parameters (so could contain Variable instances), while `.parameters` are evaluated.

The QNode always queries `Operator.params`, while the device always queries `Operator.parameters`.

**Description of the Change:**
The three main changes in `operation.py` are:
* `Operator.params` is changed to `Operator.data`
* Classes inheriting `Operator` are updated to call `self.data` instead of `self.params`
* `Tensor.params` is changed to `Tensor.data`

Furthermore, all calls to `op.params` are changed to `op.data`, including in a lot of tests.

**Benefits:**
It'll be less confusing having `op.data` and `op.parameters` rather than, as before, having `op.params` and `op.parameters`.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
Fixes #349 
